### PR TITLE
Nix script for setting up CPUnet for braidpool testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,42 @@ cargo run -- --bind=localhost:8989 --bitcoin=0.0.0.0 --rpcport=8332 --rpcuser=xx
 # run other nodes pointing to the seeding node and specify their own port as 9899
 cargo run -- --bind=localhost:9899 --addnode=localhost:8989 --bitcoin=0.0.0.0 --rpcport=8332 --rpcuser=xxxx --rpcpass=yyyy --zmqhashblockport=28332
 ```
+# Running the CPUnet testing node using nix-script
+
+Setting up `nix` locally for utilizing it from the specific releases check - [Nix setup](https://github.com/DeterminateSystems/nix-installer/releases) 
+```
+curl --proto '=https' --tlsv1.2 -sSf -L https://install.determinate.systems/nix | \
+  sh -s -- install
+```
+
+The `.nix` script present in the root directory `/braidpool/cpunet_node.nix` contains the CPUnet patched 
+bitcoin-node , can be set up locally as testnet for Braidpool.
+
+```
+# Path to the parent directory
+cd /braidpool
+
+# Run the nix-script
+nix-build cpunet_node.nix
+
+# Path to the result directory created after successful build 
+cd result
+
+# Running the CPUnet node
+./bin/bitcoind -cpunet -zmqpubsequence=tcp://127.0.0.1:28338
+
+# Creating/loading a corresponding wallet 
+./bin/bitcoin-cli -cpunet createwallet cpunet
+
+# Load an  wallet created previously
+./bin/bitcoin-cli -cpunet loadwallet cpunet
+
+# Generate blocks     
+./contrib/cpunet/miner --cli=./bin/bitcoin-cli --ongoing --address `./bin/bitcoin-cli -cpunet getnewaddress` --grind-cmd="./bin/bitcoin-util -cpunet -ntasks=1 grind"
+
+
+```
+
 
 # Documentation
 

--- a/cpunet_node.nix
+++ b/cpunet_node.nix
@@ -1,0 +1,80 @@
+#nixpackages to be required while building abd adding into the nix-shell
+{ pkgs ? import <nixpkgs> { system = builtins.currentSystem; }
+, lib ? pkgs.lib
+, stdenv ? pkgs.stdenv
+, fetchFromGitHub ? pkgs.fetchFromGitHub
+, autoreconfHook ? pkgs.autoreconfHook
+, pkg-config ? pkgs.pkg-config
+, util-linux ? pkgs.util-linux
+, hexdump ? pkgs.hexdump
+, boost ? pkgs.boost
+, libevent ? pkgs.libevent
+, miniupnpc ? pkgs.miniupnpc
+, zeromq ? pkgs.zeromq
+, zlib ? pkgs.zlib
+, db48 ? pkgs.db48
+, sqlite ? pkgs.sqlite
+, qrencode ? pkgs.qrencode
+, python3 ? pkgs.python3
+, nixosTests ? pkgs.nixosTests
+}:
+#Loop for derivations of packages
+with lib;
+let
+  version = "v27.99.0";
+  majorVersion = versions.major version;
+in
+stdenv.mkDerivation rec {
+  pname = "bitcoind-cpunet-braidpool";
+  inherit version;
+#Source directory from where it will be cloning
+  src = fetchFromGitHub {
+    owner = "braidpool";
+    repo = "bitcoin";
+    rev = "53398930f7fb080473750f2774ab66470dee0aed";
+    hash = "sha256-D69UKsHJF96rCu4WEag4xiB8V5rhUNPykSP9pm6nYGk=";
+  };
+
+  nativeBuildInputs =
+    [ autoreconfHook pkg-config ]
+    ++ optionals stdenv.isLinux [ util-linux ];
+
+  buildInputs = [ boost libevent db48 sqlite miniupnpc zeromq zlib ];
+
+  configureFlags = [
+    "--with-boost-libdir=${boost.out}/lib"
+    "--disable-bench"
+    "--disable-tests"
+    "--disable-gui-tests"
+    "--disable-fuzz"
+    "--disable-fuzz-binary"
+    "--disable-bench"
+  ];
+
+  checkInputs = [ python3 ];
+
+  doCheck = false;
+
+  checkFlags = [ "LC_ALL=en_US.UTF-8" ];
+# For better CPU core utilization while building patch enableParallelBuilding = true;
+    installPhase = ''
+    runHook preInstall
+    # Install the binaries with proper permissions can add other binaries as well
+    install -Dm755 src/bitcoind $out/bin/bitcoind
+    install -Dm755 src/bitcoin-cli $out/bin/bitcoin-cli
+    install -Dm755 src/bitcoin-tx $out/bin/bitcoin-tx
+    install -Dm755 src/bitcoin-util $out/bin/bitcoin-util
+    # Install the entire contrib directory
+    mkdir -p $out/contrib
+    cp -r contrib/* $out/contrib/
+    cp -r ./test/functional/test_framework $out/contrib/cpunet
+    chmod -R 777 $out/contrib/cpunet/test_framework
+    runHook postInstall
+  '';
+
+  meta = {
+    description = "Bitcoin Core with a CPUnet braidpool patch";
+    license = licenses.mit;
+    platforms = platforms.unix;
+  };
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,4 +1,4 @@
-site_name: Braidpool<br/>Documentation
+site_name: Braidpool Documentation
 
 markdown_extensions:
   - pymdownx.arithmatex:


### PR DESCRIPTION
Nix package bundling the patched bitcoin node with CPUnet support [](https://github.com/braidpool/bitcoin/tree/cpunet) .