### PR TITLE
Add heartbeat protocol

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -107,40 +107,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bech32"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
-
-[[package]]
-name = "bitcoin"
-version = "0.30.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
-dependencies = [
- "bech32",
- "bitcoin-private",
- "bitcoin_hashes",
- "hex_lit",
- "secp256k1",
-]
-
-[[package]]
-name = "bitcoin-private"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
-dependencies = [
- "bitcoin-private",
-]
-
-[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -150,7 +116,6 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "braidpool-node"
 version = "0.1.0"
 dependencies = [
- "bitcoin",
  "bytes",
  "clap",
  "flexbuffers",
@@ -392,12 +357,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
-name = "hex_lit"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
-
-[[package]]
 name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -617,25 +576,6 @@ name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
-
-[[package]]
-name = "secp256k1"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
-dependencies = [
- "bitcoin_hashes",
- "secp256k1-sys",
-]
-
-[[package]]
-name = "secp256k1-sys"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "serde"

--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -38,6 +38,54 @@ dependencies = [
 ]
 
 [[package]]
+name = "anstream"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f58811cfac344940f1a400b6e6231ce35171f614f26439e80f8c1465c5cc0c"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b84bf0a05bbb2a83e5eb6fa36bb6e87baa08193c35ff52bbf6b38d8af2890e46"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "938874ff5980b03a87c5524b3ae5b59cf99b1d6bc836848df7bc5ada9643c333"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca11d4be1bab0c8bc8734a9aa7bf4ee8316d462a08c6ac5052f888fef5b494b"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58f54d10c6dfa51283a066ceab3ec1ab78d13fae00aa49243a45e4571fb79dfd"
+dependencies = [
+ "anstyle",
+ "windows-sys",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -59,6 +107,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "bech32"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d86b93f97252c47b41663388e6d155714a9d0c398b99f1005cbc5f978b29f445"
+
+[[package]]
+name = "bitcoin"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e99ff7289b20a7385f66a0feda78af2fc119d28fb56aea8886a9cd0a4abdd75"
+dependencies = [
+ "bech32",
+ "bitcoin-private",
+ "bitcoin_hashes",
+ "hex_lit",
+ "secp256k1",
+]
+
+[[package]]
+name = "bitcoin-private"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d7066118b13d4b20b23645932dfb3a81ce7e29f95726c2036fa33cd7b092501"
+dependencies = [
+ "bitcoin-private",
+]
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -68,11 +150,14 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 name = "braidpool-node"
 version = "0.1.0"
 dependencies = [
+ "bitcoin",
  "bytes",
+ "clap",
  "flexbuffers",
  "futures",
  "serde",
  "serde_derive",
+ "sqlite",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -106,6 +191,52 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a13b88d2c62ff462f88e4a121f17a82c1af05693a2f192b5c38d14de73c19f6"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2bb9faaa7c2ef94b2743a21f5a29e6f0010dff4caa69ac8e9d6cf8b6fa74da08"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0862016ff20d69b84ef8247369fabf5c008a7417002411897d40ee1f4532b873"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.31",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd7cc57abe963c6d3b9d8be5b06ba7c8957a930305ca90304f24ef040aa6f961"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
 name = "equivalent"
@@ -249,10 +380,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
 
 [[package]]
+name = "heck"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95505c38b4572b2d910cecb0281560f54b440a19336cbbcb27bf6ce6adc6f5a8"
+
+[[package]]
 name = "hermit-abi"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
+
+[[package]]
+name = "hex_lit"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3011d1213f159867b13cfd6ac92d2cd5f1345762c63be3554e84092d85a50bbd"
 
 [[package]]
 name = "indexmap"
@@ -392,6 +535,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
 name = "proc-macro-crate"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -470,6 +619,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "secp256k1"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25996b82292a7a57ed3508f052cfff8640d38d32018784acd714758b43da9c8f"
+dependencies = [
+ "bitcoin_hashes",
+ "secp256k1-sys",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70a129b9e9efbfb223753b9163c4ab3b13cff7fd9c7f010fbac25ab4099fa07e"
+dependencies = [
+ "cc",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,6 +684,42 @@ dependencies = [
  "libc",
  "windows-sys",
 ]
+
+[[package]]
+name = "sqlite"
+version = "0.31.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05439db7afa0ce0b38f6d1b4c691f368adde108df021e15e900fec6a1af92488"
+dependencies = [
+ "libc",
+ "sqlite3-sys",
+]
+
+[[package]]
+name = "sqlite3-src"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfc95a51a1ee38839599371685b9d4a926abb51791f0bc3bf8c3bb7867e6e454"
+dependencies = [
+ "cc",
+ "pkg-config",
+]
+
+[[package]]
+name = "sqlite3-sys"
+version = "0.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2752c669433e40ebb08fde824146f50d9628aa0b66a3b7fc6be34db82a8063b"
+dependencies = [
+ "libc",
+ "sqlite3-src",
+]
+
+[[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
@@ -690,6 +894,12 @@ name = "unicode-ident"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "301abaae475aa91687eb82514b328ab47a211a533026cb25fc3e519b86adfc3c"
+
+[[package]]
+name = "utf8parse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "711b9620af191e0cdc7468a8d14e709c3dcdb115b36f838e601583af800a370a"
 
 [[package]]
 name = "valuable"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,3 +18,4 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_derive = "1.0.188"
 sqlite = { version = "0.31.1" }
 clap = { version = "4.4.2", features = ["derive", "string"] }
+bitcoin = "0.30.1"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,4 +18,3 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_derive = "1.0.188"
 sqlite = { version = "0.31.1" }
 clap = { version = "4.4.2", features = ["derive", "string"] }
-bitcoin = "0.30.1"

--- a/node/src/connection.rs
+++ b/node/src/connection.rs
@@ -1,5 +1,5 @@
 use bytes::Bytes;
-use std::error::Error;
+use std::{error::Error, net::SocketAddr};
 use tokio::net::tcp::{OwnedReadHalf, OwnedWriteHalf};
 //use tokio::sync::mpsc;
 use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
@@ -29,10 +29,10 @@ impl Connection {
         }
     }
 
-    pub async fn start_from_connect(&mut self) -> Result<(), Box<dyn Error>> {
+    pub async fn start_from_connect(&mut self, addr: &SocketAddr) -> Result<(), Box<dyn Error>> {
         use futures::SinkExt;
         println!("Starting from connect");
-        let message = HandshakeMessage::start().unwrap();
+        let message = HandshakeMessage::start(addr).unwrap();
         self.writer.send(message.as_bytes().unwrap()).await?;
         self.start_read_loop().await?;
         Ok(())

--- a/node/src/protocol/handshake.rs
+++ b/node/src/protocol/handshake.rs
@@ -1,5 +1,6 @@
 use super::{Message, ProtocolMessage};
 use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct HandshakeMessage {
@@ -8,7 +9,7 @@ pub struct HandshakeMessage {
 }
 
 impl ProtocolMessage for HandshakeMessage {
-    fn start() -> Option<Message> {
+    fn start(_: &SocketAddr) -> Option<Message> {
         Some(Message::Handshake(HandshakeMessage {
             message: String::from("helo"),
             version: String::from("0.1.0"),
@@ -34,11 +35,15 @@ impl ProtocolMessage for HandshakeMessage {
 
 #[cfg(test)]
 mod tests {
+    use std::net::SocketAddr;
+    use std::str::FromStr;
+
     use crate::protocol::{HandshakeMessage, Message, ProtocolMessage};
 
     #[test]
     fn it_matches_start_message_for_handshake() {
-        let start_message = HandshakeMessage::start().unwrap();
+        let addr = SocketAddr::from_str("127.0.0.1:25188").unwrap();
+        let start_message = HandshakeMessage::start(&addr).unwrap();
         assert_eq!(
             start_message,
             Message::Handshake(HandshakeMessage {
@@ -50,7 +55,8 @@ mod tests {
 
     #[test]
     fn it_matches_response_message_for_correct_handshake_start() {
-        let start_message = HandshakeMessage::start().unwrap();
+        let addr = SocketAddr::from_str("127.0.0.1:25188").unwrap();
+        let start_message = HandshakeMessage::start(&addr).unwrap();
         let response = start_message.response_for_received().unwrap();
         assert_eq!(
             response,

--- a/node/src/protocol/heartbeat.rs
+++ b/node/src/protocol/heartbeat.rs
@@ -1,0 +1,47 @@
+use super::{Message, ProtocolMessage};
+use serde::{Deserialize, Serialize};
+use std::{net::SocketAddr, time::SystemTime};
+
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct HeartbeatMessage {
+    pub from: String,
+    pub time: SystemTime,
+}
+
+impl ProtocolMessage for HeartbeatMessage {
+    fn start(addr: &SocketAddr) -> Option<Message> {
+        Some(Message::Heartbeat(HeartbeatMessage {
+            from: addr.to_string(),
+            time: SystemTime::now(),
+        }))
+    }
+
+    fn response_for_received(&self) -> Result<Option<Message>, &'static str> {
+        println!("Received {:?}", self);
+        Ok(None)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::str::FromStr;
+
+    use crate::protocol::{HeartbeatMessage, Message, ProtocolMessage};
+
+    #[test]
+    fn it_matches_start_message_for_handshake() {
+        let addr = SocketAddr::from_str("127.0.0.1:25188").unwrap();
+        if let Some(Message::Heartbeat(start_message)) = HeartbeatMessage::start(&addr) {
+            assert_eq!(start_message.from, String::from("127.0.0.1:25188"))
+        }
+    }
+
+    #[test]
+    fn it_matches_response_message_for_correct_handshake_start() {
+        let addr = SocketAddr::from_str("127.0.0.1:25188").unwrap();
+        let start_message = HeartbeatMessage::start(&addr).unwrap();
+        let response = start_message.response_for_received().unwrap();
+        assert_eq!(response, None);
+    }
+}

--- a/node/src/protocol/ping.rs
+++ b/node/src/protocol/ping.rs
@@ -1,3 +1,5 @@
+use std::net::SocketAddr;
+
 use super::{Message, ProtocolMessage};
 use serde::{Deserialize, Serialize};
 
@@ -7,7 +9,7 @@ pub struct PingMessage {
 }
 
 impl ProtocolMessage for PingMessage {
-    fn start() -> Option<Message> {
+    fn start(_: &SocketAddr) -> Option<Message> {
         Some(Message::Ping(PingMessage {
             message: String::from("ping"),
         }))


### PR DESCRIPTION
As a step toward adding gossip broadcast. https://github.com/braidpool/braidpool/issues/31

Adding a message type for heartbeat protocol. We still need to add the timer and channel to generate a heartbeat of messages.

As part of this change, I also am passing the local socket address to ProtocolMessage::start. Other protocols will need it to. This might eventually evolve to getting a ref to the connection the protocol is attached to. I don't want to jump the gun just now on that.

