### PR TITLE
Initial workflow for testing functions for braid.rs and bead.rs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ notes/
 venv
 *~
 .aider*
+/.vscode

--- a/braidpool-primitives/src/beads.rs
+++ b/braidpool-primitives/src/beads.rs
@@ -7,12 +7,13 @@ use bitcoin::transaction::TransactionExt;
 use bitcoin::{BlockHeader, CompactTarget, Transaction};
 
 // Custom Imports
-use crate::utils::BeadHash;
 use crate::utils::bitcoin::MerklePathProof;
+use crate::utils::BeadHash;
 
 // Type Aliases
-type TransactionWithMerklePath = (Transaction, MerklePathProof);
+pub type TransactionWithMerklePath = (Transaction, MerklePathProof);
 
+#[derive(Clone, Debug)]
 pub struct Bead {
     pub block_header: BlockHeader,
     pub bead_hash: BeadHash,
@@ -58,7 +59,6 @@ impl Bead {
     pub fn get_coinbase_transaction(&self) -> Transaction {
         // TODO: Implement this function.
         unimplemented!()
-
     }
 
     pub fn get_payout_update_transaction(&self) -> Transaction {

--- a/braidpool-primitives/src/braid.rs
+++ b/braidpool-primitives/src/braid.rs
@@ -9,6 +9,7 @@ use crate::beads::Bead;
 use crate::utils::BeadHash;
 
 // Type Definitions
+#[derive(Clone, Debug)]
 struct Cohort(HashSet<BeadHash>);
 
 pub enum AddBeadStatus {
@@ -18,10 +19,8 @@ pub enum AddBeadStatus {
     ParentsNotYetReceived,
 }
 
-
 // Type Aliases
 type NumberOfBeadsUnorphaned = usize;
-
 
 pub struct Braid {
     beads: HashSet<BeadHash>,
@@ -150,5 +149,248 @@ impl Braid {
 
     fn calculate_valid_difficulty_for_bead(&self, bead: &Bead) -> CompactTarget {
         unimplemented!()
+    }
+}
+#[cfg(test)]
+mod tests {
+    use super::Cohort;
+    use super::{BeadHash, HashSet};
+    use crate::braid::Braid;
+    use crate::utils::test_utils::create_test_bead;
+    use ::bitcoin::absolute::Time;
+    use ::bitcoin::BlockHash;
+
+    #[test]
+    fn test_update_orphans() {
+        let test_dag_bead_1 = create_test_bead(
+            2,
+            [0x00; 32],
+            [
+                0xf3, 0xb8, 0x76, 0x2e, 0x7c, 0x1b, 0xd6, 0x47, 0xf1, 0xf6, 0x9d, 0x2a, 0x7f, 0x9c,
+                0x85, 0xf0, 0xb2, 0x5e, 0x64, 0x69, 0xf1, 0x07, 0xd2, 0x31, 0xdf, 0xf4, 0x5c, 0x47,
+                0x1f, 0x88, 0x94, 0x58,
+            ],
+            1653195600,
+            486604799,
+            0,
+            [0x00; 32],
+            [0xbb; 32],
+            [0xbb; 32],
+            4040404,
+            vec![
+                (
+                    BeadHash::from_byte_array([0x01; 32]),
+                    Time::from_consensus(1690000000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x02; 32]),
+                    Time::from_consensus(1690001000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x03; 32]),
+                    Time::from_consensus(1690002000).expect("invalid time value"),
+                ),
+            ],
+            vec![[0x11; 32], [0x22; 32], [0x33; 32], [0x44; 32]],
+            436864982,
+            [0x00; 32],
+            1653195600,
+        );
+        let test_dag_bead_2 = create_test_bead(
+            2,
+            [0x00; 32],
+            [
+                0xf3, 0xb8, 0x76, 0x2e, 0x7c, 0x1b, 0xd6, 0x47, 0xf1, 0xf6, 0x9d, 0x2a, 0x7f, 0x9c,
+                0x85, 0xf0, 0xb2, 0x5e, 0x64, 0x69, 0xf1, 0x07, 0xd2, 0x31, 0xdf, 0xf4, 0x5c, 0x47,
+                0x1f, 0x88, 0x94, 0x58,
+            ],
+            1653195600,
+            486604799,
+            0,
+            [0x00; 32],
+            [0xbb; 32],
+            [0xbb; 32],
+            4040404,
+            vec![
+                (
+                    BeadHash::from_byte_array([0x01; 32]),
+                    Time::from_consensus(1690000000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x02; 32]),
+                    Time::from_consensus(1690001000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x03; 32]),
+                    Time::from_consensus(1690002000).expect("invalid time value"),
+                ),
+            ],
+            vec![[0x11; 32], [0x22; 32], [0x33; 32], [0x44; 32]],
+            436864982,
+            [0x00; 32],
+            1653195600,
+        );
+        let mut genesis_beads: HashSet<BeadHash> = HashSet::new();
+        let child_bead_1 = create_test_bead(
+            2,
+            [0x00; 32],
+            [
+                0xf3, 0xb8, 0x76, 0x2e, 0x7c, 0x1b, 0xd6, 0x47, 0xf1, 0xf6, 0x9d, 0x2a, 0x7f, 0x9c,
+                0x85, 0xf0, 0xb2, 0x5e, 0x64, 0x69, 0xf1, 0x07, 0xd2, 0x31, 0xdf, 0xf4, 0x5c, 0x47,
+                0x1f, 0x88, 0x94, 0x58,
+            ],
+            1653195600,
+            486604799,
+            0,
+            [0x00; 32],
+            [0xbb; 32],
+            [0xbb; 32],
+            4040404,
+            vec![
+                (
+                    BeadHash::from_byte_array([0x01; 32]),
+                    Time::from_consensus(1690000000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x02; 32]),
+                    Time::from_consensus(1690001000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x03; 32]),
+                    Time::from_consensus(1690002000).expect("invalid time value"),
+                ),
+            ],
+            vec![[0x11; 32], [0x22; 32], [0x33; 32], [0x44; 32]],
+            436864982,
+            [0x00; 32],
+            1653195600,
+        );
+
+        genesis_beads.insert(test_dag_bead_1.bead_hash);
+        genesis_beads.insert(test_dag_bead_2.bead_hash);
+
+        let mut test_braid = Braid::new(genesis_beads);
+
+        test_braid.add_bead(test_dag_bead_1);
+        test_braid.add_bead(test_dag_bead_2);
+        test_braid.add_bead(child_bead_1);
+
+        assert_eq!(test_braid.update_orphan_bead_set(), 2);
+    }
+    #[test]
+    fn test_orphan_bead() {
+        let test_dag_bead = create_test_bead(
+            2,
+            [0x00; 32],
+            [
+                0xf3, 0xb8, 0x76, 0x2e, 0x7c, 0x1b, 0xd6, 0x47, 0xf1, 0xf6, 0x9d, 0x2a, 0x7f, 0x9c,
+                0x85, 0xf0, 0xb2, 0x5e, 0x64, 0x69, 0xf1, 0x07, 0xd2, 0x31, 0xdf, 0xf4, 0x5c, 0x47,
+                0x1f, 0x88, 0x94, 0x58,
+            ],
+            1653195600,
+            486604799,
+            0,
+            [0x00; 32],
+            [0xbb; 32],
+            [0xbb; 32],
+            4040404,
+            vec![
+                (
+                    BeadHash::from_byte_array([0x01; 32]),
+                    Time::from_consensus(1690000000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x02; 32]),
+                    Time::from_consensus(1690001000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x03; 32]),
+                    Time::from_consensus(1690002000).expect("invalid time value"),
+                ),
+            ], // parents
+            vec![[0x11; 32], [0x22; 32], [0x33; 32], [0x44; 32]],
+            436864982,
+            [0x00; 32],
+            1653195600,
+        );
+        let bytes: [u8; 32] = [0; 32];
+        let mut genesis_beads: HashSet<BeadHash> = HashSet::new();
+        genesis_beads.insert(BlockHash::from_byte_array(bytes));
+        let mut test_braid = Braid::new(genesis_beads);
+        let referenced_bead = test_dag_bead.clone();
+        test_braid.add_bead(test_dag_bead);
+
+        assert_eq!(test_braid.is_bead_orphaned(&referenced_bead), false);
+    }
+    #[test]
+    fn test_remove_parents() {
+        let test_dag_bead = create_test_bead(
+            2,
+            [0x00; 32],
+            [
+                0xf3, 0xb8, 0x76, 0x2e, 0x7c, 0x1b, 0xd6, 0x47, 0xf1, 0xf6, 0x9d, 0x2a, 0x7f, 0x9c,
+                0x85, 0xf0, 0xb2, 0x5e, 0x64, 0x69, 0xf1, 0x07, 0xd2, 0x31, 0xdf, 0xf4, 0x5c, 0x47,
+                0x1f, 0x88, 0x94, 0x58,
+            ],
+            1653195600,
+            486604799,
+            0,
+            [0x00; 32],
+            [0xbb; 32],
+            [0xbb; 32],
+            4040404,
+            vec![
+                (
+                    BeadHash::from_byte_array([0x01; 32]),
+                    Time::from_consensus(1690000000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x02; 32]),
+                    Time::from_consensus(1690001000).expect("invalid time value"),
+                ),
+                (
+                    BeadHash::from_byte_array([0x03; 32]),
+                    Time::from_consensus(1690002000).expect("invalid time value"),
+                ),
+            ], // parents
+            vec![[0x11; 32], [0x22; 32], [0x33; 32], [0x44; 32]],
+            436864982,
+            [0x00; 32],
+            1653195600,
+        );
+        let bytes: [u8; 32] = [0; 32];
+        let mut genesis_beads: HashSet<BeadHash> = HashSet::new();
+        genesis_beads.insert(BlockHash::from_byte_array(bytes));
+        let mut test_braid = Braid::new(genesis_beads);
+
+        let referenced_val = test_dag_bead.clone();
+        test_braid.add_bead(test_dag_bead);
+        test_braid.remove_parent_beads_from_tips(&referenced_val);
+
+        let parents = referenced_val.parents;
+        for parent in parents {
+            assert_eq!(test_braid.tips.contains(&parent.0), false);
+        }
+    }
+
+    #[test]
+    fn test_bead_cohort_1() {
+        let bytes: [u8; 32] = [0; 32];
+        let mut genesis_beads: HashSet<BeadHash> = HashSet::new();
+        let reference = genesis_beads.clone();
+        genesis_beads.insert(BlockHash::from_byte_array(bytes));
+        let test_braid = Braid::new(genesis_beads);
+        let computed_tip_cohorts = test_braid.generate_tip_cohorts();
+        let mut expected_tip_cohorts = Vec::new();
+        expected_tip_cohorts.push(Cohort(reference));
+        assert_eq!(expected_tip_cohorts.len(), computed_tip_cohorts.len());
+        for index in 0..computed_tip_cohorts.len() {
+            let expected_cohort = expected_tip_cohorts[index].clone();
+            let computed_cohort = expected_tip_cohorts[index].clone();
+
+            for cohort_element in computed_cohort.0 {
+                assert_eq!(expected_cohort.0.contains(&cohort_element), true);
+            }
+        }
     }
 }

--- a/braidpool-primitives/src/utils/bitcoin.rs
+++ b/braidpool-primitives/src/utils/bitcoin.rs
@@ -7,7 +7,7 @@ use bitcoin::{BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget, Tx
 
 // Internal Type Definitions for Clarity
 type MerkleRoot = TxMerkleNode;
-
+#[derive(Clone,Debug)]
 pub struct MerklePathProof {
     pub transaction_hash: Txid,
     pub merkle_path: Vec<TxMerkleNode>,

--- a/braidpool-primitives/src/utils/mod.rs
+++ b/braidpool-primitives/src/utils/mod.rs
@@ -1,6 +1,7 @@
 use ::bitcoin::BlockHash;
 
 pub mod bitcoin;
+pub mod test_utils;
 
 // Type Definitions
 pub type BeadHash = BlockHash;

--- a/braidpool-primitives/src/utils/test_utils.rs
+++ b/braidpool-primitives/src/utils/test_utils.rs
@@ -1,0 +1,151 @@
+#![allow(unused)]
+use crate::beads::{Bead, TransactionWithMerklePath};
+use crate::utils::bitcoin::MerklePathProof;
+use crate::utils::BeadHash;
+use ::bitcoin::absolute::LockTime;
+use ::bitcoin::absolute::Time;
+use ::bitcoin::hex::FromHex;
+use ::bitcoin::{Amount, Txid};
+use ::bitcoin::{
+    BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget, OutPoint, ScriptBuf, Sequence,
+    Transaction, TransactionVersion, TxIn, TxMerkleNode, TxOut, Witness,
+};
+use std::collections::HashSet;
+pub fn create_block_header(
+    version: i32,
+    prev_blockhash_bytes: [u8; 32],
+    merkle_root_bytes: [u8; 32],
+    time: u32,
+    bits: u32,
+    nonce: u32,
+) -> BlockHeader {
+    BlockHeader {
+        version: BlockVersion::from_consensus(version),
+        prev_blockhash: BlockHash::from_byte_array(prev_blockhash_bytes),
+        merkle_root: TxMerkleNode::from_byte_array(merkle_root_bytes),
+        time: BlockTime::from_u32(time),
+        bits: CompactTarget::from_consensus(bits),
+        nonce,
+    }
+}
+
+pub fn create_dummy_transaction(
+    bytes: [u8; 32],
+    vout: u32,
+    sequence: u32,
+    witness_items: Vec<Vec<u8>>,
+    value: u64,
+) -> Transaction {
+    Transaction {
+        version: TransactionVersion::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint {
+                txid: Txid::from_byte_array(bytes),
+                vout,
+            },
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence(sequence),
+            witness: Witness::from_slice(&witness_items),
+        }],
+        output: vec![TxOut {
+            value: Amount::from_sat(value).unwrap(),
+            script_pubkey: ScriptBuf::new(),
+        }],
+    }
+}
+pub fn create_dummy_merkle_path_proof(bytes: [u8; 32]) -> MerklePathProof {
+    MerklePathProof {
+        transaction_hash: Txid::from_byte_array(bytes),
+        merkle_path: vec![],
+    }
+}
+pub fn create_parents_set(parents_vec: Vec<(BeadHash, Time)>) -> HashSet<(BeadHash, Time)> {
+    parents_vec.into_iter().collect()
+}
+pub fn create_test_bead(
+    block_version: i32,
+    prev_blockhash_bytes: [u8; 32],
+    merkle_root_bytes: [u8; 32],
+    timestamp: u32,
+    difficulty_bits: u32,
+    nonce: u32,
+    bead_hash_bytes: [u8; 32],
+    coinbase_tx_bytes: [u8; 32],
+    payout_tx_bytes: [u8; 32],
+    lesser_difficulty_target: u32,
+    parent_hashes: Vec<(BeadHash, Time)>,
+    transactions_bytes: Vec<[u8; 32]>,
+    bits: u32,
+    bead_bytes: [u8; 32],
+    observed_time_at_node: u32,
+) -> Bead {
+    let target: CompactTarget = CompactTarget::from_consensus(lesser_difficulty_target);
+    let bytes: [u8; 32] = bead_bytes;
+    let beadhash: BeadHash = BlockHash::from_byte_array(bytes);
+    let blockheader: BlockHeader = create_block_header(
+        block_version,
+        prev_blockhash_bytes,
+        merkle_root_bytes,
+        timestamp,
+        bits,
+        nonce,
+    );
+
+    let coinbase_transaction: TransactionWithMerklePath = (
+        create_dummy_transaction(
+            coinbase_tx_bytes,
+            2,
+            0xFFFFFFFF,
+            vec![
+                hex::decode("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105")
+                    .unwrap(),
+                hex::decode("000000").unwrap(),
+            ],
+            10_000_000,
+        ),
+        create_dummy_merkle_path_proof(coinbase_tx_bytes),
+    );
+
+    let parents: HashSet<(BeadHash, Time)> = create_parents_set(parent_hashes);
+
+    let mut transactions_of_bead: Vec<Transaction> = Vec::new();
+
+    for transaction in transactions_bytes.iter() {
+        transactions_of_bead.push(create_dummy_transaction(
+            *transaction,
+            2,
+            0xFFFFFFFF,
+            vec![
+                hex::decode("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105")
+                    .unwrap(),
+                hex::decode("000000").unwrap(),
+            ],
+            10_000_000,
+        ));
+    }
+    let payout_transaction: TransactionWithMerklePath = (
+        create_dummy_transaction(
+            payout_tx_bytes,
+            2,
+            0xFFFFFFFF,
+            vec![
+                hex::decode("03d2e15674941bad4a996372cb87e1856d3652606d98562fe39c5e9e7e413f2105")
+                    .unwrap(),
+                hex::decode("000000").unwrap(),
+            ],
+            10_000_000,
+        ),
+        create_dummy_merkle_path_proof(payout_tx_bytes),
+    );
+    return Bead {
+        block_header: blockheader,
+        bead_hash: beadhash,
+        coinbase_transaction: coinbase_transaction,
+        payout_update_transaction: payout_transaction,
+        lesser_difficulty_target: target,
+        parents: parents,
+        transactions: transactions_of_bead,
+        observed_time_at_node: Time::from_consensus(1234567).unwrap(),
+    };
+}

--- a/braidpool-primitives/tests/bead_tests.rs
+++ b/braidpool-primitives/tests/bead_tests.rs
@@ -1,1 +1,44 @@
 // Integration tests for public functions!
+use ::bitcoin::absolute::Time;
+use braidpool_primitives::utils::test_utils::create_test_bead;
+use braidpool_primitives::{beads::Bead, utils::BeadHash};
+#[cfg(test)]
+#[test]
+fn test_valid_bead() {
+    let test_dag_bead: Bead = create_test_bead(
+        2,
+        [0x00; 32],
+        [
+            0xf3, 0xb8, 0x76, 0x2e, 0x7c, 0x1b, 0xd6, 0x47, 0xf1, 0xf6, 0x9d, 0x2a, 0x7f, 0x9c,
+            0x85, 0xf0, 0xb2, 0x5e, 0x64, 0x69, 0xf1, 0x07, 0xd2, 0x31, 0xdf, 0xf4, 0x5c, 0x47,
+            0x1f, 0x88, 0x94, 0x58,
+        ],
+        1653195600,
+        486604799,
+        0,
+        [0x00; 32],
+        [0xbb; 32],
+        [0xbb; 32],
+        4040404,
+        vec![
+            (
+                BeadHash::from_byte_array([0x01; 32]),
+                Time::from_consensus(1690000000).expect("invalid time value"),
+            ),
+            (
+                BeadHash::from_byte_array([0x02; 32]),
+                Time::from_consensus(1690001000).expect("invalid time value"),
+            ),
+            (
+                BeadHash::from_byte_array([0x03; 32]),
+                Time::from_consensus(1690002000).expect("invalid time value"),
+            ),
+        ], // parents
+        vec![[0x11; 32], [0x22; 32], [0x33; 32], [0x44; 32]],
+        436864982,
+        [0x00; 32],
+        1653195600,
+    );
+    // let x = &test_dag_bead.bead_data;
+    assert_eq!(test_dag_bead.is_valid_bead(), true);
+}

--- a/braidpool-primitives/tests/braid_tests.rs
+++ b/braidpool-primitives/tests/braid_tests.rs
@@ -1,1 +1,51 @@
 // Integration tests for the braid
+use ::bitcoin::absolute::Time;
+use braidpool_primitives::braid::Braid;
+use braidpool_primitives::utils::test_utils::create_test_bead;
+use braidpool_primitives::utils::BeadHash;
+use std::collections::HashSet;
+
+#[cfg(test)]
+#[test]
+fn add_bead_test() {
+    let mut genesis_beads: HashSet<BeadHash> = HashSet::new();
+    let test_dag_bead_1 = create_test_bead(
+        2,
+        [0x00; 32],
+        [
+            0xf3, 0xb8, 0x76, 0x2e, 0x7c, 0x1b, 0xd6, 0x47, 0xf1, 0xf6, 0x9d, 0x2a, 0x7f, 0x9c,
+            0x85, 0xf0, 0xb2, 0x5e, 0x64, 0x69, 0xf1, 0x07, 0xd2, 0x31, 0xdf, 0xf4, 0x5c, 0x47,
+            0x1f, 0x88, 0x94, 0x58,
+        ],
+        1653195600,
+        486604799,
+        0,
+        [0x00; 32],
+        [0xbb; 32],
+        [0xbb; 32],
+        4040404,
+        vec![
+            (
+                BeadHash::from_byte_array([0x01; 32]),
+                Time::from_consensus(1690000000).expect("invalid time value"),
+            ),
+            (
+                BeadHash::from_byte_array([0x02; 32]),
+                Time::from_consensus(1690001000).expect("invalid time value"),
+            ),
+            (
+                BeadHash::from_byte_array([0x03; 32]),
+                Time::from_consensus(1690002000).expect("invalid time value"),
+            ),
+        ],
+        vec![[0x11; 32], [0x22; 32], [0x33; 32], [0x44; 32]],
+        436864982,
+        [0x00; 32],
+        1653195600,
+    );
+    genesis_beads.insert(test_dag_bead_1.bead_hash);
+    let mut test_braid = Braid::new(genesis_beads);
+    test_braid.add_bead(test_dag_bead_1);
+
+    // assert!(test_braid.);
+}


### PR DESCRIPTION
What does this PR do - 

- Adds the separate unit tests for private functions for `bead` and `braid` respectively .
- Adds the integration tests for public functions for `bead` and `braid` respectively.
- Inherit trait such as `Clone` , `debug` etc .  

Further addition of testcases in data directory is to be done along with few changes related to refactoring of functions as well .