### PR TITLE
add env_logger

### DIFF
--- a/node/Cargo.lock
+++ b/node/Cargo.lock
@@ -113,13 +113,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
+
+[[package]]
 name = "braidpool-node"
 version = "0.1.0"
 dependencies = [
  "bytes",
  "clap",
+ "env_logger",
  "flexbuffers",
  "futures",
+ "log",
  "serde",
  "serde_derive",
  "sqlite",
@@ -204,10 +212,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acbf1af155f9b9ef647e42cdc158db4b64a1b61f743629225fde6f3e0be2a7c7"
 
 [[package]]
+name = "env_logger"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85cdab6a89accf66733ad5a1693a4dcced6aeff64602b634530dd73c1f3ee9f0"
+dependencies = [
+ "humantime",
+ "is-terminal",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
+
+[[package]]
+name = "errno"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3e13f66a2f95e32a39eaa81f6b95d42878ca0e1db0c7543723dfe12557e860"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
 
 [[package]]
 name = "flexbuffers"
@@ -215,7 +246,7 @@ version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "15d14128f06405808ce75bfebe11e9b0f9da18719ede6d7bdb1702d6bfe0f7e8"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "byteorder",
  "num_enum",
  "serde",
@@ -357,6 +388,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "443144c8cdadd93ebf52ddb4056d257f5b52c04d3c804e657d19eb73fc33668b"
 
 [[package]]
+name = "humantime"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
 name = "indexmap"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -364,6 +401,17 @@ checksum = "d5477fe2230a79769d8dc68e0eabf5437907c0457a5614a9e8dddb67f65eb65d"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.0",
+]
+
+[[package]]
+name = "is-terminal"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb0889898416213fab133e1d33a0e5858a48177452750691bde3666d0fdbaf8b"
+dependencies = [
+ "hermit-abi",
+ "rustix",
+ "windows-sys",
 ]
 
 [[package]]
@@ -377,6 +425,12 @@ name = "libc"
 version = "0.2.147"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4668fb0ea861c1df094127ac5f1da3409a82116a4ba74fca2e58ef927159bb3"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.4.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2479e8c062e40bf0066ffa0bc823de0a9368974af99c9f6df941d2c231e03f"
 
 [[package]]
 name = "log"
@@ -578,6 +632,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d626bb9dae77e28219937af045c257c28bfd3f69333c512553507f5f9798cb76"
 
 [[package]]
+name = "rustix"
+version = "0.38.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7db8590df6dfcd144d22afd1b83b36c21a18d7cbc1dc4bb5295a8712e9eb662"
+dependencies = [
+ "bitflags 2.4.0",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
+
+[[package]]
 name = "serde"
 version = "1.0.188"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -681,6 +748,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
+]
+
+[[package]]
+name = "termcolor"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6093bad37da69aab9d123a8091e4be0aa4a03e4d601ec641c327398315f62b64"
+dependencies = [
+ "winapi-util",
 ]
 
 [[package]]
@@ -874,6 +950,15 @@ name = "winapi-i686-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
+
+[[package]]
+name = "winapi-util"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f29e6f9198ba0d26b4c9f07dbe6f9ed633e1f3d5b8b414090084349e46a52596"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winapi-x86_64-pc-windows-gnu"

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -18,3 +18,5 @@ serde = { version = "1.0.188", features = ["derive"] }
 serde_derive = "1.0.188"
 sqlite = { version = "0.31.1" }
 clap = { version = "4.4.2", features = ["derive", "string"] }
+env_logger = "0.10.0"
+log = "0.4.16"

--- a/node/src/connection.rs
+++ b/node/src/connection.rs
@@ -31,7 +31,7 @@ impl Connection {
 
     pub async fn start_from_connect(&mut self, addr: &SocketAddr) -> Result<(), Box<dyn Error>> {
         use futures::SinkExt;
-        println!("Starting from connect");
+        log::info!("Starting from connect");
         let message = HandshakeMessage::start(addr).unwrap();
         self.writer.send(message.as_bytes().unwrap()).await?;
         self.start_read_loop().await?;
@@ -39,14 +39,14 @@ impl Connection {
     }
 
     pub async fn start_from_accept(&mut self) -> Result<(), Box<dyn Error>> {
-        println!("Starting from accept");
+        log::info!("Starting from accept");
         self.start_read_loop().await?;
         Ok(())
     }
 
     pub async fn start_read_loop(&mut self) -> Result<(), Box<dyn Error>> {
         use futures::StreamExt;
-        println!("Start read loop....");
+        log::info!("Start read loop....");
         loop {
             match self.reader.next().await {
                 None => {

--- a/node/src/protocol/handshake.rs
+++ b/node/src/protocol/handshake.rs
@@ -17,7 +17,7 @@ impl ProtocolMessage for HandshakeMessage {
     }
 
     fn response_for_received(&self) -> Result<Option<Message>, &'static str> {
-        println!("Received {:?}", self);
+        log::info!("Received {:?}", self);
         match self {
             HandshakeMessage { message, version } if message == "helo" && version == "0.1.0" => {
                 Ok(Some(Message::Handshake(HandshakeMessage {

--- a/node/src/protocol/heartbeat.rs
+++ b/node/src/protocol/heartbeat.rs
@@ -17,7 +17,7 @@ impl ProtocolMessage for HeartbeatMessage {
     }
 
     fn response_for_received(&self) -> Result<Option<Message>, &'static str> {
-        println!("Received {:?}", self);
+        log::info!("Received {:?}", self);
         Ok(None)
     }
 }

--- a/node/src/protocol/ping.rs
+++ b/node/src/protocol/ping.rs
@@ -16,7 +16,7 @@ impl ProtocolMessage for PingMessage {
     }
 
     fn response_for_received(&self) -> Result<Option<Message>, &'static str> {
-        println!("Received {:?}", self.message);
+        log::info!("Received {:?}", self.message);
         if self.message == "ping" {
             Ok(Some(Message::Ping(PingMessage {
                 message: String::from("pong"),


### PR DESCRIPTION
for https://github.com/braidpool/braidpool/pull/54/ we need to print some user-facing logs for incoming `hashblock` notifications and `getblocktemplate` RPCs with a properly formatted time

doing that with `println!` is a bit cumbersome, and using `tracing` for this purpose would be overkill

since the `info` log level is enabled by default, it can replace the usage of `println!`.

before:
```
Using braid data directory: ~/.braidpool/
Binding to localhost:8989
Starting accept


accepted connection
Starting accept
Starting from accept
Start read loop....
Received HandshakeMessage { message: "helo", version: "0.1.0" }
Peer closed connection
```

after:
```
[2023-10-12T16:55:27Z INFO  braidpool_node] Using braid data directory: ~/.braidpool/
[2023-10-12T16:55:27Z INFO  braidpool_node] Binding to localhost:8989
[2023-10-12T16:55:27Z INFO  braidpool_node] Starting accept
[2023-10-12T16:55:29Z INFO  braidpool_node] Accepted connection from 127.0.0.1:49696
[2023-10-12T16:55:29Z INFO  braidpool_node] Starting accept
[2023-10-12T16:55:29Z INFO  braidpool_node::connection] Starting from accept
[2023-10-12T16:55:29Z INFO  braidpool_node::connection] Start read loop....
[2023-10-12T16:55:29Z INFO  braidpool_node::protocol::handshake] Received HandshakeMessage { message: "helo", version: "0.1.0" }
[2023-10-12T16:55:31Z WARN  braidpool_node] Peer 127.0.0.1:49696 closed connection
```

in case this gets merged I'll adapt #54 to follow the same pattern.