### PR TITLE
feat: add graceful shutdown for tip_watcher and processor_tasks and custom network type

### DIFF
--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -111,11 +111,19 @@ pub struct CoinbaseConfig {
     pub pool_identifier: String,
 }
 
-impl Default for CoinbaseConfig {
-    fn default() -> Self {
+impl CoinbaseConfig {
+    pub fn for_network(network: Network) -> Self {
+        let pool_payout_address = match network {
+            Network::Bitcoin => "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+            Network::Testnet(_) => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+            Network::Signet => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+            Network::Regtest => "bcrt1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+            _ => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+        };
+
         Self {
-            network: Network::Bitcoin,
-            pool_payout_address: "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+            network,
+            pool_payout_address,
             pool_identifier: "Braidpool".to_string(),
         }
     }


### PR DESCRIPTION
This PR addes the ability to gracefully shutdown of `tip_watcher` and `processsor_task` under `SharedBitcoinClient`. Additionally, a `Drop` trait implementation ensures that shutdown signals are sent and tasks are aborted if the client is dropped without explicit shutdown.

Second, this will add a way to choose the network type to connect with 'bitcoin-node' using CLI. One can choose different network types while starting the node `(main, testnet4, signet, regtest, cpunet)`. 
Example command:  ``` cargo run -- --ipc --ipc-socket=/tmp/bitcoin-ipc.sock --network=main```