### PR TITLE
This is updated `RPC` implementation according to the new structure we had decided 

### DIFF
--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -40,4 +40,5 @@ transitive = "1.1.0"
 secp256k1 = "0.30.0"
 libp2p = { version = "0.55.0", features = ["identify", "quic", "tokio","ping","macros","kad","dns","request-response","floodsub"] }
 toml = "0.8.22"
+jsonrpsee = {version = "0.25.1",features = ["full"]}
 async-trait = "0.1.88"

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -10,6 +10,7 @@ use bitcoin::BlockHeader;
 use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;
 use libp2p::StreamProtocol;
+use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 const GET_BEADS: u8 = 0;
@@ -18,7 +19,7 @@ const GET_GENESIS: u8 = 2;
 const GET_ALL_BEADS: u8 = 3;
 const BEAD_RESPONSE_ERROR: u8 = 4;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Bead {
     pub block_header: BlockHeader,
     pub committed_metadata: CommittedMetadata,

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -14,8 +14,6 @@ use bitcoin::consensus::encode::Encodable;
 use bitcoin::consensus::serialize;
 use bitcoin::consensus::DeserializeError;
 use bitcoin::ecdsa::Signature;
-use bitcoin::p2p::Address as P2P_Address;
-use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockHash;
 use bitcoin::BlockHeader;
 use bitcoin::BlockTime;
@@ -23,22 +21,22 @@ use bitcoin::BlockVersion;
 use bitcoin::CompactTarget;
 use bitcoin::EcdsaSighashType;
 use bitcoin::TxMerkleNode;
-use core::net::SocketAddr;
 use futures::executor::block_on;
 use libp2p::request_response::Codec;
 use std::collections::HashSet;
 use std::io::Cursor;
-use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 #[test]
 
 fn test_serialized_committed_metadata() {
-    let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
-    let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
+    // let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+    // let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
+    let _address = String::from("127.0.0.1:8000");
     let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
         .parse::<bitcoin::PublicKey>()
         .unwrap();
-    let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+    // let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+    let socket = String::from("127.0.0.1");
     let time_val = Time::from_consensus(1653195600).unwrap();
     let parent_hash_set: HashSet<BlockHash> = HashSet::new();
     let time_hash_set = TimeVec(Vec::new());
@@ -102,12 +100,11 @@ fn test_serialized_uncommitted_metadata() {
 #[test]
 
 fn test_serialized_bead() {
-    let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
-    let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
+    let _address = String::from("127.0.0.1:8000");
     let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
         .parse::<bitcoin::PublicKey>()
         .unwrap();
-    let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+    let socket = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
     let parent_hash_set: HashSet<BlockHash> = HashSet::new();
     let weak_target = CompactTarget::from_consensus(32);
@@ -177,12 +174,11 @@ fn test_bead_request_serialization() {
 
 #[test]
 fn test_bead_response_serialization() {
-    let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
-    let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
+    let _address = String::from("127.0.0.1:8000");
     let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
         .parse::<bitcoin::PublicKey>()
         .unwrap();
-    let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+    let socket = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
     let parent_hash_set: HashSet<BlockHash> = HashSet::new();
     let weak_target = CompactTarget::from_consensus(32);

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -29,13 +29,10 @@ use std::str::FromStr;
 #[test]
 
 fn test_serialized_committed_metadata() {
-    // let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
-    // let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
     let _address = String::from("127.0.0.1:8000");
     let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
         .parse::<bitcoin::PublicKey>()
         .unwrap();
-    // let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
     let socket = String::from("127.0.0.1");
     let time_val = Time::from_consensus(1653195600).unwrap();
     let parent_hash_set: HashSet<BlockHash> = HashSet::new();

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -6,8 +6,6 @@ use crate::utils::test_utils::test_utility_functions::{
 };
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::consensus::serialize;
-use bitcoin::p2p::address::Address as P2P_Address;
-use bitcoin::p2p::ServiceFlags;
 use bitcoin::BlockVersion;
 use bitcoin::CompactTarget;
 use bitcoin::{BlockHash, BlockHeader, BlockTime, EcdsaSighashType, TxMerkleNode};
@@ -16,18 +14,16 @@ use libp2p::floodsub::Topic;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{Multiaddr, Swarm, SwarmBuilder};
 use std::collections::HashSet;
-use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::str::FromStr;
 use tokio::time::timeout;
 
 // Helper function to create a test bead
 fn create_test_bead() -> Bead {
-    let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
-    let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
+    let _address = String::from("127.0.0.1:8888");
     let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
         .parse::<bitcoin::PublicKey>()
         .unwrap();
-    let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+    let socket = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
     let parent_hash_set: HashSet<BlockHash> = HashSet::new();
     let weak_target = CompactTarget::from_consensus(32);

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -46,11 +46,14 @@ impl Braid {
             bead_indices.insert(index);
             bead_index_mapping.insert(bead.block_header.block_hash(), index);
         }
-
+        let mut genesis_cohort: Vec<Cohort> = Vec::new();
+        if bead_indices.len() != 0 {
+            genesis_cohort.push(Cohort(HashSet::from(bead_indices.clone())));
+        }
         Braid {
             beads,
             tips: bead_indices.clone(),
-            cohorts: vec![Cohort(bead_indices.clone())],
+            cohorts: genesis_cohort,
             orphan_beads: Vec::new(),
             genesis_beads: bead_indices,
             bead_index_mapping,
@@ -62,29 +65,9 @@ impl Braid {
     /// Attempts to extend the braid with the given bead.
     /// Returns true if the bead successfully extended the braid, false otherwise.
     pub fn extend(&mut self, bead: &Bead) -> AddBeadStatus {
-        // No parents: bad block
+        // No parents: bad block i.e. the extend will add beads after the genesis
+        //bead is done and the extension of genesis beads to Braid shall be done via Braid::new
         if bead.committed_metadata.parents.is_empty() {
-            // Check if we already have this bead
-            let bead_hash = bead.block_header.block_hash();
-            if self
-                .beads
-                .iter()
-                .any(|b| b.block_header.block_hash() == bead_hash)
-            {
-                return AddBeadStatus::DagAlreadyContainsBead; // Already seen this bead
-            }
-
-            // Add the genesis bead
-            self.beads.push(bead.clone());
-            //current bead index
-            let new_bead_index = self.beads.len() - 1;
-
-            self.bead_index_mapping.insert(bead_hash, new_bead_index);
-
-            self.genesis_beads.insert(new_bead_index);
-
-            self.tips.insert(new_bead_index);
-            self.cohorts.push(Cohort(HashSet::from([new_bead_index])));
             return AddBeadStatus::InvalidBead;
         }
         // Don't have all parents

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -5,18 +5,17 @@ use serde::Serialize;
 use std::cmp::Ordering;
 use std::collections::VecDeque;
 use std::collections::{HashMap, HashSet};
-pub mod error;
 #[derive(Clone, Debug, Serialize, PartialEq)]
 
 pub struct Cohort(HashSet<usize>);
-
-use error::BraidError::HighestWorkBeadFetchFailed;
+#[derive(Debug, Clone)]
 pub enum AddBeadStatus {
     DagAlreadyContainsBead,
     InvalidBead,
     BeadAdded,
     ParentsNotYetReceived,
 }
+#[derive(Debug, Clone)]
 
 pub enum GenesisCheckStatus {
     GenesisBeadsValid,
@@ -37,7 +36,7 @@ pub struct Braid {
 
 impl Braid {
     ///Initializing the Braid object for keeping track of current state of Braid
-    pub fn new(genesis_beads: HashSet<Bead>) -> Self {
+    pub fn new(genesis_beads: Vec<Bead>) -> Self {
         let mut beads = Vec::new();
         let mut bead_indices = HashSet::new();
         let mut bead_index_mapping = HashMap::new();
@@ -65,6 +64,27 @@ impl Braid {
     pub fn extend(&mut self, bead: &Bead) -> AddBeadStatus {
         // No parents: bad block
         if bead.committed_metadata.parents.is_empty() {
+            // Check if we already have this bead
+            let bead_hash = bead.block_header.block_hash();
+            if self
+                .beads
+                .iter()
+                .any(|b| b.block_header.block_hash() == bead_hash)
+            {
+                return AddBeadStatus::DagAlreadyContainsBead; // Already seen this bead
+            }
+
+            // Add the genesis bead
+            self.beads.push(bead.clone());
+            //current bead index
+            let new_bead_index = self.beads.len() - 1;
+
+            self.bead_index_mapping.insert(bead_hash, new_bead_index);
+
+            self.genesis_beads.insert(new_bead_index);
+
+            self.tips.insert(new_bead_index);
+            self.cohorts.push(Cohort(HashSet::from([new_bead_index])));
             return AddBeadStatus::InvalidBead;
         }
         // Don't have all parents
@@ -242,9 +262,9 @@ impl Braid {
 mod consensus_functions {
     use num::{One, Zero};
 
-    use crate::braid::error::BraidError;
-
     use super::*;
+    use crate::error::BraidError;
+    use crate::error::BraidError::{HighestWorkBeadFetchFailed, MissingAncestorWork};
     /// Returns the set of **genesis beads** from a given Braid object.
     ///
     /// A **genesis bead** is defined as a bead that has no parents, i.e., it is a root node in the Braid DAG.

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -66,11 +66,8 @@ fn emit_bead() -> Bead {
         .as_secs() as u32;
     let current_time = Time::from_consensus(now).unwrap();
 
-    // let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
-    // let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
     let _address = String::from("127.0.0.1:8888");
     let public_key = random_public_key;
-    // let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
     let socket: String = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
     let parent_hash_set: HashSet<BlockHash> = HashSet::new();

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -17,13 +17,9 @@ use crate::committed_metadata::TimeVec;
 use crate::utils::test_utils::test_utility_functions::*;
 use bitcoin::block::BlockHash as BeadHash;
 use bitcoin::{
-    absolute::Time,
-    ecdsa::Signature,
-    p2p::{Address as P2P_Address, ServiceFlags},
-    BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget, EcdsaSighashType, PublicKey,
-    TxMerkleNode,
+    absolute::Time, ecdsa::Signature, BlockHash, BlockHeader, BlockTime, BlockVersion,
+    CompactTarget, EcdsaSighashType, PublicKey, TxMerkleNode,
 };
-use core::net::SocketAddr;
 use num::range;
 use num::BigUint;
 use rand::{rngs::OsRng, thread_rng, RngCore};
@@ -32,7 +28,6 @@ use serde::{Deserialize, Serialize};
 use serde_json;
 use std::collections::HashMap;
 use std::collections::HashSet;
-use std::net::{IpAddr, Ipv4Addr};
 use std::path::Path;
 use std::str::FromStr;
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -71,10 +66,12 @@ fn emit_bead() -> Bead {
         .as_secs() as u32;
     let current_time = Time::from_consensus(now).unwrap();
 
-    let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
-    let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
+    // let test_sock_add = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8888);
+    // let _address = P2P_Address::new(&test_sock_add.clone(), ServiceFlags::NONE);
+    let _address = String::from("127.0.0.1:8888");
     let public_key = random_public_key;
-    let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+    // let socket = bitcoin::p2p::address::AddrV2::Ipv4(Ipv4Addr::new(127, 0, 0, 1));
+    let socket: String = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
     let parent_hash_set: HashSet<BlockHash> = HashSet::new();
     let weak_target = CompactTarget::from_consensus(32);

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -47,6 +47,7 @@ pub struct Cli {
     #[arg(long, default_value = "28332")]
     pub zmqhashblockport: u16,
 
+    ///Rpc endpoints for the specific methods
     #[command(subcommand)]
     pub command: Option<RpcCommand>,
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,7 +1,10 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-#[derive(Parser, Debug)]
+use crate::rpc_server::RpcCommand;
+
+#[derive(Parser, Debug, Clone)]
+#[command(name = "braid", about = "Braidpool Node CLI")]
 pub struct Cli {
     /// Braid data directory
     #[arg(long, default_value = "~/.braidpool/")]
@@ -43,4 +46,7 @@ pub struct Cli {
     /// Use this port for bitcoin ZMQ
     #[arg(long, default_value = "28332")]
     pub zmqhashblockport: u16,
+
+    #[command(subcommand)]
+    pub command: Option<RpcCommand>,
 }

--- a/node/src/committed_metadata/mod.rs
+++ b/node/src/committed_metadata/mod.rs
@@ -4,8 +4,6 @@ use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
 use bitcoin::consensus::Error;
 use bitcoin::io::{self, BufRead, Write};
-use bitcoin::p2p::address::AddrV2;
-use bitcoin::p2p::Address as P2P_Address;
 use bitcoin::CompactTarget;
 use bitcoin::PublicKey;
 use bitcoin::Transaction;
@@ -40,21 +38,22 @@ impl Decodable for TimeVec {
         Ok(TimeVec(vec))
     }
 }
-
-#[derive(Clone, Debug, PartialEq)]
+//Changing the existing atrributes type mapping for inherit implementation of serializable and
+//deserializable trait
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CommittedMetadata {
     pub transactions: Vec<Transaction>,
     pub parents: HashSet<BeadHash>,
     pub parent_bead_timestamps: TimeVec,
-    pub payout_address: P2P_Address,
+    pub payout_address: String,
     pub start_timestamp: Time,
     pub comm_pub_key: PublicKey,
     //minimum possible target > which will be the weak target
     pub min_target: CompactTarget,
-    //the weaker target locallay apart from mainnet target ranging between the mainnet target and
+    //the weaker target locally apart from mainnet target ranging between the mainnet target and
     //minimum possible target
     pub weak_target: CompactTarget,
-    pub miner_ip: AddrV2,
+    pub miner_ip: String,
 }
 
 impl Encodable for CommittedMetadata {
@@ -82,12 +81,12 @@ impl Decodable for CommittedMetadata {
         let transactions = Vec::<Transaction>::consensus_decode(r)?;
         let parents = vec_to_hashset(Vec::<BeadHash>::consensus_decode(r)?);
         let parent_bead_timestamps = TimeVec::consensus_decode(r)?;
-        let payout_address = P2P_Address::consensus_decode(r)?;
+        let payout_address = String::consensus_decode(r)?;
         let start_timestamp = Time::from_consensus(u32::consensus_decode(r).unwrap()).unwrap();
         let comm_pub_key = PublicKey::from_slice(&Vec::<u8>::consensus_decode(r).unwrap()).unwrap();
         let min_target = CompactTarget::consensus_decode(r).unwrap();
         let weak_target = CompactTarget::consensus_decode(r).unwrap();
-        let miner_ip = AddrV2::consensus_decode(r)?;
+        let miner_ip = String::consensus_decode(r)?;
         Ok(CommittedMetadata {
             transactions,
             parents,

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -31,6 +31,19 @@ pub struct BraidpoolConfig {
     pub bitcoin_config: BitcoinConfig,
     pub braid_directory: BraidDirectoryConfig,
     pub miner_config: MinerConfig,
+    pub braid_rpc_config: BraidRpcConfig,
+}
+#[derive(Serialize, Deserialize, Clone)]
+//Rpc server configuration
+pub struct BraidRpcConfig {
+    rpc_server_addr: String,
+}
+impl Default for BraidRpcConfig {
+    fn default() -> Self {
+        BraidRpcConfig {
+            rpc_server_addr: String::from("127.0.0.1:6682"),
+        }
+    }
 }
 #[allow(dead_code)]
 impl BraidpoolConfig {
@@ -96,7 +109,7 @@ mod test {
 
     use bitcoin::Network;
 
-    use crate::config::MinerConfig;
+    use crate::config::{BraidRpcConfig, MinerConfig};
 
     use super::{BitcoinConfig, BraidDirectoryConfig, BraidpoolConfig, NetworkConfig};
     #[test]
@@ -129,6 +142,7 @@ mod test {
             miner_config: MinerConfig {
                 miner_pubkey: "".to_string(),
             },
+            braid_rpc_config: BraidRpcConfig::default(),
         };
         assert_eq!(
             from_file.braidnetwork_config.listen_address,
@@ -160,5 +174,9 @@ mod test {
             built.bitcoin_config.cookie_path
         );
         assert_eq!(from_file.braid_directory.path, built.braid_directory.path);
+        assert_eq!(
+            from_file.braid_rpc_config.rpc_server_addr,
+            built.braid_rpc_config.rpc_server_addr
+        );
     }
 }

--- a/node/src/default_braidpool_config.toml
+++ b/node/src/default_braidpool_config.toml
@@ -26,3 +26,6 @@ port="18443"
 #ip of the bitcoind node
 bitcoind_ip = "0.0.0.0"
 
+#rpc server configuration
+[braid_rpc_config]
+rpc_server_addr="127.0.0.1:6682"

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -1,3 +1,4 @@
+//All braidpool specific errors are defined here
 use std::fmt;
 
 #[derive(Debug)]
@@ -6,7 +7,26 @@ pub enum BraidError {
     MissingAncestorWork,
     HighestWorkBeadFetchFailed,
 }
-
+#[derive(Debug)]
+pub enum BraidRPCError {
+    RequestFailed {
+        method: String,
+        source: jsonrpsee::core::ClientError,
+    },
+}
+impl fmt::Display for BraidRPCError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BraidRPCError::RequestFailed { method, source } => {
+                write!(
+                    f,
+                    "{} error occurred while sending {} request to the server",
+                    method, source
+                )
+            }
+        }
+    }
+}
 impl fmt::Display for BraidError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,7 +1,14 @@
 pub mod bead;
 pub mod behaviour;
+pub mod block_template;
 pub mod braid;
+pub mod cli;
 pub mod committed_metadata;
+pub mod config;
+pub mod error;
 pub mod peer_manager;
+pub mod rpc;
+pub mod rpc_server;
 pub mod uncommitted_metadata;
 pub mod utils;
+pub mod zmq;

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -1,0 +1,419 @@
+use crate::bead::Bead;
+use crate::braid;
+use crate::braid::AddBeadStatus;
+use crate::braid::Braid;
+use crate::error::BraidRPCError;
+use crate::utils::create_test_bead;
+use crate::utils::BeadHash;
+use clap::Subcommand;
+use futures::future::join_all;
+use jsonrpsee::core::async_trait;
+use jsonrpsee::core::client::ClientT;
+use jsonrpsee::core::middleware::Batch;
+use jsonrpsee::core::middleware::Notification;
+use jsonrpsee::core::middleware::RpcServiceT;
+use jsonrpsee::core::params::ArrayParams;
+use jsonrpsee::http_client::HttpClient;
+use jsonrpsee::proc_macros::rpc;
+use jsonrpsee::types::ErrorObjectOwned;
+use jsonrpsee::types::Request;
+use jsonrpsee::ConnectionId;
+use log;
+use serde_json;
+use std::future::Future;
+use std::net::SocketAddr;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+//Rpc commands
+#[derive(Subcommand, Debug, Clone)]
+pub enum RpcCommand {
+    /// Get a bead by hash
+    GetBead {
+        /// The bead hash (as a hex string)
+        bead_hash: String,
+    },
+
+    /// Add a bead via serialized JSON string
+    AddBead {
+        /// JSON-formatted bead
+        bead_data: String,
+    },
+
+    /// Get total number of beads
+    GetBeadCount,
+
+    /// Get total number of cohorts
+    GetCohortCount,
+
+    /// Get current DAG tips
+    GetTips,
+}
+//parsing the inital rpc command line all
+pub async fn parse_arguments(cli_command: RpcCommand, server_addr: SocketAddr) -> () {
+    // //initializing a client associated with the current node
+    // //for receving the response from the server
+    let target_uri = format!("http://{}", server_addr.to_string());
+    let client_res: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let (rpc_method, method_params) = match cli_command {
+        RpcCommand::AddBead { bead_data } => {
+            let rpc_method = String::from("addbead");
+            let mut method_params = ArrayParams::new();
+            method_params.insert(bead_data).unwrap();
+
+            (rpc_method, method_params)
+        }
+        RpcCommand::GetBead { bead_hash } => {
+            let rpc_method = "getbead".to_string();
+            let mut method_params = ArrayParams::new();
+            method_params.insert(bead_hash).unwrap();
+
+            (rpc_method, method_params)
+        }
+        RpcCommand::GetBeadCount => {
+            let rpc_method = String::from("getbeadcount");
+            let method_params = ArrayParams::new();
+
+            (rpc_method, method_params)
+        }
+        RpcCommand::GetCohortCount => {
+            let method_params = ArrayParams::new();
+            let rpc_method = String::from("getcohortcount");
+
+            (rpc_method, method_params)
+        }
+        RpcCommand::GetTips => {
+            let method_params = ArrayParams::new();
+            let rpc_method = String::from("gettips");
+
+            (rpc_method, method_params)
+        }
+    };
+    tokio::spawn(handle_request(
+        rpc_method.clone(),
+        method_params,
+        client_res,
+    ));
+}
+
+//handling the request arising either from command line cli or from the external users
+pub async fn handle_request(
+    method: String,
+    method_params: ArrayParams,
+    client: HttpClient,
+) -> Result<(), BraidRPCError> {
+    let rpc_response: Result<String, jsonrpsee::core::ClientError> =
+        client.request(&method, method_params.clone()).await;
+    match rpc_response {
+        Ok(response) => {
+            log::info!(
+                "Response received successfully from the RPC server - {:?}",
+                response
+            );
+            Ok(())
+        }
+        Err(error) => {
+            log::error!(
+                "An error occurred while receiving response from Server - {:?}",
+                error
+            );
+            Err(BraidRPCError::RequestFailed {
+                method: method,
+                source: error,
+            })
+        }
+    }
+}
+
+//server side trait to be implemented for the handler
+//that is the JSON-RPC handle to initiate the RPC context
+//supporting both http and websockets
+#[rpc(server)]
+pub trait Rpc {
+    //RPC methods supported by braid-API
+    #[method(name = "getbead")]
+    async fn get_bead(&self, bead_hash: String) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "addbead")]
+    async fn add_bead(&self, bead_data: String) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "gettips")]
+    async fn get_tips(&self) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getbeadcount")]
+    async fn get_bead_count(&self) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getcohortcount")]
+    async fn get_cohort_count(&self) -> Result<String, ErrorObjectOwned>;
+}
+
+// RPC Server implementation using channels
+pub struct RpcServerImpl {
+    braid_arc: Arc<RwLock<Braid>>,
+}
+
+impl RpcServerImpl {
+    pub fn new(braid_shared_pointer: Arc<RwLock<Braid>>) -> Self {
+        Self {
+            braid_arc: braid_shared_pointer,
+        }
+    }
+}
+#[async_trait]
+impl RpcServer for RpcServerImpl {
+    async fn get_bead(&self, bead_hash: String) -> Result<String, ErrorObjectOwned> {
+        let hash = bead_hash
+            .parse::<BeadHash>()
+            .map_err(|_| ErrorObjectOwned::owned(1, "Invalid bead hash format", None::<()>))?;
+        log::info!("Get bead request recieved from client");
+        let braid_data = self.braid_arc.read().await;
+        let bead = braid_data
+            .beads
+            .iter()
+            .find(|bead| bead.block_header.block_hash() == hash)
+            .cloned();
+
+        match bead {
+            Some(bead) => {
+                let json = serde_json::to_string(&bead)
+                    .map_err(|_| ErrorObjectOwned::owned(2, "Internal error", None::<()>))
+                    .unwrap();
+                Ok(json)
+            }
+            None => Err(ErrorObjectOwned::owned(3, "Bead not found", None::<()>)),
+        }
+    }
+
+    async fn add_bead(&self, bead_data: String) -> Result<String, ErrorObjectOwned> {
+        let bead: Bead = serde_json::from_str(&bead_data).map_err(|e| {
+            ErrorObjectOwned::owned(1, format!("Invalid bead data: {}", e), None::<()>)
+        })?;
+        log::info!("Add bead request recieved from client");
+        let mut braid_data = self.braid_arc.write().await;
+        let success_status = braid_data.extend(&bead);
+
+        match success_status {
+            AddBeadStatus::BeadAdded => Ok("Bead added successfully".to_string()),
+            AddBeadStatus::DagAlreadyContainsBead => Ok("Bead already exists".to_string()),
+            AddBeadStatus::InvalidBead => {
+                Err(ErrorObjectOwned::owned(4, "Invalid bead", None::<()>))
+            }
+            AddBeadStatus::ParentsNotYetReceived => {
+                Ok("Bead queued, waiting for parents".to_string())
+            }
+        }
+    }
+
+    async fn get_tips(&self) -> Result<String, ErrorObjectOwned> {
+        let braid_data = self.braid_arc.read().await;
+        let tips: Vec<BeadHash> = braid_data
+            .tips
+            .iter()
+            .map(|&index| braid_data.beads[index].block_header.block_hash())
+            .collect();
+        log::info!("Get tips request received from client");
+        let tips_str: Vec<String> = tips.iter().map(|h| h.to_string()).collect();
+
+        serde_json::to_string(&tips_str)
+            .map_err(|_| ErrorObjectOwned::owned(2, "Internal error", None::<()>))
+    }
+
+    async fn get_bead_count(&self) -> Result<String, ErrorObjectOwned> {
+        let braid_data = self.braid_arc.read().await;
+        let count = braid_data.beads.len();
+        log::info!("Get bead count request received  from client");
+        Ok(count.to_string())
+    }
+
+    async fn get_cohort_count(&self) -> Result<String, ErrorObjectOwned> {
+        let braid_data = self.braid_arc.read().await;
+        log::info!("Get cohort request received from client ");
+        let count = braid_data.cohorts.len();
+
+        Ok(count.to_string())
+    }
+}
+struct LoggingMiddleware<S>(S);
+
+impl<S> RpcServiceT for LoggingMiddleware<S>
+where
+    S: RpcServiceT,
+{
+    type MethodResponse = S::MethodResponse;
+    type NotificationResponse = S::NotificationResponse;
+    type BatchResponse = S::BatchResponse;
+
+    fn call<'a>(
+        &self,
+        request: Request<'a>,
+    ) -> impl Future<Output = Self::MethodResponse> + Send + 'a {
+        tracing::info!("Received request: {:?}", request);
+        assert!(request.extensions().get::<ConnectionId>().is_some());
+
+        self.0.call(request)
+    }
+
+    fn batch<'a>(&self, batch: Batch<'a>) -> impl Future<Output = Self::BatchResponse> + Send + 'a {
+        tracing::info!("Received batch: {:?}", batch);
+        self.0.batch(batch)
+    }
+
+    fn notification<'a>(
+        &self,
+        n: Notification<'a>,
+    ) -> impl Future<Output = Self::NotificationResponse> + Send + 'a {
+        tracing::info!("Received notif: {:?}", n);
+        self.0.notification(n)
+    }
+}
+//server building
+//running a server in seperate spawn event
+pub async fn run_rpc_server(braid_shared_pointer: Arc<RwLock<Braid>>) -> Result<SocketAddr, ()> {
+    //Initializing the middleware
+    let rpc_middleware =
+        jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
+    //building the context/server supporting the http transport and ws
+    let server = jsonrpsee::server::Server::builder()
+        .set_rpc_middleware(rpc_middleware)
+        .build("127.0.0.1:8888")
+        .await
+        .unwrap();
+    //listening address for incoming requests/connection
+    let addr = server.local_addr().unwrap();
+    //context for the served server
+    let rpc_impl = RpcServerImpl::new(braid_shared_pointer);
+    let handle = server.start(rpc_impl.into_rpc());
+    log::info!(
+        "RPC Server is listening at socket address http://{:?}",
+        addr
+    );
+    tokio::spawn(
+        //handling the stopping of the server
+        handle.stopped(),
+    );
+    Ok(addr)
+}
+
+#[tokio::test]
+pub async fn test_extend_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    let _ = run_rpc_server(Arc::clone(&braid)).await.unwrap();
+
+    let server_addr = "127.0.0.1:8888";
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let new_bead = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let bead_json_str = serde_json::to_string(&new_bead).expect("Failed to serialize bead");
+
+    let mut params = ArrayParams::new();
+    params.insert(bead_json_str).unwrap();
+
+    //Extending the bead
+    let response: Result<String, jsonrpsee::core::ClientError> =
+        client.request("addbead", params).await;
+
+    assert_eq!(response.unwrap(), "Bead added successfully".to_string());
+
+    let get_bead_params = ArrayParams::new();
+    //Checking for the updated bead count after successful extension of braid
+    let num_beads: Result<String, jsonrpsee::core::ClientError> =
+        client.request("getbeadcount", get_bead_params).await;
+
+    assert_eq!(num_beads.unwrap(), "2".to_string());
+}
+
+#[tokio::test]
+pub async fn test_same_bead_extend() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    let _ = run_rpc_server(Arc::clone(&braid)).await.unwrap();
+
+    let server_addr = "127.0.0.1:8888";
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let new_bead = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+
+    let bead_json_str = serde_json::to_string(&new_bead).expect("Failed to serialize bead");
+
+    let mut params = ArrayParams::new();
+    params.insert(bead_json_str).unwrap();
+
+    //Extending the bead
+    let response_original: Result<String, jsonrpsee::core::ClientError> =
+        client.request("addbead", params.clone()).await;
+
+    //Extending the same bead again bead
+    let response_duplicate: Result<String, jsonrpsee::core::ClientError> =
+        client.request("addbead", params).await;
+    assert_eq!(
+        response_duplicate.unwrap(),
+        "Bead already exists".to_string()
+    );
+}
+#[tokio::test]
+pub async fn test_cohort_count_rpc() {
+    let test_bead_1 = create_test_bead(1, None);
+    let test_bead_2 = create_test_bead(2, Some(test_bead_1.block_header.block_hash()));
+    let test_bead_3 = create_test_bead(3, Some(test_bead_2.block_header.block_hash()));
+    let test_bead_4 = create_test_bead(2, Some(test_bead_3.block_header.block_hash()));
+
+    let genesis_beads = vec![test_bead_1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    let _ = run_rpc_server(Arc::clone(&braid)).await.unwrap();
+
+    let server_addr = "127.0.0.1:8888";
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let test_bead_2_json_str =
+        serde_json::to_string(&test_bead_2).expect("Failed to serialize bead");
+    let test_bead_3_json_str =
+        serde_json::to_string(&test_bead_3).expect("Failed to serialize bead");
+    let test_bead_4_json_str =
+        serde_json::to_string(&test_bead_4).expect("Failed to serialize bead");
+
+    let mut params_test_bead_2 = ArrayParams::new();
+    params_test_bead_2.insert(test_bead_2_json_str).unwrap();
+    let mut params_test_bead_3 = ArrayParams::new();
+    params_test_bead_3.insert(test_bead_3_json_str).unwrap();
+    let mut params_test_bead_4 = ArrayParams::new();
+    params_test_bead_4.insert(test_bead_4_json_str).unwrap();
+
+    //Extending the bead
+    let response_test_bead_2: Result<String, jsonrpsee::core::ClientError> =
+        client.request("addbead", params_test_bead_2).await;
+    assert_eq!(
+        response_test_bead_2.unwrap(),
+        "Bead added successfully".to_string()
+    );
+
+    let response_test_bead_3: Result<String, jsonrpsee::core::ClientError> =
+        client.request("addbead", params_test_bead_3).await;
+    assert_eq!(
+        response_test_bead_3.unwrap(),
+        "Bead added successfully".to_string()
+    );
+
+    let response_test_bead_4: Result<String, jsonrpsee::core::ClientError> =
+        client.request("addbead", params_test_bead_4).await;
+    assert_eq!(
+        response_test_bead_4.unwrap(),
+        "Bead added successfully".to_string()
+    );
+    let response_cohort_cnt: Result<String, jsonrpsee::core::ClientError> =
+        client.request("getcohortcount", ArrayParams::new()).await;
+
+    assert_eq!(response_cohort_cnt.unwrap(), "4".to_string());
+}

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -276,7 +276,7 @@ pub async fn run_rpc_server(braid_shared_pointer: Arc<RwLock<Braid>>) -> Result<
     //building the context/server supporting the http transport and ws
     let server = jsonrpsee::server::Server::builder()
         .set_rpc_middleware(rpc_middleware)
-        .build("127.0.0.1:8888")
+        .build("127.0.0.1:6682")
         .await
         .unwrap();
     //listening address for incoming requests/connection
@@ -304,7 +304,7 @@ pub async fn test_extend_rpc() {
 
     let _ = run_rpc_server(Arc::clone(&braid)).await.unwrap();
 
-    let server_addr = "127.0.0.1:8888";
+    let server_addr = "127.0.0.1:6682";
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
@@ -335,9 +335,18 @@ pub async fn test_same_bead_extend() {
 
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
 
-    let _ = run_rpc_server(Arc::clone(&braid)).await.unwrap();
+    //Initializing the test server
+    let rpc_middleware =
+        jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
+    let server = jsonrpsee::server::Server::builder()
+        .set_rpc_middleware(rpc_middleware)
+        .build("127.0.0.1:8889")
+        .await
+        .unwrap();
+    let rpc_impl = RpcServerImpl::new(braid);
+    let handle = server.start(rpc_impl.into_rpc());
 
-    let server_addr = "127.0.0.1:8888";
+    let server_addr = "127.0.0.1:8889";
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
@@ -370,10 +379,18 @@ pub async fn test_cohort_count_rpc() {
     let genesis_beads = vec![test_bead_1.clone()];
 
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    //Initializing the test server
+    let rpc_middleware =
+        jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
+    let server = jsonrpsee::server::Server::builder()
+        .set_rpc_middleware(rpc_middleware)
+        .build("127.0.0.1:9000")
+        .await
+        .unwrap();
+    let rpc_impl = RpcServerImpl::new(braid);
+    let handle = server.start(rpc_impl.into_rpc());
 
-    let _ = run_rpc_server(Arc::clone(&braid)).await.unwrap();
-
-    let server_addr = "127.0.0.1:8888";
+    let server_addr = "127.0.0.1:9000";
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 

--- a/node/src/uncommitted_metadata/mod.rs
+++ b/node/src/uncommitted_metadata/mod.rs
@@ -5,8 +5,10 @@ use bitcoin::consensus::Error;
 use bitcoin::ecdsa::Signature;
 use bitcoin::io::{self, BufRead, Write};
 use core::str::FromStr;
+use serde::Deserialize;
+use serde::Serialize;
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UnCommittedMetadata {
     pub extra_nonce: i32,
     pub broadcast_timestamp: Time,

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -1,6 +1,14 @@
 // Bitcoin Imports
-use crate::bead::Bead;
+use crate::{
+    bead::Bead,
+    committed_metadata::{CommittedMetadata, TimeVec},
+    uncommitted_metadata::UnCommittedMetadata,
+};
 use ::bitcoin::BlockHash;
+use bitcoin::{
+    absolute::MedianTimePast as Time, ecdsa::Signature, BlockHeader, BlockTime, BlockVersion,
+    CompactTarget, EcdsaSighashType, TxMerkleNode,
+};
 // Standard Imports
 
 pub mod test_utils;
@@ -15,7 +23,7 @@ pub type Bytes = Vec<Byte>;
 pub(crate) type Relatives = HashSet<BeadHash>;
 
 // Error Definitions
-use std::collections::HashSet;
+use std::{collections::HashSet, str::FromStr};
 
 pub(crate) fn hashset_to_vec_deterministic(hashset: &HashSet<BeadHash>) -> Vec<BeadHash> {
     let mut vec: Vec<BeadHash> = hashset.iter().cloned().collect();
@@ -31,4 +39,55 @@ pub(crate) fn retrieve_bead(_beadhash: BeadHash) -> Option<Bead> {
     // This function is a placeholder for the actual retrieval logic.
     // In a real implementation, this would fetch the bead from a database or other storage.
     None
+}
+
+// Helper function to create test beads
+pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
+    let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
+        .parse::<bitcoin::PublicKey>()
+        .unwrap();
+    let time_hash_set = TimeVec(Vec::new());
+    let mut parent_hash_set: HashSet<BlockHash> = HashSet::new();
+    if let Some(hash) = prev_hash {
+        parent_hash_set.insert(hash);
+    }
+    let weak_target = CompactTarget::from_consensus(32);
+    let min_target = CompactTarget::from_consensus(1);
+    let time_val = Time::from_consensus(1653195600).unwrap();
+    let test_committed_metadata: CommittedMetadata = CommittedMetadata {
+        comm_pub_key: public_key,
+        min_target: min_target,
+        miner_ip: "".to_string(),
+        transactions: vec![],
+        parents: parent_hash_set,
+        parent_bead_timestamps: time_hash_set,
+        payout_address: String::from(""),
+        start_timestamp: time_val,
+        weak_target: weak_target,
+    };
+    let extra_nonce = 42;
+    let hex = "3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45";
+    let sig = Signature {
+        signature: secp256k1::ecdsa::Signature::from_str(hex).unwrap(),
+        sighash_type: EcdsaSighashType::All,
+    };
+    let test_uncommitted_metadata = UnCommittedMetadata {
+        broadcast_timestamp: time_val,
+        extra_nonce: extra_nonce,
+        signature: sig,
+    };
+    let test_bytes: [u8; 32] = [0u8; 32];
+    let test_block_header = BlockHeader {
+        version: BlockVersion::TWO,
+        prev_blockhash: prev_hash.unwrap_or(BlockHash::from_byte_array(test_bytes)),
+        bits: CompactTarget::from_consensus(32),
+        nonce: nonce,
+        time: BlockTime::from_u32(8328429),
+        merkle_root: TxMerkleNode::from_byte_array(test_bytes),
+    };
+    Bead {
+        block_header: test_block_header,
+        committed_metadata: test_committed_metadata,
+        uncommitted_metadata: test_uncommitted_metadata,
+    }
 }

--- a/node/src/utils/test_utils.rs
+++ b/node/src/utils/test_utils.rs
@@ -69,12 +69,12 @@ pub mod test_utility_functions {
         transactions: Vec<Transaction>,
         parents: std::collections::HashSet<BeadHash>,
         parent_bead_timestamps: Option<TimeVec>,
-        payout_address: Option<P2P_Address>,
+        payout_address: Option<String>,
         start_timestamp: Option<Time>,
         comm_pub_key: Option<PublicKey>,
         min_target: Option<CompactTarget>,
         weak_target: Option<CompactTarget>,
-        miner_ip: Option<AddrV2>,
+        miner_ip: Option<String>,
     }
 
     #[cfg(test)]
@@ -108,7 +108,7 @@ pub mod test_utility_functions {
             self
         }
 
-        pub fn payout_address(mut self, address: P2P_Address) -> Self {
+        pub fn payout_address(mut self, address: String) -> Self {
             self.payout_address = Some(address);
             self
         }
@@ -123,7 +123,7 @@ pub mod test_utility_functions {
             self
         }
 
-        pub fn miner_ip(mut self, ip: AddrV2) -> Self {
+        pub fn miner_ip(mut self, ip: String) -> Self {
             self.miner_ip = Some(ip);
             self
         }


### PR DESCRIPTION
- It includes `rpc` methods accessible both via `cli` as well as from frontend via `curl` or `axios`.
- Unit tests regarding each method is added respectively .
- This PR also involves the replacing of snippets which are common and also the module accessibility structure as well.