### PR TITLE
Implement `encodable` trait for `Bead` structure

### DIFF
--- a/braidpool-primitives/src/bead/mod.rs
+++ b/braidpool-primitives/src/bead/mod.rs
@@ -1,4 +1,5 @@
 #![allow(unused)]
+use bitcoin::io::{self, Write};
 // Standard Imports
 use ::serde::{Deserialize, Serialize};
 use std::collections::HashSet;
@@ -7,6 +8,9 @@ use std::net::SocketAddr;
 // Bitcoin primitives
 use bitcoin::Address;
 use bitcoin::absolute::Time;
+use bitcoin::consensus::encode::Decodable;
+use bitcoin::consensus::encode::Encodable;
+use bitcoin::consensus::encode::serialize;
 use bitcoin::ecdsa::Signature;
 use bitcoin::p2p::Address as P2P_Address;
 use bitcoin::secp256k1::PublicKey;
@@ -14,19 +18,86 @@ use bitcoin::transaction::TransactionExt;
 use bitcoin::{BlockHeader, Transaction};
 // Custom Imports
 use crate::utils::BeadHash;
-#[derive(Clone, Debug, Serialize)]
+
+/// Wrapper type for HashSet<BeadHash> to allow custom trait implementations.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct BeadHashSet(pub HashSet<BeadHash>);
+
+impl Encodable for BeadHashSet {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += (self.0.len() as u64).consensus_encode(w)?;
+        for item in self.0.iter() {
+            len += item.consensus_encode(w)?;
+        }
+        Ok(len)
+    }
+}
+
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
+pub struct TimeHashSet(pub HashSet<Time>);
+
+impl Encodable for TimeHashSet {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        // Encode the length for deterministic encoding
+        len += (self.0.len() as u64).consensus_encode(w)?;
+        for time in &self.0 {
+            len += time.to_consensus_u32().consensus_encode(w)?;
+        }
+        Ok(len)
+    }
+}
+
+/// Wrapper type for SocketAddr to allow custom trait implementations.
+#[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Hash)]
+pub struct SerializableSocketAddr(pub SocketAddr);
+
+impl Encodable for SerializableSocketAddr {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let (address, port) = match self.0 {
+            SocketAddr::V4(addr) => (addr.ip().to_ipv6_mapped().segments(), addr.port()),
+            SocketAddr::V6(addr) => (addr.ip().segments(), addr.port()),
+        };
+        let mut len = 0;
+        len += address.consensus_encode(w)?;
+        len += port.consensus_encode(w)?;
+        Ok(len)
+    }
+}
+
+#[derive(Clone, Debug)]
 
 pub struct CommittedMetadata {
     // Committed Braidpool Metadata,
     pub transaction_cnt: u32,
     pub transactions: Vec<Transaction>,
-    pub parents: HashSet<BeadHash>,
-    pub payout_address: Address,
+    pub parents: BeadHashSet,
+    pub payout_address: P2P_Address,
     //timestamp when the bead was created
     pub observed_time_at_node: Time,
     pub comm_pub_key: PublicKey,
-    pub miner_ip: SocketAddr,
+    pub miner_ip: SerializableSocketAddr,
 }
+
+impl Encodable for CommittedMetadata {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.transaction_cnt.consensus_encode(w)?;
+        len += self.transactions.consensus_encode(w)?;
+        len += self.parents.consensus_encode(w)?;
+        len += self.payout_address.consensus_encode(w)?;
+        len += self
+            .observed_time_at_node
+            .to_consensus_u32()
+            .consensus_encode(w)?;
+        let pubkey_bytes = self.comm_pub_key.serialize();
+        len += pubkey_bytes.consensus_encode(w)?;
+        len += self.miner_ip.consensus_encode(w)?;
+        Ok(len)
+    }
+}
+
 #[derive(Clone, Debug, Serialize)]
 
 pub struct UnCommittedMetadata {
@@ -35,14 +106,39 @@ pub struct UnCommittedMetadata {
     pub extra_nonce: i32,
     pub broadcast_timestamp: Time,
     pub signature: Signature,
-    pub parent_bead_timestamps: HashSet<Time>,
+    pub parent_bead_timestamps: TimeHashSet,
 }
-#[derive(Clone, Debug, Serialize)]
+
+impl Encodable for UnCommittedMetadata {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.extra_nonce.consensus_encode(w)?;
+        len += self
+            .broadcast_timestamp
+            .to_consensus_u32()
+            .consensus_encode(w)?;
+        len += self.signature.to_string().consensus_encode(w)?;
+        len += self.parent_bead_timestamps.consensus_encode(w)?;
+        Ok(len)
+    }
+}
+
+#[derive(Clone, Debug)]
 
 pub struct Bead {
     pub block_header: BlockHeader,
     pub committed_metadata: CommittedMetadata,
     pub uncommitted_metadata: UnCommittedMetadata,
+}
+
+impl Encodable for Bead {
+    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
+        let mut len = 0;
+        len += self.block_header.consensus_encode(w)?;
+        len += self.committed_metadata.consensus_encode(w)?;
+        len += self.uncommitted_metadata.consensus_encode(w)?;
+        Ok(len)
+    }
 }
 
 impl Bead {
@@ -58,6 +154,69 @@ impl Bead {
     pub fn get_payout_update_transaction(&self) -> Transaction {
         // TODO: Implement this function.
         unimplemented!()
+    }
+
+    // #[inline]
+    // pub fn is_parent_of(&self, child_bead_hash: BeadHash) -> bool {
+    //     self.children.borrow().contains(&child_bead_hash)
+    // }
+
+    pub fn is_genesis_bead(&self, braid: &Braid) -> bool {
+        if self.committed_metadata.parents.0.is_empty() {
+            return true;
+        };
+
+        // We need to check whether even one of the parent beads have been pruned from memory!
+        for parent_bead_hash in self.committed_metadata.parents.0.iter() {
+            let parent_bead = braid.load_bead_from_hash(*parent_bead_hash);
+            if let Err(error_type) = parent_bead {
+                match error_type {
+                    BeadLoadError::BeadPruned => return true,
+                    _ => panic!("Fatal Error Detected!"),
+                };
+            }
+        }
+
+        false
+    }
+
+    #[inline]
+    pub fn is_orphaned(&self, braid: &Braid) -> bool {
+        for parent in self.committed_metadata.parents.0.iter() {
+            if braid.beads.contains(parent) == false {
+                return true;
+            }
+        }
+
+        false
+    }
+
+    #[inline]
+    pub fn get_parents(&self) -> Parents {
+        // The bead might get pruned later, so we can't give a shared reference!
+        self.committed_metadata.parents.0.clone()
+    }
+
+    // #[inline]
+    // pub fn get_children(&self) -> Children {
+    //     self.children.borrow().iter().cloned().collect()
+    // }
+}
+
+impl Bead {
+    // All pub(crate) function definitions go here!
+    #[inline]
+    pub(crate) fn add_child(&self, child_bead_hash: BeadHash) {
+        // TODO: While Implementing the DB, we also need to update the corresponding DB Entry!
+        // self.children.borrow_mut().insert(child_bead_hash);
+        unimplemented!();
+    }
+
+    pub fn get_bead_hash(&self) -> BlockHash {
+        let serialized_bead = serialize(self);
+        let mut serialized_bytes = [0u8; 32];
+        hex::decode_to_slice(serialized_bead, &mut serialized_bytes).unwrap();
+        BlockHash::from_byte_array(serialized_bytes)
     }
 }
 

--- a/braidpool-primitives/src/bead/mod.rs
+++ b/braidpool-primitives/src/bead/mod.rs
@@ -1,27 +1,22 @@
-#![allow(unused)]
-use bitcoin::consensus::Error;
-use bitcoin::io::{self, BufRead, Write};
-use bitcoin::p2p::address::AddrV2;
-// Standard Imports
-use ::serde::{Deserialize, Serialize};
-use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
-
-// Bitcoin primitives
 use crate::braid::Braid;
+use crate::utils::{
+    BeadHash, BeadLoadError, Parents, hashset_to_vec_deterministic, vec_to_hashset,
+};
+use ::serde::{Deserialize, Serialize};
+use bitcoin::BlockHash;
+use bitcoin::CompactTarget;
+use bitcoin::PublicKey;
 use bitcoin::absolute::Time;
+use bitcoin::consensus::Error;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
-use bitcoin::consensus::encode::serialize;
 use bitcoin::ecdsa::Signature;
+use bitcoin::io::{self, BufRead, Write};
 use bitcoin::p2p::Address as P2P_Address;
-use bitcoin::secp256k1::PublicKey;
-use bitcoin::transaction::TransactionExt;
-use bitcoin::{Address, BlockHash};
+use bitcoin::p2p::address::AddrV2;
 use bitcoin::{BlockHeader, Transaction};
 use core::str::FromStr;
-// Custom Imports
-use crate::utils::{BeadHash, BeadLoadError, Children, Parents};
+use std::collections::HashSet;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
 pub struct TimeVec(pub Vec<Time>);
@@ -51,17 +46,20 @@ impl Decodable for TimeVec {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 
 pub struct CommittedMetadata {
-    // Committed Braidpool Metadata,
     pub transaction_cnt: u32,
     pub transactions: Vec<Transaction>,
-    pub parents: Vec<BeadHash>,
+    pub parents: HashSet<BeadHash>,
     pub payout_address: P2P_Address,
-    //timestamp when the bead was created
-    pub observed_time_at_node: Time,
+    pub start_timestamp: Time,
     pub comm_pub_key: PublicKey,
+    //minimum possible target > which will be the weak target
+    pub min_target: CompactTarget,
+    //the weaker target locallay apart from mainnet target ranging between the mainnet target and
+    //minimum possible target
+    pub weak_target: CompactTarget,
     pub miner_ip: AddrV2,
 }
 
@@ -70,14 +68,16 @@ impl Encodable for CommittedMetadata {
         let mut len = 0;
         len += self.transaction_cnt.consensus_encode(w)?;
         len += self.transactions.consensus_encode(w)?;
-        len += self.parents.consensus_encode(w)?;
+        len += hashset_to_vec_deterministic(&self.parents).consensus_encode(w)?;
         len += self.payout_address.consensus_encode(w)?;
         len += self
-            .observed_time_at_node
+            .start_timestamp
             .to_consensus_u32()
             .consensus_encode(w)?;
-        let pubkey_bytes = self.comm_pub_key.serialize();
+        let pubkey_bytes = self.comm_pub_key.to_vec();
         len += pubkey_bytes.consensus_encode(w)?;
+        len += self.min_target.consensus_encode(w)?;
+        len += self.weak_target.consensus_encode(w)?;
         len += self.miner_ip.consensus_encode(w)?;
         Ok(len)
     }
@@ -87,29 +87,30 @@ impl Decodable for CommittedMetadata {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let transaction_cnt = u32::consensus_decode(r)?;
         let transactions = Vec::<Transaction>::consensus_decode(r)?;
-        let parents = Vec::<BeadHash>::consensus_decode(r)?;
+        let parents = vec_to_hashset(Vec::<BeadHash>::consensus_decode(r)?);
         let payout_address = P2P_Address::consensus_decode(r)?;
-        let observed_time_at_node =
-            Time::from_consensus(u32::consensus_decode(r).unwrap()).unwrap();
+        let start_timestamp = Time::from_consensus(u32::consensus_decode(r).unwrap()).unwrap();
         let comm_pub_key = PublicKey::from_slice(&Vec::<u8>::consensus_decode(r).unwrap()).unwrap();
+        let min_target = CompactTarget::consensus_decode(r).unwrap();
+        let weak_target = CompactTarget::consensus_decode(r).unwrap();
         let miner_ip = AddrV2::consensus_decode(r)?;
         Ok(CommittedMetadata {
             transaction_cnt,
             transactions,
             parents,
             payout_address,
-            observed_time_at_node,
+            start_timestamp,
             comm_pub_key,
+            min_target,
+            weak_target,
             miner_ip,
         })
     }
 }
 
-#[derive(Clone, Debug, Serialize)]
+#[derive(Clone, Debug, Serialize, PartialEq)]
 
 pub struct UnCommittedMetadata {
-    //Uncomitted Metadata
-    //timestamp when the bead was broadcasted
     pub extra_nonce: i32,
     pub broadcast_timestamp: Time,
     pub signature: Signature,
@@ -145,7 +146,7 @@ impl Decodable for UnCommittedMetadata {
     }
 }
 
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 
 pub struct Bead {
     pub block_header: BlockHeader,
@@ -190,12 +191,6 @@ impl Bead {
         // TODO: Implement this function.
         unimplemented!()
     }
-
-    // #[inline]
-    // pub fn is_parent_of(&self, child_bead_hash: BeadHash) -> bool {
-    //     self.children.borrow().contains(&child_bead_hash)
-    // }
-
     pub fn is_genesis_bead(&self, braid: &Braid) -> bool {
         if self.committed_metadata.parents.is_empty() {
             return true;
@@ -231,27 +226,11 @@ impl Bead {
         // The bead might get pruned later, so we can't give a shared reference!
         self.committed_metadata.parents.clone()
     }
-
-    // #[inline]
-    // pub fn get_children(&self) -> Children {
-    //     self.children.borrow().iter().cloned().collect()
-    // }
 }
 
 impl Bead {
-    // All pub(crate) function definitions go here!
-    #[inline]
-    pub(crate) fn add_child(&self, child_bead_hash: BeadHash) {
-        // TODO: While Implementing the DB, we also need to update the corresponding DB Entry!
-        // self.children.borrow_mut().insert(child_bead_hash);
-        unimplemented!();
-    }
-
     pub fn get_bead_hash(&self) -> BlockHash {
-        let serialized_bead = serialize(self);
-        let mut serialized_bytes = [0u8; 32];
-        hex::decode_to_slice(serialized_bead, &mut serialized_bytes).unwrap();
-        BlockHash::from_byte_array(serialized_bytes)
+        self.block_header.block_hash()
     }
 }
 

--- a/braidpool-primitives/src/utils/mod.rs
+++ b/braidpool-primitives/src/utils/mod.rs
@@ -14,8 +14,8 @@ pub type Bytes = Vec<Byte>;
 // Internal Type Aliases
 pub(crate) type ParentBeadHash = BeadHash;
 pub(crate) type ChildrenBeadHash = BeadHash;
-pub(crate) type Parents = HashSet<ParentBeadHash>;
-pub(crate) type Children = HashSet<ChildrenBeadHash>;
+pub(crate) type Parents = Vec<ParentBeadHash>;
+pub(crate) type Children = Vec<ChildrenBeadHash>;
 
 // Error Definitions
 use std::fmt::{self};

--- a/braidpool-primitives/src/utils/mod.rs
+++ b/braidpool-primitives/src/utils/mod.rs
@@ -13,10 +13,13 @@ pub type Bytes = Vec<Byte>;
 
 // Internal Type Aliases
 pub(crate) type ParentBeadHash = BeadHash;
-pub(crate) type Parents = Vec<ParentBeadHash>;
+pub(crate) type Parents = HashSet<ParentBeadHash>;
 
 // Error Definitions
-use std::fmt::{self};
+use std::{
+    collections::HashSet,
+    fmt::{self},
+};
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum BeadLoadError {
     BeadPruned,
@@ -37,3 +40,13 @@ impl fmt::Display for BeadLoadError {
 }
 
 impl std::error::Error for BeadLoadError {}
+
+pub(crate) fn hashset_to_vec_deterministic(hashset: &HashSet<BeadHash>) -> Vec<BeadHash> {
+    let mut vec: Vec<BeadHash> = hashset.iter().cloned().collect();
+    vec.sort();
+    vec
+}
+
+pub(crate) fn vec_to_hashset(vec: Vec<BeadHash>) -> HashSet<BeadHash> {
+    vec.iter().cloned().collect()
+}

--- a/braidpool-primitives/src/utils/mod.rs
+++ b/braidpool-primitives/src/utils/mod.rs
@@ -2,9 +2,9 @@
 use ::bitcoin::BlockHash;
 
 // Standard Imports
-use std::collections::HashSet;
 
 pub mod bitcoin;
+pub mod test_utils;
 
 // External Type Aliases
 pub type BeadHash = BlockHash;
@@ -13,9 +13,7 @@ pub type Bytes = Vec<Byte>;
 
 // Internal Type Aliases
 pub(crate) type ParentBeadHash = BeadHash;
-pub(crate) type ChildrenBeadHash = BeadHash;
 pub(crate) type Parents = Vec<ParentBeadHash>;
-pub(crate) type Children = Vec<ChildrenBeadHash>;
 
 // Error Definitions
 use std::fmt::{self};

--- a/braidpool-primitives/src/utils/test_utils.rs
+++ b/braidpool-primitives/src/utils/test_utils.rs
@@ -14,6 +14,10 @@ use bitcoin::p2p::Address as P2P_Address;
 use bitcoin::{PublicKey, Transaction, absolute::Time, p2p::address::AddrV2};
 #[cfg(test)]
 pub mod test_utility_functions {
+    use std::collections::HashSet;
+
+    use bitcoin::CompactTarget;
+
     use super::*;
     pub struct TestUnCommittedMetadataBuilder {
         extra_nonce: i32,
@@ -67,122 +71,134 @@ pub mod test_utility_functions {
         }
     }
     #[cfg(test)]
-pub struct TestCommittedMetadataBuilder {
-    transaction_cnt: u32,
-    transactions: Vec<Transaction>,
-    parents: Vec<BeadHash>,
-    payout_address: Option<P2P_Address>,
-    start_timestamp: Option<Time>,
-    comm_pub_key: Option<PublicKey>,
-    miner_ip: Option<AddrV2>,
-}
+    pub struct TestCommittedMetadataBuilder {
+        transaction_cnt: u32,
+        transactions: Vec<Transaction>,
+        parents: std::collections::HashSet<BeadHash>,
+        payout_address: Option<P2P_Address>,
+        start_timestamp: Option<Time>,
+        comm_pub_key: Option<PublicKey>,
+        min_target: Option<CompactTarget>,
+        weak_target: Option<CompactTarget>,
+        miner_ip: Option<AddrV2>,
+    }
 
-#[cfg(test)]
-impl TestCommittedMetadataBuilder {
-    pub fn new() -> Self {
-        Self {
-            transaction_cnt: 0,
-            transactions: Vec::new(),
-            parents: Vec::new(),
-            payout_address: None,
-            start_timestamp: None,
-            comm_pub_key: None,
-            miner_ip: None,
+    #[cfg(test)]
+    impl TestCommittedMetadataBuilder {
+        pub fn new() -> Self {
+            Self {
+                transaction_cnt: 0,
+                transactions: Vec::new(),
+                parents: HashSet::new(),
+                payout_address: None,
+                start_timestamp: None,
+                comm_pub_key: None,
+                min_target: None,
+                weak_target: None,
+                miner_ip: None,
+            }
+        }
+
+        pub fn transaction_cnt(mut self, count: u32) -> Self {
+            self.transaction_cnt = count;
+            self
+        }
+
+        pub fn transactions(mut self, txs: Vec<Transaction>) -> Self {
+            self.transactions = txs;
+            self
+        }
+
+        pub fn parents(mut self, parents: HashSet<BeadHash>) -> Self {
+            self.parents = parents;
+            self
+        }
+
+        pub fn payout_address(mut self, address: P2P_Address) -> Self {
+            self.payout_address = Some(address);
+            self
+        }
+
+        pub fn start_timestamp(mut self, time: Time) -> Self {
+            self.start_timestamp = Some(time);
+            self
+        }
+
+        pub fn comm_pub_key(mut self, key: PublicKey) -> Self {
+            self.comm_pub_key = Some(key);
+            self
+        }
+
+        pub fn miner_ip(mut self, ip: AddrV2) -> Self {
+            self.miner_ip = Some(ip);
+            self
+        }
+        pub fn min_target(mut self, min_target: CompactTarget) -> Self {
+            self.min_target = Some(min_target);
+            self
+        }
+        pub fn weak_target(mut self, weak_target: CompactTarget) -> Self {
+            self.weak_target = Some(weak_target);
+            self
+        }
+        pub fn build(self) -> CommittedMetadata {
+            CommittedMetadata {
+                transaction_cnt: self.transaction_cnt,
+                transactions: self.transactions,
+                parents: self.parents,
+                payout_address: self.payout_address.expect("payout_address is required"),
+                start_timestamp: self
+                    .start_timestamp
+                    .expect("observed_time_at_node is required"),
+                comm_pub_key: self.comm_pub_key.expect("comm_pub_key is required"),
+                min_target: self.min_target.expect("min_target is required"),
+                weak_target: self.weak_target.expect("weak_target is required"),
+                miner_ip: self.miner_ip.expect("miner_ip is required"),
+            }
         }
     }
-
-    pub fn transaction_cnt(mut self, count: u32) -> Self {
-        self.transaction_cnt = count;
-        self
+    #[cfg(test)]
+    pub struct TestBeadBuilder {
+        block_header: Option<BlockHeader>,
+        committed_metadata: Option<CommittedMetadata>,
+        uncommitted_metadata: Option<UnCommittedMetadata>,
     }
 
-    pub fn transactions(mut self, txs: Vec<Transaction>) -> Self {
-        self.transactions = txs;
-        self
-    }
+    #[cfg(test)]
+    impl TestBeadBuilder {
+        pub fn new() -> Self {
+            Self {
+                block_header: None,
+                committed_metadata: None,
+                uncommitted_metadata: None,
+            }
+        }
 
-    pub fn parents(mut self, parents: Vec<BeadHash>) -> Self {
-        self.parents = parents;
-        self
-    }
+        pub fn block_header(mut self, block_header: BlockHeader) -> Self {
+            self.block_header = Some(block_header);
+            self
+        }
 
-    pub fn payout_address(mut self, address: P2P_Address) -> Self {
-        self.payout_address = Some(address);
-        self
-    }
+        pub fn committed_metadata(mut self, committed_metadata: CommittedMetadata) -> Self {
+            self.committed_metadata = Some(committed_metadata);
+            self
+        }
 
-    pub fn start_timestamp(mut self, time: Time) -> Self {
-        self.start_timestamp = Some(time);
-        self
-    }
+        pub fn uncommitted_metadata(mut self, uncommitted_metadata: UnCommittedMetadata) -> Self {
+            self.uncommitted_metadata = Some(uncommitted_metadata);
+            self
+        }
 
-    pub fn comm_pub_key(mut self, key: PublicKey) -> Self {
-        self.comm_pub_key = Some(key);
-        self
-    }
-
-    pub fn miner_ip(mut self, ip: AddrV2) -> Self {
-        self.miner_ip = Some(ip);
-        self
-    }
-
-    pub fn build(self) -> CommittedMetadata {
-        CommittedMetadata {
-            transaction_cnt: self.transaction_cnt,
-            transactions: self.transactions,
-            parents: self.parents,
-            payout_address: self.payout_address.expect("payout_address is required"),
-            start_timestamp: self
-                .start_timestamp
-                .expect("observed_time_at_node is required"),
-            comm_pub_key: self.comm_pub_key.expect("comm_pub_key is required"),
-            miner_ip: self.miner_ip.expect("miner_ip is required"),
+        pub fn build(self) -> Bead {
+            Bead {
+                block_header: self.block_header.expect("BlockHeader is required"),
+                committed_metadata: self
+                    .committed_metadata
+                    .expect("CommittedMetadata is required"),
+                uncommitted_metadata: self
+                    .uncommitted_metadata
+                    .expect("UnCommittedMetadata is required"),
+            }
         }
     }
-}
-#[cfg(test)]
-pub struct TestBeadBuilder {
-    block_header: Option<BlockHeader>,
-    committed_metadata: Option<CommittedMetadata>,
-    uncommitted_metadata: Option<UnCommittedMetadata>,
-}
-
-#[cfg(test)]
-impl TestBeadBuilder {
-    pub fn new() -> Self {
-        Self {
-            block_header: None,
-            committed_metadata: None,
-            uncommitted_metadata: None,
-        }
-    }
-
-    pub fn block_header(mut self, block_header: BlockHeader) -> Self {
-        self.block_header = Some(block_header);
-        self
-    }
-
-    pub fn committed_metadata(mut self, committed_metadata: CommittedMetadata) -> Self {
-        self.committed_metadata = Some(committed_metadata);
-        self
-    }
-
-    pub fn uncommitted_metadata(mut self, uncommitted_metadata: UnCommittedMetadata) -> Self {
-        self.uncommitted_metadata = Some(uncommitted_metadata);
-        self
-    }
-
-    pub fn build(self) -> Bead {
-        Bead {
-            block_header: self.block_header.expect("BlockHeader is required"),
-            committed_metadata: self
-                .committed_metadata
-                .expect("CommittedMetadata is required"),
-            uncommitted_metadata: self
-                .uncommitted_metadata
-                .expect("UnCommittedMetadata is required"),
-        }
-    }
-}
-
 }

--- a/braidpool-primitives/src/utils/test_utils.rs
+++ b/braidpool-primitives/src/utils/test_utils.rs
@@ -1,0 +1,188 @@
+#[cfg(test)]
+use super::BeadHash;
+#[cfg(test)]
+use crate::bead::TimeVec;
+#[cfg(test)]
+use crate::bead::{Bead, CommittedMetadata, UnCommittedMetadata};
+#[cfg(test)]
+use bitcoin::BlockHeader;
+#[cfg(test)]
+use bitcoin::ecdsa::Signature;
+#[cfg(test)]
+use bitcoin::p2p::Address as P2P_Address;
+#[cfg(test)]
+use bitcoin::{PublicKey, Transaction, absolute::Time, p2p::address::AddrV2};
+#[cfg(test)]
+pub mod test_utility_functions {
+    use super::*;
+    pub struct TestUnCommittedMetadataBuilder {
+        extra_nonce: i32,
+        broadcast_timestamp: Option<Time>,
+        signature: Option<Signature>,
+        parent_bead_timestamps: Option<TimeVec>,
+    }
+
+    #[cfg(test)]
+    impl TestUnCommittedMetadataBuilder {
+        pub fn new() -> Self {
+            Self {
+                extra_nonce: 0,
+                broadcast_timestamp: None,
+                signature: None,
+                parent_bead_timestamps: None,
+            }
+        }
+
+        pub fn extra_nonce(mut self, nonce: i32) -> Self {
+            self.extra_nonce = nonce;
+            self
+        }
+
+        pub fn broadcast_timestamp(mut self, time: Time) -> Self {
+            self.broadcast_timestamp = Some(time);
+            self
+        }
+
+        pub fn signature(mut self, sig: Signature) -> Self {
+            self.signature = Some(sig);
+            self
+        }
+
+        pub fn parent_bead_timestamps(mut self, times: TimeVec) -> Self {
+            self.parent_bead_timestamps = Some(times);
+            self
+        }
+
+        pub fn build(self) -> UnCommittedMetadata {
+            UnCommittedMetadata {
+                extra_nonce: self.extra_nonce,
+                broadcast_timestamp: self
+                    .broadcast_timestamp
+                    .expect("broadcast_timestamp is required"),
+                signature: self.signature.expect("signature is required"),
+                parent_bead_timestamps: self
+                    .parent_bead_timestamps
+                    .expect("parent_bead_timestamps is required"),
+            }
+        }
+    }
+    #[cfg(test)]
+pub struct TestCommittedMetadataBuilder {
+    transaction_cnt: u32,
+    transactions: Vec<Transaction>,
+    parents: Vec<BeadHash>,
+    payout_address: Option<P2P_Address>,
+    start_timestamp: Option<Time>,
+    comm_pub_key: Option<PublicKey>,
+    miner_ip: Option<AddrV2>,
+}
+
+#[cfg(test)]
+impl TestCommittedMetadataBuilder {
+    pub fn new() -> Self {
+        Self {
+            transaction_cnt: 0,
+            transactions: Vec::new(),
+            parents: Vec::new(),
+            payout_address: None,
+            start_timestamp: None,
+            comm_pub_key: None,
+            miner_ip: None,
+        }
+    }
+
+    pub fn transaction_cnt(mut self, count: u32) -> Self {
+        self.transaction_cnt = count;
+        self
+    }
+
+    pub fn transactions(mut self, txs: Vec<Transaction>) -> Self {
+        self.transactions = txs;
+        self
+    }
+
+    pub fn parents(mut self, parents: Vec<BeadHash>) -> Self {
+        self.parents = parents;
+        self
+    }
+
+    pub fn payout_address(mut self, address: P2P_Address) -> Self {
+        self.payout_address = Some(address);
+        self
+    }
+
+    pub fn start_timestamp(mut self, time: Time) -> Self {
+        self.start_timestamp = Some(time);
+        self
+    }
+
+    pub fn comm_pub_key(mut self, key: PublicKey) -> Self {
+        self.comm_pub_key = Some(key);
+        self
+    }
+
+    pub fn miner_ip(mut self, ip: AddrV2) -> Self {
+        self.miner_ip = Some(ip);
+        self
+    }
+
+    pub fn build(self) -> CommittedMetadata {
+        CommittedMetadata {
+            transaction_cnt: self.transaction_cnt,
+            transactions: self.transactions,
+            parents: self.parents,
+            payout_address: self.payout_address.expect("payout_address is required"),
+            start_timestamp: self
+                .start_timestamp
+                .expect("observed_time_at_node is required"),
+            comm_pub_key: self.comm_pub_key.expect("comm_pub_key is required"),
+            miner_ip: self.miner_ip.expect("miner_ip is required"),
+        }
+    }
+}
+#[cfg(test)]
+pub struct TestBeadBuilder {
+    block_header: Option<BlockHeader>,
+    committed_metadata: Option<CommittedMetadata>,
+    uncommitted_metadata: Option<UnCommittedMetadata>,
+}
+
+#[cfg(test)]
+impl TestBeadBuilder {
+    pub fn new() -> Self {
+        Self {
+            block_header: None,
+            committed_metadata: None,
+            uncommitted_metadata: None,
+        }
+    }
+
+    pub fn block_header(mut self, block_header: BlockHeader) -> Self {
+        self.block_header = Some(block_header);
+        self
+    }
+
+    pub fn committed_metadata(mut self, committed_metadata: CommittedMetadata) -> Self {
+        self.committed_metadata = Some(committed_metadata);
+        self
+    }
+
+    pub fn uncommitted_metadata(mut self, uncommitted_metadata: UnCommittedMetadata) -> Self {
+        self.uncommitted_metadata = Some(uncommitted_metadata);
+        self
+    }
+
+    pub fn build(self) -> Bead {
+        Bead {
+            block_header: self.block_header.expect("BlockHeader is required"),
+            committed_metadata: self
+                .committed_metadata
+                .expect("CommittedMetadata is required"),
+            uncommitted_metadata: self
+                .uncommitted_metadata
+                .expect("UnCommittedMetadata is required"),
+        }
+    }
+}
+
+}


### PR DESCRIPTION
This PR add implementations of `Encodable` trait for custom structs, e.g., `bead`.