### PR TITLE
feat: add simulator api

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,67 @@
+# Simulator API
+
+This README provides instructions on how to run the `simulator_api.py` script and access its deployed URL, Swagger documentation, and endpoints.
+
+## Prerequisites
+
+Ensure you have the following installed:
+
+- Python 3.8 or higher
+- Required dependencies (install via `requirements.txt`)
+
+## Setup
+
+Install dependencies:
+
+```
+    pip install -r requirements.txt
+```
+
+## Running the Simulator
+
+1. Run the script:
+
+   ```
+   python simulator_api.py
+   ```
+
+2. The API will start, and you can access it at:
+
+   ```
+   http://127.0.0.1:65433
+   ```
+
+3. For testing and API documentation, refer to:
+   ```
+   http://127.0.0.1:65433/apidocs
+   ```
+
+## Accessing the Deployed URL
+
+You can access the API at the provided URL:
+
+Websocket:
+
+```
+http://french.braidpool.net:65433/
+```
+
+## Deployed Swagger Documentation
+
+To view the deployed Swagger UI for API documentation, navigate to:
+
+```
+http://french.braidpool.net:65433/apidocs
+```
+
+## Endpoints
+
+Refer to the Swagger UI for a detailed list of available endpoints and their usage.
+
+# Testing
+
+Run `pytest simulator_api_tests.py` to run the test suite.
+
+## Notes
+
+- Ensure the server is running before accessing the endpoints if running locally.

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -3,3 +3,5 @@ matplotlib==3.10.1
 numpy==2.2.4
 pytest==8.3.5
 scipy==1.15.2
+flask
+flask_cors

--- a/tests/simulator_api.py
+++ b/tests/simulator_api.py
@@ -1,0 +1,123 @@
+from flask import Flask, jsonify
+from flask_socketio import SocketIO
+from flask_cors import CORS
+from flasgger import Swagger, swag_from
+import threading
+import time
+from simulator import Network
+from braid import reverse, descendant_work, highest_work_path, cohorts
+import logging
+
+logging.basicConfig(level=logging.INFO)
+
+app = Flask(__name__)
+CORS(app)
+socketio = SocketIO(app, cors_allowed_origins="*", async_mode="threading")
+
+swagger = Swagger(app)
+
+
+@app.route("/hello")
+@swag_from(
+    {
+        "responses": {
+            200: {
+                "description": "Returns a simple hello message",
+                "examples": {"text": "Hello Braidpool"},
+            }
+        }
+    }
+)
+def hello():
+    return "Hello Braidpool"
+
+
+braid_data = {}
+
+
+@app.route("/test_data")
+@swag_from(
+    {
+        "responses": {
+            200: {
+                "description": "Returns simulated braid data",
+                "schema": {
+                    "type": "object",
+                    "properties": {
+                        "highest_work_path": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                        },
+                        "parents": {"type": "object"},
+                        "children": {"type": "object"},
+                        "work": {"type": "object"},
+                        "cohorts": {
+                            "type": "array",
+                            "items": {"type": "array", "items": {"type": "string"}},
+                        },
+                        "bead_count": {"type": "integer"},
+                    },
+                },
+            }
+        }
+    }
+)
+def data():
+    logging.info(f"Returning braid_data on test_data endpoint")
+    return jsonify(braid_data)
+
+
+class BraidSimulator:
+    def __init__(self):
+        self.network = Network(
+            nnodes=50, target=2**240 - 1, hashrate=800000, target_algo="exp"
+        )
+        self.current_beads = 0
+        self.bead_increment = 1
+        self.update_interval = 0.5
+
+    def run(self):
+        while True:
+            new_beads = self.bead_increment
+            self.network.simulate(nbeads=new_beads, mine=False)
+            self.current_beads += new_beads
+            self.bead_increment += 1
+            self.emit_braid_update()
+            time.sleep(self.update_interval)
+
+    def emit_braid_update(self):
+        global braid_data
+        try:
+            braid = self.network.nodes[0].braid
+            hashed_parents = {int(k): list(map(int, v)) for k, v in dict(braid).items()}
+            parents = hashed_parents
+
+            braid_data = {
+                "highest_work_path": list(
+                    map(str, highest_work_path(parents, reverse(parents)))
+                ),
+                "parents": {str(k): list(map(str, v)) for k, v in parents.items()},
+                "children": {
+                    str(k): list(map(str, v)) for k, v in reverse(parents).items()
+                },
+                "work": {str(k): v for k, v in descendant_work(parents).items()},
+                "cohorts": [list(map(str, cohort)) for cohort in cohorts(parents)],
+                "bead_count": len(braid.beads),
+            }
+
+            socketio.emit("braid_update", braid_data)
+            logging.log(braid_data["bead_count"])
+
+        except Exception as e:
+            logging.error(f"Error in emit_braid_update: {str(e)}", exc_info=True)
+            raise
+
+
+def start_simulator():
+    simulator = BraidSimulator()
+    simulator.run()
+
+
+if __name__ == "__main__":
+    threading.Thread(target=start_simulator, daemon=True).start()
+    socketio.run(app, host="0.0.0.0", port=65433, debug=True)

--- a/tests/simulator_api_tests.py
+++ b/tests/simulator_api_tests.py
@@ -1,0 +1,65 @@
+import pytest
+from flask.testing import FlaskClient
+from simulator_api import app
+
+
+@pytest.fixture
+def client():
+    with app.test_client() as client:
+        yield client
+
+
+def test_hello(client: FlaskClient):
+    """Test the /hello endpoint returns correct response."""
+    response = client.get("/hello")
+    assert response.status_code == 200
+    assert b"Hello Braidpool" in response.data
+
+
+def test_test_data_empty(client: FlaskClient):
+    """Test the /test_data endpoint returns correct structure with empty braid_data."""
+    response = client.get("/test_data")
+    assert response.status_code == 200
+    data = response.get_json()
+
+    # As braid_data might be empty at startup, we validate it's a dictionary
+    assert isinstance(data, dict)
+
+
+def test_test_data_structure(client: FlaskClient):
+    """Test the /test_data endpoint returns valid structure when braid_data is populated."""
+    # Mocking braid_data for test
+    from simulator_api import braid_data
+
+    braid_data.update(
+        {
+            "highest_work_path": ["1", "2"],
+            "parents": {"1": ["0"], "2": ["1"]},
+            "children": {"0": ["1"], "1": ["2"]},
+            "work": {"0": 1, "1": 2, "2": 3},
+            "cohorts": [["0"], ["1", "2"]],
+            "bead_count": 3,
+        }
+    )
+
+    response = client.get("/test_data")
+    assert response.status_code == 200
+    data = response.get_json()
+
+    assert "highest_work_path" in data
+    assert isinstance(data["highest_work_path"], list)
+
+    assert "parents" in data
+    assert isinstance(data["parents"], dict)
+
+    assert "children" in data
+    assert isinstance(data["children"], dict)
+
+    assert "work" in data
+    assert isinstance(data["work"], dict)
+
+    assert "cohorts" in data
+    assert isinstance(data["cohorts"], list)
+
+    assert "bead_count" in data
+    assert isinstance(data["bead_count"], int)


### PR DESCRIPTION
- Integrated Flask-SocketIO to stream live braid simulation updates in a json format
- Added Swagger UI for API testing
- Enabled CORS for frontend calls
- Implemented a background thread to run simulations continuously
- Add tests for the api 
- Docs for tutorial about running the API
- Update requirements.txt for dependencies