### PR TITLE
persistent private key

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -2,11 +2,15 @@ use clap::Parser;
 use futures::StreamExt;
 use libp2p::{
     core::multiaddr::Multiaddr,
-    identify, ping,
+    identify,
+    identity::Keypair,
+    ping,
     swarm::{NetworkBehaviour, SwarmEvent},
 };
 use std::error::Error;
 use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
 use std::time::Duration;
 use tokio::sync::mpsc;
 
@@ -55,7 +59,49 @@ async fn main() -> Result<(), Box<dyn Error>> {
     tokio::spawn(zmq::zmq_hashblock_listener(zmq_url, rpc, block_template_tx));
     tokio::spawn(block_template::consumer(block_template_rx));
 
-    let mut swarm = libp2p::SwarmBuilder::with_new_identity()
+    let datadir_path = Path::new(&*datadir);
+    let keystore_path = datadir_path.join("keystore");
+    #[cfg(unix)]
+    {
+        if keystore_path.exists() {
+            let perms = fs::metadata(&keystore_path)?.permissions();
+            if perms.mode() & 0o777 != 0o400 {
+                log::warn!(
+                    "Keystore permissions are not secure: {:o}, setting to 0o400",
+                    perms.mode() & 0o777
+                );
+                let mut new_perms = perms.clone();
+                new_perms.set_mode(0o400);
+                fs::set_permissions(&keystore_path, new_perms)?;
+            }
+        }
+    }
+
+    let keypair = match fs::read(&keystore_path) {
+        Ok(keypair) => {
+            log::info!("Loading existing keypair from keystore...");
+            libp2p::identity::Keypair::from_protobuf_encoding(&keypair).map_err(|e| {
+                log::error!("Failed to read keypair from keystore: {}", e);
+                e
+            })?
+        }
+        Err(_) => {
+            log::info!("No existing keypair found, generating new keypair...");
+            let keypair: Keypair = libp2p::identity::Keypair::generate_ed25519();
+            let keypair_bytes = keypair.to_protobuf_encoding()?;
+            fs::write(&keystore_path, keypair_bytes)?;
+            #[cfg(unix)]
+            {
+                let mut perms = fs::metadata(&keystore_path)?.permissions();
+                perms.set_mode(0o400);
+                fs::set_permissions(&keystore_path, perms)?;
+                log::info!("Set keystore file permissions to 0o400");
+            }
+            keypair
+        }
+    };
+
+    let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
         .with_tokio()
         .with_quic()
         .with_behaviour(|key| NodeBehaviour {


### PR DESCRIPTION
Resolves #183 
- The keys get stored in the file **keystore** inside the data directory (default data directory is "~/.braidpool/")
- Keys are stored in protobuf encoded format
- In order to run multiple instance of node on the same machine for testing in future comment the lines 64-79 and add the line:
``` 
 let keypair: Keypair = libp2p::identity::Keypair::generate_ed25519(); 
```
