### PR TITLE
Added support for IBD 

### DIFF
--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -70,7 +70,7 @@ impl Decodable for Bead {
 #[derive(Debug, Clone, PartialEq)]
 pub enum BeadRequest {
     // Request beads from a specific set of hashes
-    GetBeads(HashSet<BeadHash>),
+    GetBeads(Vec<BeadHash>),
     // Request the latest tips from a peer
     GetTips,
     GetGenesis,
@@ -138,9 +138,8 @@ impl Encodable for BeadRequest {
             BeadRequest::GetBeads(hashes) => {
                 let mut written = 0;
                 written += GET_BEADS.consensus_encode(writer)?; // 0 for GetBeads
-                let hashes_vec = hashset_to_vec_deterministic(hashes);
-                written += (hashes_vec.len() as u32).consensus_encode(writer)?;
-                for hash in hashes_vec {
+                written += (hashes.len() as u32).consensus_encode(writer)?;
+                for hash in hashes {
                     written += hash.consensus_encode(writer)?;
                 }
                 Ok(written)
@@ -173,10 +172,10 @@ impl Decodable for BeadRequest {
         match request_type {
             GET_BEADS => {
                 let count = u32::consensus_decode(d)?;
-                let mut hashes = HashSet::new();
+                let mut hashes = Vec::new();
                 for _ in 0..count {
                     let hash = BeadHash::consensus_decode(d)?;
-                    hashes.insert(hash);
+                    hashes.push(hash);
                 }
                 Ok(BeadRequest::GetBeads(hashes))
             }

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -1,6 +1,6 @@
 use crate::committed_metadata::CommittedMetadata;
 use crate::uncommitted_metadata::UnCommittedMetadata;
-use crate::utils::{hashset_to_vec_deterministic, BeadHash};
+use crate::utils::BeadHash;
 use async_trait::async_trait;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
@@ -11,7 +11,6 @@ use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;
 use libp2p::StreamProtocol;
 use serde::{Deserialize, Serialize};
-use std::collections::HashSet;
 
 const GET_BEADS: u8 = 0;
 const GET_TIPS: u8 = 1;

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -89,7 +89,7 @@ pub enum BeadResponse {
     // Get all beads for IBD
     GetAllBeads(Vec<Bead>),
     // Get beads after a specific set of hashes
-    GetBeadsAfter(Vec<Bead>),
+    GetBeadsAfter(Vec<BeadHash>),
     // Error response
     Error(BeadSyncError),
 }
@@ -247,8 +247,8 @@ impl Encodable for BeadResponse {
                 let mut written = 0;
                 written += GET_BEADS_AFTER.consensus_encode(writer)?;
                 written += (beads.len() as u32).consensus_encode(writer)?;
-                for bead in beads {
-                    written += bead.consensus_encode(writer)?;
+                for bead_hash in beads {
+                    written += bead_hash.consensus_encode(writer)?;
                 }
                 Ok(written)
             }
@@ -302,12 +302,12 @@ impl Decodable for BeadResponse {
             }
             GET_BEADS_AFTER => {
                 let count = u32::consensus_decode(d)?;
-                let mut beads = Vec::new();
+                let mut bead_hashes = Vec::new();
                 for _ in 0..count {
-                    let bead = Bead::consensus_decode(d)?;
-                    beads.push(bead);
+                    let bead_hash = BeadHash::consensus_decode(d)?;
+                    bead_hashes.push(bead_hash);
                 }
-                Ok(BeadResponse::GetBeadsAfter(beads))
+                Ok(BeadResponse::GetBeadsAfter(bead_hashes))
             }
             _ => Err(Error::from(io::Error::new(
                 io::ErrorKind::InvalidData,

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -11,14 +11,6 @@ use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;
 use libp2p::StreamProtocol;
 use serde::{Deserialize, Serialize};
-
-const GET_BEADS: u8 = 0;
-const GET_TIPS: u8 = 1;
-const GET_GENESIS: u8 = 2;
-const GET_ALL_BEADS: u8 = 3;
-const GET_BEADS_AFTER: u8 = 4;
-const BEAD_RESPONSE_ERROR: u8 = 5;
-
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Bead {
     pub block_header: BlockHeader,
@@ -62,6 +54,31 @@ impl Decodable for Bead {
             committed_metadata,
             uncommitted_metadata,
         })
+    }
+}
+
+#[repr(u8)]
+#[derive(Debug, Clone, Copy)]
+pub enum BeadRequestType {
+    GetBeads = 0,
+    GetTips = 1,
+    GetGenesis = 2,
+    GetAllBeads = 3,
+    GetBeadsAfter = 4,
+    BeadResponseError = 5,
+}
+//Converting from u8 to `RequestType`/ `ResponseType`
+impl BeadRequestType {
+    pub fn from_u8(v: u8) -> Option<Self> {
+        match v {
+            0 => Some(Self::GetBeads),
+            1 => Some(Self::GetTips),
+            2 => Some(Self::GetGenesis),
+            3 => Some(Self::GetAllBeads),
+            4 => Some(Self::GetBeadsAfter),
+            5 => Some(Self::BeadResponseError),
+            _ => None,
+        }
     }
 }
 
@@ -136,25 +153,21 @@ impl Encodable for BeadRequest {
         match self {
             BeadRequest::GetBeads(hashes) => {
                 let mut written = 0;
-                written += GET_BEADS.consensus_encode(writer)?; // 0 for GetBeads
+                written += (BeadRequestType::GetBeads as u8).consensus_encode(writer)?;
                 written += (hashes.len() as u32).consensus_encode(writer)?;
                 for hash in hashes {
                     written += hash.consensus_encode(writer)?;
                 }
                 Ok(written)
             }
-            BeadRequest::GetTips => {
-                GET_TIPS.consensus_encode(writer) // 1 for GetTips
-            }
-            BeadRequest::GetGenesis => {
-                GET_GENESIS.consensus_encode(writer) // 2 for GetGenesis
-            }
+            BeadRequest::GetTips => (BeadRequestType::GetTips as u8).consensus_encode(writer),
+            BeadRequest::GetGenesis => (BeadRequestType::GetGenesis as u8).consensus_encode(writer),
             BeadRequest::GetAllBeads => {
-                GET_ALL_BEADS.consensus_encode(writer) // 3 for GetAllBeads
+                (BeadRequestType::GetAllBeads as u8).consensus_encode(writer)
             }
             BeadRequest::GetBeadsAfter(hashes) => {
                 let mut written = 0;
-                written += GET_BEADS_AFTER.consensus_encode(writer)?;
+                written += (BeadRequestType::GetBeadsAfter as u8).consensus_encode(writer)?;
                 written += (hashes.len() as u32).consensus_encode(writer)?;
                 for hash in hashes {
                     written += hash.consensus_encode(writer)?;
@@ -167,9 +180,12 @@ impl Encodable for BeadRequest {
 
 impl Decodable for BeadRequest {
     fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let request_type = u8::consensus_decode(d)?;
+        let request_type_u8 = u8::consensus_decode(d)?;
+        let request_type = BeadRequestType::from_u8(request_type_u8).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "Invalid bead request type")
+        })?;
         match request_type {
-            GET_BEADS => {
+            BeadRequestType::GetBeads => {
                 let count = u32::consensus_decode(d)?;
                 let mut hashes = Vec::new();
                 for _ in 0..count {
@@ -178,10 +194,10 @@ impl Decodable for BeadRequest {
                 }
                 Ok(BeadRequest::GetBeads(hashes))
             }
-            GET_TIPS => Ok(BeadRequest::GetTips),
-            GET_GENESIS => Ok(BeadRequest::GetGenesis),
-            GET_ALL_BEADS => Ok(BeadRequest::GetAllBeads),
-            GET_BEADS_AFTER => {
+            BeadRequestType::GetTips => Ok(BeadRequest::GetTips),
+            BeadRequestType::GetGenesis => Ok(BeadRequest::GetGenesis),
+            BeadRequestType::GetAllBeads => Ok(BeadRequest::GetAllBeads),
+            BeadRequestType::GetBeadsAfter => {
                 let count = u32::consensus_decode(d)?;
                 let mut hashes = Vec::new();
                 for _ in 0..count {
@@ -203,7 +219,7 @@ impl Encodable for BeadResponse {
         match self {
             BeadResponse::Beads(beads) => {
                 let mut written = 0;
-                written += GET_BEADS.consensus_encode(writer)?; // 0 for Beads
+                written += (BeadRequestType::GetBeads as u8).consensus_encode(writer)?;
                 written += (beads.len() as u32).consensus_encode(writer)?;
                 for bead in beads {
                     written += bead.consensus_encode(writer)?;
@@ -212,7 +228,7 @@ impl Encodable for BeadResponse {
             }
             BeadResponse::Tips(tips) => {
                 let mut written = 0;
-                written += GET_TIPS.consensus_encode(writer)?; // 1 for Tips
+                written += (BeadRequestType::GetTips as u8).consensus_encode(writer)?;
                 written += (tips.len() as u32).consensus_encode(writer)?;
                 for tip in tips {
                     written += tip.consensus_encode(writer)?;
@@ -221,7 +237,7 @@ impl Encodable for BeadResponse {
             }
             BeadResponse::Genesis(genesis) => {
                 let mut written = 0;
-                written += GET_GENESIS.consensus_encode(writer)?; // 2 for Genesis
+                written += (BeadRequestType::GetGenesis as u8).consensus_encode(writer)?;
                 written += (genesis.len() as u32).consensus_encode(writer)?;
                 for hash in genesis {
                     written += hash.consensus_encode(writer)?;
@@ -230,7 +246,7 @@ impl Encodable for BeadResponse {
             }
             BeadResponse::GetAllBeads(beads) => {
                 let mut written = 0;
-                written += GET_ALL_BEADS.consensus_encode(writer)?; // 3 for GetAllBeads
+                written += (BeadRequestType::GetAllBeads as u8).consensus_encode(writer)?;
                 written += (beads.len() as u32).consensus_encode(writer)?;
                 for bead in beads {
                     written += bead.consensus_encode(writer)?;
@@ -239,13 +255,13 @@ impl Encodable for BeadResponse {
             }
             BeadResponse::Error(error) => {
                 let mut written = 0;
-                written += BEAD_RESPONSE_ERROR.consensus_encode(writer)?;
+                written += (BeadRequestType::BeadResponseError as u8).consensus_encode(writer)?;
                 written += error.consensus_encode(writer)?;
                 Ok(written)
             }
             BeadResponse::GetBeadsAfter(beads) => {
                 let mut written = 0;
-                written += GET_BEADS_AFTER.consensus_encode(writer)?;
+                written += (BeadRequestType::GetBeadsAfter as u8).consensus_encode(writer)?;
                 written += (beads.len() as u32).consensus_encode(writer)?;
                 for bead_hash in beads {
                     written += bead_hash.consensus_encode(writer)?;
@@ -258,9 +274,12 @@ impl Encodable for BeadResponse {
 
 impl Decodable for BeadResponse {
     fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let response_type = u8::consensus_decode(d)?;
+        let response_type_u8 = u8::consensus_decode(d)?;
+        let response_type = BeadRequestType::from_u8(response_type_u8).ok_or_else(|| {
+            io::Error::new(io::ErrorKind::InvalidData, "Invalid bead response type")
+        })?;
         match response_type {
-            GET_BEADS => {
+            BeadRequestType::GetBeads => {
                 let count = u32::consensus_decode(d)?;
                 let mut beads = Vec::new();
                 for _ in 0..count {
@@ -269,7 +288,7 @@ impl Decodable for BeadResponse {
                 }
                 Ok(BeadResponse::Beads(beads))
             }
-            GET_TIPS => {
+            BeadRequestType::GetTips => {
                 let count = u32::consensus_decode(d)?;
                 let mut tips = Vec::new();
                 for _ in 0..count {
@@ -278,7 +297,7 @@ impl Decodable for BeadResponse {
                 }
                 Ok(BeadResponse::Tips(tips))
             }
-            GET_GENESIS => {
+            BeadRequestType::GetGenesis => {
                 let count = u32::consensus_decode(d)?;
                 let mut genesis = Vec::new();
                 for _ in 0..count {
@@ -287,7 +306,7 @@ impl Decodable for BeadResponse {
                 }
                 Ok(BeadResponse::Genesis(genesis))
             }
-            GET_ALL_BEADS => {
+            BeadRequestType::GetAllBeads => {
                 let count = u32::consensus_decode(d)?;
                 let mut beads = Vec::new();
                 for _ in 0..count {
@@ -296,11 +315,11 @@ impl Decodable for BeadResponse {
                 }
                 Ok(BeadResponse::GetAllBeads(beads))
             }
-            BEAD_RESPONSE_ERROR => {
+            BeadRequestType::BeadResponseError => {
                 let error = BeadSyncError::consensus_decode(d)?;
                 Ok(BeadResponse::Error(error))
             }
-            GET_BEADS_AFTER => {
+            BeadRequestType::GetBeadsAfter => {
                 let count = u32::consensus_decode(d)?;
                 let mut bead_hashes = Vec::new();
                 for _ in 0..count {
@@ -309,10 +328,6 @@ impl Decodable for BeadResponse {
                 }
                 Ok(BeadResponse::GetBeadsAfter(bead_hashes))
             }
-            _ => Err(Error::from(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid BeadResponse type",
-            ))),
         }
     }
 }

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -115,11 +115,9 @@ braidpool_protocol! {
     /// **Variants:**
     /// - `GenesisMismatch`: Genesis beads don't match between peers
     /// - `BeadHashNotFound`: Requested bead hash not found in local store
-    /// - `PeerSyncing`: Peer is still syncing (in IBD) and cannot serve requests
     pub enum BeadSyncError {
         GenesisMismatch     = 0,
         BeadHashNotFound    = 1,
-        PeerSyncing         = 2,
     }
 }
 

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -4,29 +4,56 @@ use crate::utils::BeadHash;
 use async_trait::async_trait;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
-use bitcoin::consensus::Error;
-use bitcoin::io::{self, BufRead, Write};
 use bitcoin::{BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget, TxMerkleNode};
 use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;
 use libp2p::StreamProtocol;
 use serde::{Deserialize, Serialize};
+use std::io::{Error as IoError, ErrorKind, Result as IoResult};
+
+/// Collection of beads.
+///
+/// Newtype wrapper around `Vec<Bead>` that provides Bitcoin consensus encoding/decoding
+/// and convenient iteration methods. Used to work around Rust's orphan rule.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Beads(pub Vec<Bead>);
+impl_vec_wrapper!(Beads, Bead);
+
+/// Collection of bead hashes.
+///
+/// Newtype wrapper around `Vec<BeadHash>` that provides Bitcoin consensus encoding/decoding
+/// and convenient iteration methods. Used for requesting and responding with bead identifiers.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BeadHashes(pub Vec<BeadHash>);
+impl_vec_wrapper!(BeadHashes, BeadHash);
+
+/// A bead in the Braidpool DAG structure.
+///
+/// A bead represents a weak share in the Braidpool mining protocol. It combines a Bitcoin
+/// block header with metadata about the mining process and network topology.
+///
+/// **Fields:**
+/// - `block_header`: Standard Bitcoin block header with proof-of-work
+/// - `committed_metadata`: Metadata committed to the block (parents, timestamps, transactions)
+/// - `uncommitted_metadata`: Metadata not part of the hash (signature, broadcast time)
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Bead {
     pub block_header: BlockHeader,
     pub committed_metadata: CommittedMetadata,
     pub uncommitted_metadata: UnCommittedMetadata,
 }
+impl_consensus_encoding!(Bead, block_header, committed_metadata, uncommitted_metadata);
+
 impl Default for Bead {
     fn default() -> Self {
         let empty_merkle_bytes: [u8; 32] = [0; 32];
         Self {
             block_header: BlockHeader {
-                bits: CompactTarget::from_consensus(486604799),
+                bits: CompactTarget::from_consensus(1),
                 merkle_root: TxMerkleNode::from_byte_array(empty_merkle_bytes),
                 nonce: 0,
                 prev_blockhash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
-                time: BlockTime::from_u32(23021),
+                time: BlockTime::from_u32(0),
                 version: BlockVersion::TWO,
             },
             committed_metadata: CommittedMetadata::default(),
@@ -34,304 +61,72 @@ impl Default for Bead {
         }
     }
 }
-impl Encodable for Bead {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        let mut len = 0;
-        len += self.block_header.consensus_encode(w)?;
-        len += self.committed_metadata.consensus_encode(w)?;
-        len += self.uncommitted_metadata.consensus_encode(w)?;
-        Ok(len)
+
+braidpool_protocol! {
+    /// Request types for bead synchronization protocol.
+    ///
+    /// Used in the request-response protocol to request beads from remote peers.
+    /// Each variant maps to a specific opcode for network encoding.
+    ///
+    /// **Variants:**
+    /// - `GetBeads(BeadHashes)`: Request specific beads by their hashes
+    /// - `GetTips`: Request the current DAG tips
+    /// - `GetGenesis`: Request the genesis bead(s)
+    /// - `GetAllBeads`: Request all beads (for IBD)
+    /// - `GetBeadsAfter(BeadHashes)`: Request all beads after specified hashes (for sync)
+    pub enum BeadRequest {
+        GetBeads(BeadHashes)        = 0,
+        GetTips                     = 1,
+        GetGenesis                  = 2,
+        GetAllBeads                 = 3,
+        GetBeadsAfter(BeadHashes)   = 4,
     }
 }
 
-impl Decodable for Bead {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
-        let block_header = BlockHeader::consensus_decode(r)?;
-        let committed_metadata = CommittedMetadata::consensus_decode(r)?;
-        let uncommitted_metadata = UnCommittedMetadata::consensus_decode(r)?;
-        Ok(Bead {
-            block_header,
-            committed_metadata,
-            uncommitted_metadata,
-        })
+braidpool_protocol! {
+    /// Response types for bead synchronization protocol.
+    ///
+    /// Responses to `BeadRequest` messages. Contains either the requested data
+    /// or an error explaining why the request couldn't be fulfilled.
+    ///
+    /// **Variants:**
+    /// - `Beads(Beads)`: Response containing requested beads
+    /// - `Tips(BeadHashes)`: Response containing current DAG tip hashes
+    /// - `Genesis(BeadHashes)`: Response containing genesis bead hash(es)
+    /// - `GetAllBeads(Beads)`: Response containing all beads (for IBD)
+    /// - `GetBeadsAfter(BeadHashes)`: Response containing beads after specified hashes
+    /// - `Error(BeadSyncError)`: Error response indicating why request failed
+    pub enum BeadResponse {
+        Beads(Beads)                = 0,
+        Tips(BeadHashes)            = 1,
+        Genesis(BeadHashes)         = 2,
+        GetAllBeads(Beads)          = 3,
+        GetBeadsAfter(BeadHashes)   = 4,
+        Error(BeadSyncError)        = 5,
     }
 }
 
-#[repr(u8)]
-#[derive(Debug, Clone, Copy)]
-pub enum BeadRequestType {
-    GetBeads = 0,
-    GetTips = 1,
-    GetGenesis = 2,
-    GetAllBeads = 3,
-    GetBeadsAfter = 4,
-    BeadResponseError = 5,
-}
-//Converting from u8 to `RequestType`/ `ResponseType`
-impl BeadRequestType {
-    pub fn from_u8(v: u8) -> Option<Self> {
-        match v {
-            0 => Some(Self::GetBeads),
-            1 => Some(Self::GetTips),
-            2 => Some(Self::GetGenesis),
-            3 => Some(Self::GetAllBeads),
-            4 => Some(Self::GetBeadsAfter),
-            5 => Some(Self::BeadResponseError),
-            _ => None,
-        }
+braidpool_protocol! {
+    /// Errors that can occur during bead synchronization.
+    ///
+    /// These errors are returned in `BeadResponse::Error` to indicate
+    /// why a bead request could not be fulfilled.
+    ///
+    /// **Variants:**
+    /// - `GenesisMismatch`: Genesis beads don't match between peers
+    /// - `BeadHashNotFound`: Requested bead hash not found in local store
+    /// - `PeerSyncing`: Peer is still syncing (in IBD) and cannot serve requests
+    pub enum BeadSyncError {
+        GenesisMismatch     = 0,
+        BeadHashNotFound    = 1,
+        PeerSyncing         = 2,
     }
 }
 
-// Request types for bead download
-#[derive(Debug, Clone, PartialEq)]
-pub enum BeadRequest {
-    // Request beads from a specific set of hashes
-    GetBeads(Vec<BeadHash>),
-    // Request the latest tips from a peer
-    GetTips,
-    GetGenesis,
-    GetAllBeads,
-    GetBeadsAfter(Vec<BeadHash>),
-}
-
-// Response types for bead download
-#[derive(Debug, Clone, PartialEq)]
-pub enum BeadResponse {
-    // Response containing requested beads
-    Beads(Vec<Bead>),
-    // Response containing tips
-    Tips(Vec<BeadHash>),
-    // Response containing genesis
-    Genesis(Vec<BeadHash>),
-    // Get all beads for IBD
-    GetAllBeads(Vec<Bead>),
-    // Get beads after a specific set of hashes
-    GetBeadsAfter(Vec<BeadHash>),
-    // Error response
-    Error(BeadSyncError),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum BeadSyncError {
-    GenesisMismatch,
-    Other(String),
-}
-
-impl Encodable for BeadSyncError {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        match self {
-            BeadSyncError::GenesisMismatch => 0u8.consensus_encode(w),
-            BeadSyncError::Other(message) => {
-                let mut written = 0;
-                written += 1u8.consensus_encode(w)?;
-                written += message.consensus_encode(w)?;
-                Ok(written)
-            }
-        }
-    }
-}
-
-impl Decodable for BeadSyncError {
-    fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let error_type = u8::consensus_decode(d)?;
-        match error_type {
-            0 => Ok(BeadSyncError::GenesisMismatch),
-            1 => {
-                let message = String::consensus_decode(d)?;
-                Ok(BeadSyncError::Other(message))
-            }
-            _ => Err(Error::from(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid BeadSyncError type",
-            ))),
-        }
-    }
-}
-
-impl Encodable for BeadRequest {
-    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        match self {
-            BeadRequest::GetBeads(hashes) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeads as u8).consensus_encode(writer)?;
-                written += (hashes.len() as u32).consensus_encode(writer)?;
-                for hash in hashes {
-                    written += hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadRequest::GetTips => (BeadRequestType::GetTips as u8).consensus_encode(writer),
-            BeadRequest::GetGenesis => (BeadRequestType::GetGenesis as u8).consensus_encode(writer),
-            BeadRequest::GetAllBeads => {
-                (BeadRequestType::GetAllBeads as u8).consensus_encode(writer)
-            }
-            BeadRequest::GetBeadsAfter(hashes) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeadsAfter as u8).consensus_encode(writer)?;
-                written += (hashes.len() as u32).consensus_encode(writer)?;
-                for hash in hashes {
-                    written += hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-        }
-    }
-}
-
-impl Decodable for BeadRequest {
-    fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let request_type_u8 = u8::consensus_decode(d)?;
-        let request_type = BeadRequestType::from_u8(request_type_u8).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "Invalid bead request type")
-        })?;
-        match request_type {
-            BeadRequestType::GetBeads => {
-                let count = u32::consensus_decode(d)?;
-                let mut hashes = Vec::new();
-                for _ in 0..count {
-                    let hash = BeadHash::consensus_decode(d)?;
-                    hashes.push(hash);
-                }
-                Ok(BeadRequest::GetBeads(hashes))
-            }
-            BeadRequestType::GetTips => Ok(BeadRequest::GetTips),
-            BeadRequestType::GetGenesis => Ok(BeadRequest::GetGenesis),
-            BeadRequestType::GetAllBeads => Ok(BeadRequest::GetAllBeads),
-            BeadRequestType::GetBeadsAfter => {
-                let count = u32::consensus_decode(d)?;
-                let mut hashes = Vec::new();
-                for _ in 0..count {
-                    let hash = BeadHash::consensus_decode(d)?;
-                    hashes.push(hash);
-                }
-                Ok(BeadRequest::GetBeadsAfter(hashes))
-            }
-            _ => Err(Error::from(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid BeadRequest type",
-            ))),
-        }
-    }
-}
-
-impl Encodable for BeadResponse {
-    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        match self {
-            BeadResponse::Beads(beads) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeads as u8).consensus_encode(writer)?;
-                written += (beads.len() as u32).consensus_encode(writer)?;
-                for bead in beads {
-                    written += bead.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::Tips(tips) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetTips as u8).consensus_encode(writer)?;
-                written += (tips.len() as u32).consensus_encode(writer)?;
-                for tip in tips {
-                    written += tip.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::Genesis(genesis) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetGenesis as u8).consensus_encode(writer)?;
-                written += (genesis.len() as u32).consensus_encode(writer)?;
-                for hash in genesis {
-                    written += hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::GetAllBeads(beads) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetAllBeads as u8).consensus_encode(writer)?;
-                written += (beads.len() as u32).consensus_encode(writer)?;
-                for bead in beads {
-                    written += bead.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::Error(error) => {
-                let mut written = 0;
-                written += (BeadRequestType::BeadResponseError as u8).consensus_encode(writer)?;
-                written += error.consensus_encode(writer)?;
-                Ok(written)
-            }
-            BeadResponse::GetBeadsAfter(beads) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeadsAfter as u8).consensus_encode(writer)?;
-                written += (beads.len() as u32).consensus_encode(writer)?;
-                for bead_hash in beads {
-                    written += bead_hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-        }
-    }
-}
-
-impl Decodable for BeadResponse {
-    fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let response_type_u8 = u8::consensus_decode(d)?;
-        let response_type = BeadRequestType::from_u8(response_type_u8).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "Invalid bead response type")
-        })?;
-        match response_type {
-            BeadRequestType::GetBeads => {
-                let count = u32::consensus_decode(d)?;
-                let mut beads = Vec::new();
-                for _ in 0..count {
-                    let bead = Bead::consensus_decode(d)?;
-                    beads.push(bead);
-                }
-                Ok(BeadResponse::Beads(beads))
-            }
-            BeadRequestType::GetTips => {
-                let count = u32::consensus_decode(d)?;
-                let mut tips = Vec::new();
-                for _ in 0..count {
-                    let tip = BeadHash::consensus_decode(d)?;
-                    tips.push(tip);
-                }
-                Ok(BeadResponse::Tips(tips))
-            }
-            BeadRequestType::GetGenesis => {
-                let count = u32::consensus_decode(d)?;
-                let mut genesis = Vec::new();
-                for _ in 0..count {
-                    let hash = BeadHash::consensus_decode(d)?;
-                    genesis.push(hash);
-                }
-                Ok(BeadResponse::Genesis(genesis))
-            }
-            BeadRequestType::GetAllBeads => {
-                let count = u32::consensus_decode(d)?;
-                let mut beads = Vec::new();
-                for _ in 0..count {
-                    let bead = Bead::consensus_decode(d)?;
-                    beads.push(bead);
-                }
-                Ok(BeadResponse::GetAllBeads(beads))
-            }
-            BeadRequestType::BeadResponseError => {
-                let error = BeadSyncError::consensus_decode(d)?;
-                Ok(BeadResponse::Error(error))
-            }
-            BeadRequestType::GetBeadsAfter => {
-                let count = u32::consensus_decode(d)?;
-                let mut bead_hashes = Vec::new();
-                for _ in 0..count {
-                    let bead_hash = BeadHash::consensus_decode(d)?;
-                    bead_hashes.push(bead_hash);
-                }
-                Ok(BeadResponse::GetBeadsAfter(bead_hashes))
-            }
-        }
-    }
-}
-
+/// Codec for encoding/decoding bead sync messages over libp2p.
+///
+/// Implements the `libp2p::request_response::Codec` trait to handle serialization
+/// of `BeadRequest` and `BeadResponse` messages using Bitcoin consensus encoding.
 #[derive(Clone, Default)]
 pub struct BeadCodec;
 
@@ -341,32 +136,24 @@ impl Codec for BeadCodec {
     type Request = BeadRequest;
     type Response = BeadResponse;
 
-    async fn read_request<T>(
-        &mut self,
-        _: &Self::Protocol,
-        io: &mut T,
-    ) -> std::io::Result<Self::Request>
+    async fn read_request<T>(&mut self, _: &Self::Protocol, io: &mut T) -> IoResult<Self::Request>
     where
         T: AsyncRead + Unpin + Send,
     {
         let mut buf = Vec::new();
         io.read_to_end(&mut buf).await?;
         BeadRequest::consensus_decode(&mut buf.as_slice())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))
     }
 
-    async fn read_response<T>(
-        &mut self,
-        _: &Self::Protocol,
-        io: &mut T,
-    ) -> std::io::Result<Self::Response>
+    async fn read_response<T>(&mut self, _: &Self::Protocol, io: &mut T) -> IoResult<Self::Response>
     where
         T: AsyncRead + Unpin + Send,
     {
         let mut buf = Vec::new();
         io.read_to_end(&mut buf).await?;
         BeadResponse::consensus_decode(&mut buf.as_slice())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))
     }
 
     async fn write_request<T>(
@@ -374,17 +161,17 @@ impl Codec for BeadCodec {
         _: &Self::Protocol,
         io: &mut T,
         request: Self::Request,
-    ) -> std::io::Result<()>
+    ) -> IoResult<()>
     where
         T: AsyncWrite + Unpin + Send,
     {
         let mut buf = Vec::new();
         request
             .consensus_encode(&mut buf)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))?;
         io.write_all(&buf)
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            .map_err(|e| IoError::new(ErrorKind::Other, e))
     }
 
     async fn write_response<T>(
@@ -392,17 +179,17 @@ impl Codec for BeadCodec {
         _: &Self::Protocol,
         io: &mut T,
         response: Self::Response,
-    ) -> std::io::Result<()>
+    ) -> IoResult<()>
     where
         T: AsyncWrite + Unpin + Send,
     {
         let mut buf = Vec::new();
         response
             .consensus_encode(&mut buf)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))?;
         io.write_all(&buf)
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            .map_err(|e| IoError::new(ErrorKind::Other, e))
     }
 }
 

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -338,7 +338,7 @@ fn test_bead_response_codec() {
         BeadResponse::Tips(vec![test_hash, test_hash2]),
         BeadResponse::Genesis(vec![test_hash]),
         BeadResponse::GetAllBeads(vec![test_bead.clone(), test_bead.clone()]),
-        BeadResponse::GetBeadsAfter(vec![test_bead.clone()]),
+        BeadResponse::GetBeadsAfter(vec![test_bead.block_header.block_hash()]),
         BeadResponse::Error(BeadSyncError::GenesisMismatch),
         BeadResponse::Error(BeadSyncError::Other("Test error message".to_string())),
     ];

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -357,7 +357,6 @@ fn test_bead_sync_error_codec() {
     let errors = vec![
         BeadSyncError::GenesisMismatch,
         BeadSyncError::BeadHashNotFound,
-        BeadSyncError::PeerSyncing,
     ];
 
     for error in errors {

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -1,9 +1,11 @@
 use super::Bead;
 use super::BeadCodec;
 use super::BeadHash;
+use super::BeadHashes;
 use super::BeadRequest;
 use super::BeadResponse;
 use super::BeadSyncError;
+use super::Beads;
 use super::CommittedMetadata;
 use super::UnCommittedMetadata;
 use crate::committed_metadata::TimeVec;
@@ -164,11 +166,7 @@ fn test_serialized_bead() {
 
 #[test]
 fn test_bead_request_serialization() {
-    let request = BeadRequest::GetBeads(
-        vec![BeadHash::from_byte_array([0u8; 32])]
-            .into_iter()
-            .collect(),
-    );
+    let request = BeadRequest::GetBeads(vec![BeadHash::from_byte_array([0u8; 32])].into());
     let mut buffer = Vec::new();
     request.consensus_encode(&mut buffer).unwrap();
 
@@ -224,7 +222,7 @@ fn test_bead_response_serialization() {
         .committed_metadata(test_committed_metadata)
         .uncommitted_metadata(test_uncommitted_metadata)
         .build();
-    let response = BeadResponse::Beads(vec![test_bead]);
+    let response = BeadResponse::Beads(Beads(vec![test_bead]));
     let mut buffer = Vec::new();
     response.consensus_encode(&mut buffer).unwrap();
     let decoded = BeadResponse::consensus_decode(&mut buffer.as_slice()).unwrap();
@@ -251,20 +249,16 @@ fn test_codec_request_roundtrip() {
 #[test]
 fn test_codec_response_roundtrip() {
     let mut codec = BeadCodec::default();
-    let response = BeadResponse::Tips(
-        vec![
-            BeadHash::from_byte_array([
-                3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 1, 24, 12, 14, 35, 35, 34, 3, 42, 32, 32,
-                32, 32, 4, 32, 24, 5, 12, 1,
-            ]),
-            BeadHash::from_byte_array([
-                1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1,
-                2, 3, 4, 5,
-            ]),
-        ]
-        .into_iter()
-        .collect(),
-    );
+    let response = BeadResponse::Tips(BeadHashes(vec![
+        BeadHash::from_byte_array([
+            3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 1, 24, 12, 14, 35, 35, 34, 3, 42, 32, 32, 32,
+            32, 4, 32, 24, 5, 12, 1,
+        ]),
+        BeadHash::from_byte_array([
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2,
+            3, 4, 5,
+        ]),
+    ]));
 
     // Serialize
     let mut buffer = Vec::new();
@@ -280,11 +274,8 @@ fn test_codec_response_roundtrip() {
 #[test]
 fn test_get_beads_after_serialization() {
     let mut codec = BeadCodec::default();
-    let request = BeadRequest::GetBeadsAfter(
-        vec![BeadHash::from_byte_array([0u8; 32])]
-            .into_iter()
-            .collect(),
-    );
+    let request =
+        BeadRequest::GetBeadsAfter(BeadHashes(vec![BeadHash::from_byte_array([0u8; 32])]));
 
     // Serialize
     let mut buffer = Vec::new();
@@ -305,10 +296,12 @@ fn test_bead_request_codec() {
 
     for request in vec![
         BeadRequest::GetTips,
-        BeadRequest::GetBeads(Vec::from([BeadHash::from_byte_array([0u8; 32])])),
+        BeadRequest::GetBeads(BeadHashes(Vec::from([BeadHash::from_byte_array(
+            [0u8; 32],
+        )]))),
         BeadRequest::GetGenesis,
         BeadRequest::GetAllBeads,
-        BeadRequest::GetBeadsAfter(vec![BeadHash::from_byte_array([0u8; 32])]),
+        BeadRequest::GetBeadsAfter(BeadHashes(vec![BeadHash::from_byte_array([0u8; 32])])),
     ] {
         // Serialize
         let mut buffer = Vec::new();
@@ -334,13 +327,13 @@ fn test_bead_response_codec() {
 
     // Test all BeadResponse variants
     let responses = vec![
-        BeadResponse::Beads(vec![test_bead.clone()]),
-        BeadResponse::Tips(vec![test_hash, test_hash2]),
-        BeadResponse::Genesis(vec![test_hash]),
-        BeadResponse::GetAllBeads(vec![test_bead.clone(), test_bead.clone()]),
-        BeadResponse::GetBeadsAfter(vec![test_bead.block_header.block_hash()]),
+        BeadResponse::Beads(Beads(vec![test_bead.clone()])),
+        BeadResponse::Tips(BeadHashes(vec![test_hash, test_hash2])),
+        BeadResponse::Genesis(BeadHashes(vec![test_hash])),
+        BeadResponse::GetAllBeads(Beads(vec![test_bead.clone(), test_bead.clone()])),
+        BeadResponse::GetBeadsAfter(BeadHashes(vec![test_bead.block_header.block_hash()])),
         BeadResponse::Error(BeadSyncError::GenesisMismatch),
-        BeadResponse::Error(BeadSyncError::Other("Test error message".to_string())),
+        BeadResponse::Error(BeadSyncError::BeadHashNotFound),
     ];
 
     for response in responses {
@@ -363,10 +356,8 @@ fn test_bead_sync_error_codec() {
     // Test BeadSyncError encoding/decoding directly (not through codec)
     let errors = vec![
         BeadSyncError::GenesisMismatch,
-        BeadSyncError::Other("Network timeout".to_string()),
-        BeadSyncError::Other("Invalid bead format".to_string()),
-        BeadSyncError::Other("".to_string()), // Empty string edge case
-        BeadSyncError::Other("Very long error message that tests the string encoding and decoding with special characters: !@#$%^&*()_+-=[]{}|;':,.<>?".to_string()),
+        BeadSyncError::BeadHashNotFound,
+        BeadSyncError::PeerSyncing,
     ];
 
     for error in errors {

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -1,4 +1,4 @@
-use crate::bead::{Bead, BeadCodec, BeadRequest, BeadResponse};
+use crate::bead::{Bead, BeadCodec, BeadRequest, BeadResponse, BeadSyncError};
 use crate::utils::BeadHash;
 use libp2p::floodsub;
 use libp2p::{
@@ -135,7 +135,11 @@ impl BraidPoolBehaviour {
     }
 
     // Respond with an error
-    pub fn respond_with_error(&mut self, channel: ResponseChannel<BeadResponse>, error: String) {
+    pub fn respond_with_error(
+        &mut self,
+        channel: ResponseChannel<BeadResponse>,
+        error: BeadSyncError,
+    ) {
         self.bead_sync
             .send_response(channel, BeadResponse::Error(error))
             .expect("Failed to send response");

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -90,7 +90,7 @@ impl BraidPoolBehaviour {
     }
 
     // Request beads from a peer
-    pub fn request_beads(&mut self, peer: PeerId, hashes: HashSet<BeadHash>) -> OutboundRequestId {
+    pub fn request_beads(&mut self, peer: PeerId, hashes: Vec<BeadHash>) -> OutboundRequestId {
         self.bead_sync
             .send_request(&peer, BeadRequest::GetBeads(hashes))
     }

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -89,9 +89,9 @@ impl BraidPoolBehaviour {
     }
 
     // Request beads from a peer
-    pub fn request_beads(&mut self, peer: PeerId, hashes: Vec<BeadHash>) -> OutboundRequestId {
+    pub fn request_beads(&mut self, peer: PeerId, hashes: &Vec<BeadHash>) -> OutboundRequestId {
         self.bead_sync
-            .send_request(&peer, BeadRequest::GetBeads(hashes))
+            .send_request(&peer, BeadRequest::GetBeads(hashes.clone()))
     }
 
     // Request tips from a peer
@@ -110,7 +110,16 @@ impl BraidPoolBehaviour {
             .send_response(channel, BeadResponse::Beads(beads))
             .expect("Failed to send response");
     }
-
+    //Respond with `GetBeadsAfter` beadhashes request
+    pub fn respond_with_beadhashes(
+        &mut self,
+        channel: ResponseChannel<BeadResponse>,
+        bead_hashes: Vec<BeadHash>,
+    ) {
+        self.bead_sync
+            .send_response(channel, BeadResponse::GetBeadsAfter(bead_hashes))
+            .expect("Failed to send response");
+    }
     // Respond to a tips request
     pub fn respond_with_tips(
         &mut self,

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -10,7 +10,6 @@ use libp2p::{
     swarm::NetworkBehaviour,
     PeerId, StreamProtocol,
 };
-use std::collections::HashSet;
 use std::{error::Error, time::Duration};
 
 // Protocol names

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -1,4 +1,4 @@
-use crate::bead::{Bead, BeadCodec, BeadRequest, BeadResponse, BeadSyncError};
+use crate::bead::{Bead, BeadCodec, BeadHashes, BeadRequest, BeadResponse, BeadSyncError};
 use crate::utils::BeadHash;
 use libp2p::floodsub;
 use libp2p::{
@@ -90,7 +90,7 @@ impl BraidPoolBehaviour {
     // Request beads from a peer
     pub fn request_beads(&mut self, peer: PeerId, hashes: &Vec<BeadHash>) -> OutboundRequestId {
         self.bead_sync
-            .send_request(&peer, BeadRequest::GetBeads(hashes.clone()))
+            .send_request(&peer, BeadRequest::GetBeads(BeadHashes(hashes.clone())))
     }
 
     // Request tips from a peer
@@ -106,7 +106,7 @@ impl BraidPoolBehaviour {
     // Respond to a bead request
     pub fn respond_with_beads(&mut self, channel: ResponseChannel<BeadResponse>, beads: Vec<Bead>) {
         self.bead_sync
-            .send_response(channel, BeadResponse::Beads(beads))
+            .send_response(channel, BeadResponse::Beads(crate::bead::Beads(beads)))
             .expect("Failed to send response");
     }
     //Respond with `GetBeadsAfter` beadhashes request
@@ -116,7 +116,10 @@ impl BraidPoolBehaviour {
         bead_hashes: Vec<BeadHash>,
     ) {
         self.bead_sync
-            .send_response(channel, BeadResponse::GetBeadsAfter(bead_hashes))
+            .send_response(
+                channel,
+                BeadResponse::GetBeadsAfter(BeadHashes(bead_hashes)),
+            )
             .expect("Failed to send response");
     }
     // Respond to a tips request
@@ -126,7 +129,7 @@ impl BraidPoolBehaviour {
         tips: Vec<BeadHash>,
     ) {
         self.bead_sync
-            .send_response(channel, BeadResponse::Tips(tips))
+            .send_response(channel, BeadResponse::Tips(BeadHashes(tips)))
             .expect("Failed to send response");
     }
 
@@ -137,7 +140,7 @@ impl BraidPoolBehaviour {
         genesis: Vec<BeadHash>,
     ) {
         self.bead_sync
-            .send_response(channel, BeadResponse::Genesis(genesis))
+            .send_response(channel, BeadResponse::Genesis(BeadHashes(genesis)))
             .expect("Failed to send response");
     }
 

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -43,7 +43,6 @@ pub struct BraidPoolBehaviour {
     pub bead_sync: request_response::Behaviour<BeadCodec>,
     pub bead_announce: floodsub::Floodsub,
 }
-
 impl BraidPoolBehaviour {
     pub fn new(local_key: &Keypair) -> Result<BraidPoolBehaviour, Box<dyn Error>> {
         //initializing the store for kademlia based DHT
@@ -63,7 +62,7 @@ impl BraidPoolBehaviour {
         let identify_behaviour = identify::Behaviour::new(identify_config);
         let ping_config = ping::Config::default()
             .with_timeout(Duration::from_secs(3600))
-            .with_interval(Duration::from_secs(60));
+            .with_interval(Duration::from_secs(5));
         let ping_behaviour = ping::Behaviour::new(ping_config.clone());
 
         // Initialize bead download behaviour

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -184,9 +184,9 @@ async fn test_bead_request_handling() {
                                         .bead_sync
                                         .send_response(
                                             channel,
-                                            BeadResponse::Error(
+                                            BeadResponse::Error(BeadSyncError::Other(
                                                 "Bead retrieval not implemented yet".to_string(),
-                                            ),
+                                            )),
                                         )
                                         .unwrap();
                                 }
@@ -241,10 +241,10 @@ async fn test_bead_request_handling() {
                                             .bead_sync
                                             .send_response(
                                                 channel,
-                                                BeadResponse::Error(
+                                                BeadResponse::Error(BeadSyncError::Other(
                                                     "Bead retrieval not implemented yet"
                                                         .to_string(),
-                                                ),
+                                                )),
                                             )
                                             .unwrap();
                                     }
@@ -255,8 +255,13 @@ async fn test_bead_request_handling() {
                                     response,
                                 } => {
                                     if let BeadResponse::Error(error) = response {
-                                        println!("Swarm2: Received error response: {}", error);
-                                        assert_eq!(error, "Bead retrieval not implemented yet");
+                                        println!("Swarm2: Received error response: {:?}", error);
+                                        assert_eq!(
+                                            error,
+                                            BeadSyncError::Other(String::from(
+                                                "Bead retrieval not implemented yet"
+                                            ))
+                                        );
                                         break;
                                     }
                                 }

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -211,8 +211,8 @@ async fn test_bead_request_handling() {
             match swarm.next().await {
                 Some(SwarmEvent::ConnectionEstablished { peer_id, .. }) => {
                     println!("Swarm2: Connection established with {}", peer_id);
-                    let mut hashes = HashSet::new();
-                    hashes.insert(bead_hash);
+                    let mut hashes = Vec::new();
+                    hashes.push(bead_hash);
                     swarm.behaviour_mut().request_beads(local_peer_id, hashes);
                 }
                 Some(SwarmEvent::IncomingConnection { .. }) => {

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -213,7 +213,7 @@ async fn test_bead_request_handling() {
                     println!("Swarm2: Connection established with {}", peer_id);
                     let mut hashes = Vec::new();
                     hashes.push(bead_hash);
-                    swarm.behaviour_mut().request_beads(local_peer_id, hashes);
+                    swarm.behaviour_mut().request_beads(local_peer_id, &hashes);
                 }
                 Some(SwarmEvent::IncomingConnection { .. }) => {
                     println!("Swarm2: Incoming connection");

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -178,15 +178,13 @@ async fn test_bead_request_handling() {
                                     );
                                     assert_eq!(hashes.len(), 1);
                                     assert_eq!(hashes.iter().next().unwrap(), &bead_hash);
-                                    // Respond with an error for now
+                                    // Bead not found in local store - return appropriate error
                                     swarm
                                         .behaviour_mut()
                                         .bead_sync
                                         .send_response(
                                             channel,
-                                            BeadResponse::Error(BeadSyncError::Other(
-                                                "Bead retrieval not implemented yet".to_string(),
-                                            )),
+                                            BeadResponse::Error(BeadSyncError::BeadHashNotFound),
                                         )
                                         .unwrap();
                                 }
@@ -235,16 +233,15 @@ async fn test_bead_request_handling() {
                                 } => {
                                     if let BeadRequest::GetBeads(hashes) = request {
                                         println!("Swarm2: Received bead request from {} with hashes: {:?}", peer, hashes);
-                                        // Respond with an error for now
+                                        // Bead not found in local store - return appropriate error
                                         swarm
                                             .behaviour_mut()
                                             .bead_sync
                                             .send_response(
                                                 channel,
-                                                BeadResponse::Error(BeadSyncError::Other(
-                                                    "Bead retrieval not implemented yet"
-                                                        .to_string(),
-                                                )),
+                                                BeadResponse::Error(
+                                                    BeadSyncError::BeadHashNotFound,
+                                                ),
                                             )
                                             .unwrap();
                                     }
@@ -256,12 +253,7 @@ async fn test_bead_request_handling() {
                                 } => {
                                     if let BeadResponse::Error(error) = response {
                                         println!("Swarm2: Received error response: {:?}", error);
-                                        assert_eq!(
-                                            error,
-                                            BeadSyncError::Other(String::from(
-                                                "Bead retrieval not implemented yet"
-                                            ))
-                                        );
+                                        assert_eq!(error, BeadSyncError::BeadHashNotFound);
                                         break;
                                     }
                                 }

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -60,6 +60,15 @@ impl Braid {
             bead_index_mapping,
         }
     }
+    pub fn reset(&mut self) {
+        self.beads.clear();
+        self.tips.clear();
+        self.cohorts.clear();
+        self.cohort_tips.clear();
+        self.orphan_beads.clear();
+        self.genesis_beads.clear();
+        self.bead_index_mapping.clear();
+    }
 }
 #[allow(unused)]
 impl Braid {
@@ -248,7 +257,34 @@ impl Braid {
             }
         }
     }
+
+    /// utility function for GetBeadsAfter request
+    pub fn get_beads_after(&self, old_tips_and_genesis: Vec<BeadHash>) -> Option<Vec<Bead>> {
+        let old_tips_and_genesis: HashSet<BeadHash> = old_tips_and_genesis.into_iter().collect();
+        let mut response_beads = Vec::new();
+        let mut flag = false;
+        for genesis_index in &self.genesis_beads {
+            let genesis_bead = &self.beads[*genesis_index];
+            let genesis_hash = genesis_bead.block_header.block_hash();
+            if !old_tips_and_genesis.contains(&genesis_hash) {
+                return None;
+            }
+        }
+        for bead in &self.beads {
+            let bead_hash = bead.block_header.block_hash();
+            if flag {
+                response_beads.push(bead.clone());
+            } else {
+                if old_tips_and_genesis.contains(&bead_hash) {
+                    flag = true;
+                    continue;
+                }
+            }
+        }
+        Some(response_beads)
+    }
 }
+
 #[allow(unused)]
 pub mod consensus_functions {
     use num::{One, Zero};

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -255,33 +255,54 @@ impl Braid {
             }
         }
     }
-
     /// utility function for GetBeadsAfter request
     pub fn get_beads_after(&self, old_tips: Vec<BeadHash>) -> Option<Vec<Bead>> {
         let old_tips: HashSet<BeadHash> = old_tips.into_iter().collect();
+        tracing::warn!(
+            old_tips=?old_tips,"Tips received from the peer for which beads are requested for during IBD"
+        );
+        //In case no tips are present i.e. the new braid-node has been initialized
+        if old_tips.len() == 0 {
+            return Some(self.beads.clone());
+        }
         let mut response_beads = Vec::new();
         let mut found_start = false;
         let mut smallest_index = usize::MAX;
-        for hash in old_tips {
-            if let Some(&index) = self.bead_index_mapping.get(&hash) {
+        //finding the starting index
+        for hash in &old_tips {
+            if let Some(&index) = self.bead_index_mapping.get(hash) {
                 if index < smallest_index {
                     smallest_index = index;
                 }
                 found_start = true;
             }
         }
+        tracing::debug!(
+            smallest_index=?smallest_index,"Smallest possible index from all the tips - ",
+
+        );
         // just iterating over the vector of cohorts for now, this needs to be changed to use a more efficient retrieval of cohort index given bead hash
         let mut smallest_cohort_index = usize::MAX;
         for (idx, cohort) in self.cohorts.iter().enumerate() {
             if cohort.0.contains(&smallest_index) {
+                //Finding the cohort for which the smallest index is a part of
                 smallest_cohort_index = idx;
                 break;
             }
         }
+        tracing::debug!(
+            smallest_index=?smallest_index,"Smallest possible cohort index for which the given smallest index is a part of - ",
+        );
         while (smallest_cohort_index < self.cohorts.len()) {
             let cohort = &self.cohorts[smallest_cohort_index];
             for bead_index in &cohort.0 {
-                response_beads.push(self.beads[*bead_index].clone());
+                let curr_bead = self.beads[*bead_index].clone();
+                //Not including the beads that are already present in old_tips
+                if !old_tips.contains(&curr_bead.block_header.block_hash()) {
+                    response_beads.push(curr_bead);
+                } else {
+                    println!("This bead is already present in old tips thus skipping");
+                }
             }
             smallest_cohort_index += 1;
         }

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -1,5 +1,5 @@
 use crate::bead::Bead;
-use crate::utils::{retrieve_bead, BeadHash};
+use crate::utils::BeadHash;
 use num::BigUint;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;
@@ -91,13 +91,10 @@ impl Braid {
 
             if !parent_exists {
                 // Try to retrieve the parent
-                if let Some(retrieved_bead) = retrieve_bead(*parent_hash) {
-                    self.extend(&retrieved_bead);
-                } else {
-                    // Parent not found and can't be retrieved
-                    self.orphan_beads.push(bead.clone());
-                    return AddBeadStatus::ParentsNotYetReceived;
-                }
+                //This is not required if a bead exists in DB it would already been extended to local braid as well
+                // Parent not found and can't be retrieved
+                self.orphan_beads.push(bead.clone());
+                return AddBeadStatus::ParentsNotYetReceived;
             }
         }
         // Already seen this bead
@@ -221,6 +218,7 @@ impl Braid {
                     AddBeadStatus::InvalidBead => {
                         continue;
                     }
+                    //Unecessary condition
                     AddBeadStatus::ParentsNotYetReceived => {
                         self.orphan_beads.push(orphan_bead);
                     }

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -218,7 +218,6 @@ impl Braid {
                     AddBeadStatus::InvalidBead => {
                         continue;
                     }
-                    //Unecessary condition
                     AddBeadStatus::ParentsNotYetReceived => {
                         self.orphan_beads.push(orphan_bead);
                     }
@@ -277,6 +276,11 @@ impl Braid {
                 found_start = true;
             }
         }
+        //If somehow no bead matched that can be due to possible latency/fork so send all the beads instead as fallback
+        if smallest_index == usize::MAX {
+            return Some(self.beads.clone());
+        }
+
         tracing::debug!(
             smallest_index=?smallest_index,"Smallest possible index from all the tips - ",
 

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -265,7 +265,6 @@ impl Braid {
             return Some(self.beads.clone());
         }
         let mut response_beads = Vec::new();
-        let mut found_start = false;
         let mut smallest_index = usize::MAX;
         //finding the starting index
         for hash in &old_tips {
@@ -273,7 +272,6 @@ impl Braid {
                 if index < smallest_index {
                     smallest_index = index;
                 }
-                found_start = true;
             }
         }
         //If somehow no bead matched that can be due to possible latency/fork so send all the beads instead as fallback
@@ -294,10 +292,13 @@ impl Braid {
                 break;
             }
         }
+        if smallest_cohort_index == usize::MAX {
+            return Some(self.beads.clone());
+        }
         tracing::debug!(
-            smallest_index=?smallest_index,"Smallest possible cohort index for which the given smallest index is a part of - ",
+            smallest_index=?smallest_index,"Smallest possible cohort index for which the given smallest index is a part of",
         );
-        while (smallest_cohort_index < self.cohorts.len()) {
+        while smallest_cohort_index < self.cohorts.len() {
             let cohort = &self.cohorts[smallest_cohort_index];
             for bead_index in &cohort.0 {
                 let curr_bead = self.beads[*bead_index].clone();
@@ -305,7 +306,7 @@ impl Braid {
                 if !old_tips.contains(&curr_bead.block_header.block_hash()) {
                     response_beads.push(curr_bead);
                 } else {
-                    println!("This bead is already present in old tips thus skipping");
+                    tracing::debug!("This bead is already present in old tips thus skipping");
                 }
             }
             smallest_cohort_index += 1;

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -280,7 +280,7 @@ impl Braid {
         }
 
         tracing::debug!(
-            smallest_index=?smallest_index,"Smallest possible index from all the tips - ",
+            smallest_index=?smallest_index,"Smallest possible index from all the tips",
 
         );
         // just iterating over the vector of cohorts for now, this needs to be changed to use a more efficient retrieval of cohort index given bead hash

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -1446,3 +1446,461 @@ fn test_extend_function() {
         assert_eq!(computed_cohorts_by_hash, file_cohorts_by_hash);
     }
 }
+
+#[test]
+fn test_get_beads_after() {
+    // Test Case 1: Simple linear chain
+    // Genesis -> Bead1 -> Bead2 -> Bead3
+    // Test getting beads after genesis, after bead1, etc.
+
+    let mut beads = Vec::new();
+    let mut parent_relationships = HashMap::new();
+
+    // Create 4 beads for a linear chain
+    for _i in 0..4 {
+        beads.push(emit_bead());
+    }
+
+    // Set up parent relationships for linear chain
+    parent_relationships.insert(0, HashSet::new()); // Genesis has no parents
+    parent_relationships.insert(1, HashSet::from([0])); // Bead1 -> Genesis
+    parent_relationships.insert(2, HashSet::from([1])); // Bead2 -> Bead1
+    parent_relationships.insert(3, HashSet::from([2])); // Bead3 -> Bead2
+
+    // Collect parent hashes first to avoid borrowing issues
+    let mut parent_hashes: HashMap<usize, Vec<bitcoin::BlockHash>> = HashMap::new();
+    for (index, parents) in &parent_relationships {
+        let mut hashes = Vec::new();
+        for &parent_idx in parents {
+            hashes.push(beads[parent_idx].block_header.block_hash());
+        }
+        parent_hashes.insert(*index, hashes);
+    }
+
+    // Update parent hashes in committed metadata
+    for (index, hashes) in parent_hashes {
+        for hash in hashes {
+            beads[index].committed_metadata.parents.insert(hash);
+        }
+    }
+
+    // Create braid with genesis
+    let genesis_set = HashSet::from([0]);
+    let mut bead_index_mapping = HashMap::new();
+    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+
+    let mut test_braid = Braid {
+        beads: vec![beads[0].clone()],
+        tips: genesis_set.clone(),
+        cohorts: vec![Cohort(genesis_set.clone())],
+        cohort_tips: vec![genesis_set.clone()],
+        orphan_beads: Vec::new(),
+        genesis_beads: genesis_set,
+        bead_index_mapping,
+    };
+
+    // Extend braid with remaining beads
+    for i in 1..4 {
+        test_braid.extend(&beads[i]);
+    }
+
+    // Test 1: Get beads after genesis (should return beads 1, 2, 3)
+    let genesis_hash = beads[0].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![genesis_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    // Should return beads from cohort containing genesis onwards
+    // In a linear chain, each bead is in its own cohort after genesis
+    assert!(
+        returned_beads.len() >= 3,
+        "Should return at least 3 beads after genesis"
+    );
+
+    // Verify the returned beads contain the expected hashes
+    let returned_hashes: HashSet<_> = returned_beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+    assert!(returned_hashes.contains(&beads[1].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[2].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+
+    // Test 2: Get beads after bead1 (should return beads 2, 3)
+    let bead1_hash = beads[1].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![bead1_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    let returned_hashes: HashSet<_> = returned_beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+    assert!(returned_hashes.contains(&beads[2].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+
+    // Test 3: Get beads after the last bead (should return empty or just that bead)
+    let last_hash = beads[3].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![last_hash]);
+    assert!(result.is_some());
+
+    println!("✅ Linear chain tests passed");
+}
+
+#[test]
+fn test_get_beads_after_diamond_structure() {
+    // Test Case 2: Diamond structure
+    //     Genesis (0)
+    //    /           \
+    //   Bead1(1)    Bead2(2)
+    //    \           /
+    //     Bead3(3)
+
+    let mut beads = Vec::new();
+    let mut parent_relationships = HashMap::new();
+
+    // Create 4 beads for diamond structure
+    for _i in 0..4 {
+        beads.push(emit_bead());
+    }
+
+    // Set up parent relationships for diamond
+    parent_relationships.insert(0, HashSet::new()); // Genesis
+    parent_relationships.insert(1, HashSet::from([0])); // Bead1 -> Genesis
+    parent_relationships.insert(2, HashSet::from([0])); // Bead2 -> Genesis
+    parent_relationships.insert(3, HashSet::from([1, 2])); // Bead3 -> Bead1, Bead2
+
+    // Collect parent hashes first to avoid borrowing issues
+    let mut parent_hashes: HashMap<usize, Vec<bitcoin::BlockHash>> = HashMap::new();
+    for (index, parents) in &parent_relationships {
+        let mut hashes = Vec::new();
+        for &parent_idx in parents {
+            hashes.push(beads[parent_idx].block_header.block_hash());
+        }
+        parent_hashes.insert(*index, hashes);
+    }
+
+    // Update parent hashes in committed metadata
+    for (index, hashes) in parent_hashes {
+        for hash in hashes {
+            beads[index].committed_metadata.parents.insert(hash);
+        }
+    }
+
+    // Create braid with genesis
+    let genesis_set = HashSet::from([0]);
+    let mut bead_index_mapping = HashMap::new();
+    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+
+    let mut test_braid = Braid {
+        beads: vec![beads[0].clone()],
+        tips: genesis_set.clone(),
+        cohorts: vec![Cohort(genesis_set.clone())],
+        cohort_tips: vec![genesis_set.clone()],
+        orphan_beads: Vec::new(),
+        genesis_beads: genesis_set,
+        bead_index_mapping,
+    };
+
+    // Extend braid with remaining beads
+    for i in 1..4 {
+        test_braid.extend(&beads[i]);
+    }
+
+    // Test 1: Get beads after genesis
+    let genesis_hash = beads[0].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![genesis_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    // Should include all beads after genesis
+    let returned_hashes: HashSet<_> = returned_beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+    assert!(returned_hashes.contains(&beads[1].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[2].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+
+    // Test 2: Get beads after both middle beads (should return bead3)
+    let bead1_hash = beads[1].block_header.block_hash();
+    let bead2_hash = beads[2].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![bead1_hash, bead2_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    let returned_hashes: HashSet<_> = returned_beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+
+    println!("✅ Diamond structure tests passed");
+}
+
+#[test]
+fn test_get_beads_after_complex_braid() {
+    // Test Case 3: More complex braid structure
+    //     Genesis(0)
+    //    /     |     \
+    //   B1(1)  B2(2)  B3(3)
+    //   |      |      |
+    //   B4(4)  B5(5)  B6(6)
+    //    \     |     /
+    //      B7(7)
+
+    let mut beads = Vec::new();
+    let mut parent_relationships = HashMap::new();
+
+    // Create 8 beads
+    for _i in 0..8 {
+        beads.push(emit_bead());
+    }
+
+    // Set up parent relationships
+    parent_relationships.insert(0, HashSet::new()); // Genesis
+    parent_relationships.insert(1, HashSet::from([0])); // B1 -> Genesis
+    parent_relationships.insert(2, HashSet::from([0])); // B2 -> Genesis
+    parent_relationships.insert(3, HashSet::from([0])); // B3 -> Genesis
+    parent_relationships.insert(4, HashSet::from([1])); // B4 -> B1
+    parent_relationships.insert(5, HashSet::from([2])); // B5 -> B2
+    parent_relationships.insert(6, HashSet::from([3])); // B6 -> B3
+    parent_relationships.insert(7, HashSet::from([4, 5, 6])); // B7 -> B4, B5, B6
+
+    // Collect parent hashes first to avoid borrowing issues
+    let mut parent_hashes: HashMap<usize, Vec<bitcoin::BlockHash>> = HashMap::new();
+    for (index, parents) in &parent_relationships {
+        let mut hashes = Vec::new();
+        for &parent_idx in parents {
+            hashes.push(beads[parent_idx].block_header.block_hash());
+        }
+        parent_hashes.insert(*index, hashes);
+    }
+
+    // Update parent hashes in committed metadata
+    for (index, hashes) in parent_hashes {
+        for hash in hashes {
+            beads[index].committed_metadata.parents.insert(hash);
+        }
+    }
+
+    // Create braid with genesis
+    let genesis_set = HashSet::from([0]);
+    let mut bead_index_mapping = HashMap::new();
+    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+
+    let mut test_braid = Braid {
+        beads: vec![beads[0].clone()],
+        tips: genesis_set.clone(),
+        cohorts: vec![Cohort(genesis_set.clone())],
+        cohort_tips: vec![genesis_set.clone()],
+        orphan_beads: Vec::new(),
+        genesis_beads: genesis_set,
+        bead_index_mapping,
+    };
+
+    // Extend braid with remaining beads
+    for i in 1..8 {
+        test_braid.extend(&beads[i]);
+    }
+
+    // Test 1: Get beads after genesis (should return all other beads)
+    let genesis_hash = beads[0].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![genesis_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+    assert!(
+        returned_beads.len() >= 7,
+        "Should return at least 7 beads after genesis"
+    );
+
+    // Test 2: Get beads after first cohort (B1, B2, B3)
+    let b1_hash = beads[1].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![b1_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    let returned_hashes: HashSet<_> = returned_beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+
+    // Should include beads from the cohort containing B1 onwards
+    assert!(
+        returned_hashes.contains(&beads[4].block_header.block_hash())
+            || returned_hashes.contains(&beads[5].block_header.block_hash())
+            || returned_hashes.contains(&beads[6].block_header.block_hash())
+            || returned_hashes.contains(&beads[7].block_header.block_hash())
+    );
+
+    // Test 3: Get beads after multiple tips from second level
+    let b4_hash = beads[4].block_header.block_hash();
+    let b5_hash = beads[5].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![b4_hash, b5_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    let returned_hashes: HashSet<_> = returned_beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+    assert!(returned_hashes.contains(&beads[7].block_header.block_hash()));
+
+    println!("✅ Complex braid tests passed");
+}
+
+#[test]
+fn test_get_beads_after_edge_cases() {
+    // Test Case 4: Edge cases
+
+    // Create a simple braid for edge case testing
+    let mut beads = Vec::new();
+    for _i in 0..3 {
+        beads.push(emit_bead());
+    }
+
+    // Simple chain: Genesis -> Bead1 -> Bead2
+    // Collect parent hashes first to avoid borrowing issues
+    let parent0_hash = beads[0].block_header.block_hash();
+    let parent1_hash = beads[1].block_header.block_hash();
+    beads[1].committed_metadata.parents.insert(parent0_hash);
+    beads[2].committed_metadata.parents.insert(parent1_hash);
+
+    let genesis_set = HashSet::from([0]);
+    let mut bead_index_mapping = HashMap::new();
+    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+
+    let mut test_braid = Braid {
+        beads: vec![beads[0].clone()],
+        tips: genesis_set.clone(),
+        cohorts: vec![Cohort(genesis_set.clone())],
+        cohort_tips: vec![genesis_set.clone()],
+        orphan_beads: Vec::new(),
+        genesis_beads: genesis_set,
+        bead_index_mapping,
+    };
+
+    test_braid.extend(&beads[1]);
+    test_braid.extend(&beads[2]);
+
+    // Test 1: Empty input vector
+    let _result = test_braid.get_beads_after(vec![]);
+    // Function should handle empty input gracefully
+
+    // Test 2: Non-existent hash
+    let fake_hash =
+        BeadHash::from_str("0000000000000000000000000000000000000000000000000000000000000001")
+            .unwrap();
+    let _result = test_braid.get_beads_after(vec![fake_hash]);
+    // Should handle non-existent hash gracefully
+
+    // Test 3: Mix of valid and invalid hashes
+    let genesis_hash = beads[0].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![genesis_hash, fake_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    // Should still work with valid hash and ignore invalid one
+    let returned_hashes: HashSet<_> = returned_beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+    assert!(
+        returned_hashes.contains(&beads[1].block_header.block_hash())
+            || returned_hashes.contains(&beads[2].block_header.block_hash())
+    );
+
+    // Test 4: Get beads after the tip (last bead)
+    let tip_hash = beads[2].block_header.block_hash();
+    let result = test_braid.get_beads_after(vec![tip_hash]);
+    assert!(result.is_some());
+    // Should return at least the tip bead itself or beads from its cohort
+}
+
+#[test]
+fn test_get_beads_after_multiple_tips() {
+    // Test Case 5: Multiple tips scenario
+    // Test with multiple valid tips to ensure function finds smallest index correctly
+
+    let mut beads = Vec::new();
+    for _i in 0..6 {
+        beads.push(emit_bead());
+    }
+
+    // Create a structure:
+    //   Genesis(0)
+    //   /        \
+    //  B1(1)    B2(2)
+    //  |        |
+    //  B3(3)    B4(4)
+    //           |
+    //           B5(5)
+
+    let mut parent_relationships = HashMap::new();
+    parent_relationships.insert(0, HashSet::new());
+    parent_relationships.insert(1, HashSet::from([0]));
+    parent_relationships.insert(2, HashSet::from([0]));
+    parent_relationships.insert(3, HashSet::from([1]));
+    parent_relationships.insert(4, HashSet::from([2]));
+    parent_relationships.insert(5, HashSet::from([4]));
+
+    // Collect parent hashes first to avoid borrowing issues
+    let mut parent_hashes: HashMap<usize, Vec<bitcoin::BlockHash>> = HashMap::new();
+    for (index, parents) in &parent_relationships {
+        let mut hashes = Vec::new();
+        for &parent_idx in parents {
+            hashes.push(beads[parent_idx].block_header.block_hash());
+        }
+        parent_hashes.insert(*index, hashes);
+    }
+
+    // Update parent hashes in committed metadata
+    for (index, hashes) in parent_hashes {
+        for hash in hashes {
+            beads[index].committed_metadata.parents.insert(hash);
+        }
+    }
+
+    // Create and build braid
+    let genesis_set = HashSet::from([0]);
+    let mut bead_index_mapping = HashMap::new();
+    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+
+    let mut test_braid = Braid {
+        beads: vec![beads[0].clone()],
+        tips: genesis_set.clone(),
+        cohorts: vec![Cohort(genesis_set.clone())],
+        cohort_tips: vec![genesis_set.clone()],
+        orphan_beads: Vec::new(),
+        genesis_beads: genesis_set,
+        bead_index_mapping,
+    };
+
+    for i in 1..6 {
+        test_braid.extend(&beads[i]);
+    }
+
+    // Test: Get beads after multiple tips with different indices
+    let b3_hash = beads[3].block_header.block_hash(); // Index 3
+    let b5_hash = beads[5].block_header.block_hash(); // Index 5
+
+    let result = test_braid.get_beads_after(vec![b3_hash, b5_hash]);
+    assert!(result.is_some());
+    let returned_beads = result.unwrap();
+
+    // Should start from the cohort containing the smallest index (B3 at index 3)
+    // and return beads from that cohort onwards
+    assert!(!returned_beads.is_empty(), "Should return some beads");
+
+    // Test with tips in reverse order (larger index first)
+    let result2 = test_braid.get_beads_after(vec![b5_hash, b3_hash]);
+    assert!(result2.is_some());
+    let returned_beads2 = result2.unwrap();
+
+    // Should return the same result regardless of order
+    assert_eq!(
+        returned_beads.len(),
+        returned_beads2.len(),
+        "Order of input tips should not affect result"
+    );
+}

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -15,10 +15,12 @@ use crate::braid::consensus_functions::updating_ancestors;
 use crate::braid::Cohort;
 use crate::utils::test_utils::test_utility_functions::loading_braid_from_file;
 use crate::utils::test_utils::test_utility_functions::*;
+use bitcoin::BlockHash;
 use num::BigUint;
 use std::collections::HashMap;
 use std::collections::HashSet;
 use std::path::Path;
+use std::str::FromStr;
 #[test]
 pub fn test_extend_functionality() {
     // Create a braid with one bead.
@@ -1544,7 +1546,7 @@ fn test_get_beads_after() {
     let result = test_braid.get_beads_after(vec![last_hash]);
     assert!(result.is_some());
 
-    println!("✅ Linear chain tests passed");
+    println!("Linear chain tests passed");
 }
 
 #[test]
@@ -1635,7 +1637,7 @@ fn test_get_beads_after_diamond_structure() {
         .collect();
     assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
 
-    println!("✅ Diamond structure tests passed");
+    println!("Diamond structure tests passed");
 }
 
 #[test]
@@ -1746,13 +1748,13 @@ fn test_get_beads_after_complex_braid() {
         .collect();
     assert!(returned_hashes.contains(&beads[7].block_header.block_hash()));
 
-    println!("✅ Complex braid tests passed");
+    println!("Complex braid tests passed");
 }
 
 #[test]
 fn test_get_beads_after_edge_cases() {
     // Test Case 4: Edge cases
-
+    pub type BeadHash = BlockHash;
     // Create a simple braid for edge case testing
     let mut beads = Vec::new();
     for _i in 0..3 {

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -1544,7 +1544,7 @@ fn test_get_beads_after() {
     // Test 3: Get beads after the last bead (should return empty or just that bead)
     let last_hash = beads[3].block_header.block_hash();
     let result = test_braid.get_beads_after(vec![last_hash]);
-    assert!(result.is_some());
+    assert!(result.is_none());
 
     println!("Linear chain tests passed");
 }
@@ -1815,7 +1815,7 @@ fn test_get_beads_after_edge_cases() {
     // Test 4: Get beads after the tip (last bead)
     let tip_hash = beads[2].block_header.block_hash();
     let result = test_braid.get_beads_after(vec![tip_hash]);
-    assert!(result.is_some());
+    assert!(result.is_none());
     // Should return at least the tip bead itself or beads from its cohort
 }
 

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -2,9 +2,9 @@
 use crate::braid::consensus_functions;
 use crate::{
     bead::Bead,
-    braid::Braid,
     db::{init_db::init_db, BraidpoolDBTypes, InsertTupleTypes},
     error::DBErrors,
+    utils::BeadHash,
 };
 use bitcoin::{
     absolute::MedianTimePast, ecdsa::Signature, BlockHash, BlockTime, BlockVersion, CompactTarget,
@@ -14,14 +14,9 @@ use futures::lock::Mutex;
 use num::ToPrimitive;
 use serde_json::json;
 use sqlx::{Pool, Row, Sqlite};
-use std::{
-    collections::{HashMap, HashSet},
-    sync::Arc,
-};
-use tokio::sync::{
-    mpsc::{Receiver, Sender},
-    RwLock,
-};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::mpsc::{Receiver, Sender};
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 const DB_CHANNEL_CAPACITY: usize = 1024;
@@ -57,12 +52,9 @@ pub struct DBHandler {
     receiver: Receiver<BraidpoolDBTypes>,
     //Shared across tasks for accessing DB after contention using `Mutex`
     pub db_connection_pool: Arc<Mutex<Pool<Sqlite>>>,
-    local_braid_arc: Arc<RwLock<Braid>>,
 }
 impl DBHandler {
-    pub async fn new(
-        local_braid_arc: Arc<RwLock<Braid>>,
-    ) -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
+    pub async fn new() -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
         debug!("Initializing schema for persistent database");
         let connection = match init_db().await {
             Ok(conn) => conn,
@@ -78,7 +70,6 @@ impl DBHandler {
             Self {
                 receiver: db_handler_rx,
                 db_connection_pool: Arc::new(Mutex::new(connection)),
-                local_braid_arc: local_braid_arc,
             },
             db_handler_tx,
         ))
@@ -141,8 +132,11 @@ impl DBHandler {
             error!(error = ?e, "Transaction failed, rolling back");
             match conn.rollback().await {
                 Ok(_) => {
-                    info!("Transaction rollbacked successfully");
-                    return Ok(());
+                    info!("Transaction rollbacked successfully and not committed");
+                    return Err(DBErrors::InsertionTransactionNotCommitted {
+                        error: e.to_string(),
+                        query_name: "Combined insert transaction".to_string(),
+                    });
                 }
                 Err(error) => {
                     error!(error = ?error, "Failed to rollback transaction");
@@ -155,7 +149,7 @@ impl DBHandler {
         }
         match conn.commit().await {
             Ok(_) => {
-                debug!("Transaction committed successfully");
+                debug!("Transaction committed and not rolledback successfully");
             }
             Err(error) => {
                 error!(error = ?error, "Failed to commit transaction");
@@ -173,87 +167,13 @@ impl DBHandler {
         while let Some(query_request) = self.receiver.recv().await {
             match query_request {
                 BraidpoolDBTypes::InsertTupleTypes { query } => match query {
-                    InsertTupleTypes::InsertBeadSequentially { bead_to_insert } => {
-                        let braid_data = self.local_braid_arc.read().await;
-                        let mut braid_parent_set: HashMap<usize, HashSet<usize>> = HashMap::new();
-                        //Constructing the parent set
-                        for bead in braid_data.beads.iter().enumerate() {
-                            let parent_beads = &bead.1.committed_metadata.parents;
-                            braid_parent_set.insert(bead.0, HashSet::new());
-                            for parent_bead_hash in parent_beads.iter() {
-                                let current_parent_bead_index = braid_data
-                                    .bead_index_mapping
-                                    .get(&*parent_bead_hash)
-                                    .unwrap();
-                                if let Some(value) = braid_parent_set.get_mut(&bead.0) {
-                                    value.insert(*current_parent_bead_index);
-                                }
-                            }
-                        }
-                        //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                        let bead_id = braid_data
-                            .bead_index_mapping
-                            .get(&bead_to_insert.block_header.block_hash())
-                            .unwrap();
-                        let current_bead_parent_set = braid_parent_set.get(&(bead_id)).unwrap();
-
-                        let mut relative_tuples: Vec<(u64, u64)> = Vec::new();
-                        let mut parent_timestamp_tuples: Vec<(u64, u64, u64)> = Vec::new();
-                        let mut transaction_tuples: Vec<(u64, String)> = Vec::new();
-                        //Constructing relatives and parent_timestamps
-                        for parent_bead in current_bead_parent_set {
-                            relative_tuples.push(((*parent_bead as u64), (*bead_id as u64)));
-                            let current_parent_timestamp = braid_data
-                                .beads
-                                .get(*parent_bead)
-                                .unwrap()
-                                .committed_metadata
-                                .start_timestamp;
-                            parent_timestamp_tuples.push((
-                                (*parent_bead as u64),
-                                (*bead_id as u64),
-                                current_parent_timestamp.to_u32().to_u64().unwrap(),
-                            ));
-                        }
-                        for bead_tx in bead_to_insert.committed_metadata.transaction_ids.0.iter() {
-                            transaction_tuples
-                                .push(((*bead_id as u64), hex::encode(bead_tx.to_byte_array())));
-                        }
-                        //Constructing json bindings
-                        let transactions_values = transaction_tuples
-                            .iter()
-                            .map(|t| {
-                                json!({
-                                    "txid":t.1,
-                                    "bead_id":t.0
-                                })
-                            })
-                            .collect::<Vec<_>>();
-                        let parent_timestamps_values = parent_timestamp_tuples
-                            .iter()
-                            .map(|p| {
-                                json!({
-                                    "child":p.1,
-                                    "parent":p.0,
-                                    "timestamp":p.2
-                                })
-                            })
-                            .collect::<Vec<_>>();
-
-                        let relatives_values = relative_tuples
-                            .iter()
-                            .map(|r| {
-                                json!({
-                                    "parent":r.0,
-                                    "child":r.1
-                                })
-                            })
-                            .collect::<Vec<_>>();
-                        let txs_json = serde_json::to_string(&transactions_values).unwrap();
-                        let relative_json = serde_json::to_string(&relatives_values).unwrap();
-                        let parent_timestamp_json =
-                            serde_json::to_string(&parent_timestamps_values).unwrap();
-
+                    InsertTupleTypes::InsertBeadSequentially {
+                        bead_to_insert,
+                        txs_json,
+                        relative_json,
+                        parent_timestamp_json,
+                        bead_id,
+                    } => {
                         let bead_hash = bead_to_insert.block_header.block_hash();
                         match self
                             .insert_bead(
@@ -261,12 +181,12 @@ impl DBHandler {
                                 txs_json,
                                 relative_json,
                                 parent_timestamp_json,
-                                bead_id,
+                                &bead_id,
                             )
                             .await
                         {
                             Ok(_) => {
-                                info!(
+                                debug!(
                                     bead_id = bead_id,
                                     bead_hash = %bead_hash,
                                     "Bead inserted successfully"
@@ -287,6 +207,69 @@ impl DBHandler {
             }
         }
     }
+}
+pub fn prepare_bead_tuple_data(
+    beads: &Vec<Bead>,
+    bead_index_mapping: &HashMap<BeadHash, usize>,
+    bead: &Bead,
+) -> anyhow::Result<(String, String, String)> {
+    let mut parent_set: HashMap<usize, HashSet<usize>> = HashMap::new();
+
+    for (idx, b) in beads.iter().enumerate() {
+        let mut set = HashSet::new();
+        for p in &b.committed_metadata.parents {
+            let parent_idx = *bead_index_mapping.get(p).unwrap();
+            set.insert(parent_idx);
+        }
+        parent_set.insert(idx, set);
+    }
+
+    let bead_id = *bead_index_mapping
+        .get(&bead.block_header.block_hash())
+        .unwrap();
+    let current_parents = parent_set.get(&bead_id).cloned().unwrap_or_default();
+
+    let mut relatives = Vec::new();
+    let mut parent_ts = Vec::new();
+    let mut txs = Vec::new();
+
+    for parent in current_parents {
+        let ts = beads[parent]
+            .committed_metadata
+            .start_timestamp
+            .to_u32()
+            .to_u64()
+            .expect("An error occurred while casting u32 to u64");
+
+        relatives.push((parent as u64, bead_id as u64));
+        parent_ts.push((parent as u64, bead_id as u64, ts));
+    }
+
+    for tx in &bead.committed_metadata.transaction_ids.0 {
+        txs.push((bead_id as u64, hex::encode(tx.to_byte_array())));
+    }
+
+    let txs_json = serde_json::to_string(
+        &txs.iter()
+            .map(|t| json!({ "txid": t.1, "bead_id": t.0 }))
+            .collect::<Vec<_>>(),
+    )?;
+
+    let relatives_json = serde_json::to_string(
+        &relatives
+            .iter()
+            .map(|r| json!({ "parent": r.0, "child": r.1 }))
+            .collect::<Vec<_>>(),
+    )?;
+
+    let parent_ts_json = serde_json::to_string(
+        &parent_ts
+            .iter()
+            .map(|p| json!({ "child": p.1, "parent": p.0, "timestamp": p.2 }))
+            .collect::<Vec<_>>(),
+    )?;
+
+    Ok((txs_json, relatives_json, parent_ts_json))
 }
 //Fetching beads in batch
 pub async fn fetch_beads_in_batch(

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -1,6 +1,8 @@
+#[cfg(test)]
+use crate::braid::consensus_functions;
 use crate::{
     bead::Bead,
-    braid::{consensus_functions, Braid},
+    braid::Braid,
     db::{init_db::init_db, BraidpoolDBTypes, InsertTupleTypes},
     error::DBErrors,
 };
@@ -88,7 +90,6 @@ impl DBHandler {
         txs_json: String,
         relative_json: String,
         parent_timestamp_json: String,
-        _ancestor_mapping: &HashMap<usize, HashSet<usize>>,
         bead_id: &usize,
     ) -> Result<(), DBErrors> {
         trace!("Sequential insertion query received");
@@ -102,7 +103,15 @@ impl DBHandler {
         let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
         let public_key_bytes = bead.committed_metadata.comm_pub_key.to_vec();
         let signature_bytes = bead.uncommitted_metadata.signature.to_vec();
-        let mut conn = self.db_connection_pool.lock().await.begin().await.unwrap();
+        let mut conn = match self.db_connection_pool.lock().await.begin().await {
+            Ok(conn) => conn,
+            Err(err) => {
+                error!("Failed to begin DB transaction: {}", err);
+                return Err(DBErrors::ConnectionToSQlitePoolFailed {
+                    error: err.to_string(),
+                });
+            }
+        };
         //All fields are in be format
         if let Err(e) = sqlx::query(&INSERT_QUERY)
             .bind(*bead_id as i64)
@@ -181,14 +190,6 @@ impl DBHandler {
                                 }
                             }
                         }
-                        //Constructing ancestor set, children set will be empty as it will become the next tip
-                        let mut ancestor_mapping: HashMap<usize, HashSet<usize>> = HashMap::new();
-                        consensus_functions::updating_ancestors(
-                            &braid_data,
-                            bead_to_insert.block_header.block_hash(),
-                            &mut ancestor_mapping,
-                            &braid_parent_set,
-                        );
                         //Considering the index of the beads in braid will be same as the (insertion ids-1)
                         let bead_id = braid_data
                             .bead_index_mapping
@@ -260,7 +261,6 @@ impl DBHandler {
                                 txs_json,
                                 relative_json,
                                 parent_timestamp_json,
-                                &ancestor_mapping,
                                 bead_id,
                             )
                             .await

--- a/node/src/db/mod.rs
+++ b/node/src/db/mod.rs
@@ -1,5 +1,4 @@
 #![allow(non_snake_case)]
-
 use crate::bead::Bead;
 pub mod db_handlers;
 pub mod init_db;
@@ -7,7 +6,13 @@ pub mod init_db;
 #[derive(Debug, Clone)]
 
 pub enum InsertTupleTypes {
-    InsertBeadSequentially { bead_to_insert: Bead },
+    InsertBeadSequentially {
+        bead_to_insert: Bead,
+        txs_json: String,
+        relative_json: String,
+        parent_timestamp_json: String,
+        bead_id: usize,
+    },
 }
 #[derive(Debug, Clone)]
 pub enum BraidpoolDBTypes {

--- a/node/src/ibd_manager/mod.rs
+++ b/node/src/ibd_manager/mod.rs
@@ -6,6 +6,7 @@ pub const IBD_BATCH_SIZE: usize = 100;
 
 //Storing tips mapping received from peers during `GetTips`
 //that will be flushed out after IBD is done hence no complete dependency
+#[derive(Debug)]
 pub enum IBDCommands {
     //Updating tips received from various sync peers that will act as the stopping window for IBD
     UpdateIBDTipsCache {
@@ -28,7 +29,7 @@ pub enum IBDCommands {
         peer_id: String,
         tips_sender: tokio::sync::oneshot::Sender<Vec<BeadHash>>,
     },
-    //
+    //Fetching cached beadshashes received during GetBeads
     FetchGetBeadCache {
         peer_id: String,
         beadhash_sender: tokio::sync::oneshot::Sender<Vec<BeadHash>>,
@@ -71,7 +72,7 @@ impl IBDManager {
                             }
                             Err(error) => {
                                 tracing::error!(
-                                error=?error, "Error while updating and sending it to request channel due to - "
+                                error=?error, "Error while updating and sending it to request channel"
                                 );
                             }
                         };
@@ -83,7 +84,7 @@ impl IBDManager {
                             }
                             Err(error) => {
                                 tracing::error!(
-                                    error,"Error while intiating batch offset and sending it to request channel due to - "
+                                    error,"Error while initiating batch offset and sending it to request channel"
                                 );
                             }
                         }

--- a/node/src/ibd_manager/mod.rs
+++ b/node/src/ibd_manager/mod.rs
@@ -1,0 +1,139 @@
+use std::collections::HashMap;
+
+use crate::utils::BeadHash;
+//Beads fetching will be done with batch size
+pub const IBD_BATCH_SIZE: usize = 100;
+
+//Storing tips mapping received from peers during `GetTips`
+//that will be flushed out after IBD is done hence no complete dependency
+pub enum IBDCommands {
+    //Updating tips received from various sync peers that will act as the stopping window for IBD
+    UpdateIBDTipsCache {
+        received_tips: Vec<BeadHash>,
+        peer_id: String,
+    },
+    //Caching the received beadhashes received during `GetBead` request which will be used to fetch and extend beads in batches via `GetBead`
+    UpdateIBDGetBeadCache {
+        get_bead_response: Vec<BeadHash>,
+        peer_id: String,
+    },
+    //Update the batch offset and fetch newer batch offset window will become [offset*batchsize,(offset*batchsize)+batchsize]
+    UpdateAndFetchBatchOffset {
+        peer_id: String,
+        offset_sender: tokio::sync::oneshot::Sender<usize>,
+        batch_size: usize,
+    },
+    //Fetching the cached Tips
+    FetchCachedTips {
+        peer_id: String,
+        tips_sender: tokio::sync::oneshot::Sender<Vec<BeadHash>>,
+    },
+    //
+    FetchGetBeadCache {
+        peer_id: String,
+        beadhash_sender: tokio::sync::oneshot::Sender<Vec<BeadHash>>,
+    },
+}
+pub struct IBDManager {
+    tips_mapping: HashMap<String, Vec<BeadHash>>,
+    batch_mapping: HashMap<String, usize>,
+    get_bead_mapping: HashMap<String, Vec<BeadHash>>,
+    command_receiver: tokio::sync::mpsc::Receiver<IBDCommands>,
+}
+impl IBDManager {
+    pub fn new() -> (Self, tokio::sync::mpsc::Sender<IBDCommands>) {
+        let (ibd_tx, ibd_rx) = tokio::sync::mpsc::channel::<IBDCommands>(1024);
+        (
+            Self {
+                tips_mapping: HashMap::new(),
+                batch_mapping: HashMap::new(),
+                get_bead_mapping: HashMap::new(),
+                command_receiver: ibd_rx,
+            },
+            ibd_tx,
+        )
+    }
+    pub async fn handle_ibd_command(&mut self) {
+        while let Some(ibd_command) = self.command_receiver.recv().await {
+            match ibd_command {
+                IBDCommands::UpdateAndFetchBatchOffset {
+                    peer_id,
+                    offset_sender,
+                    batch_size,
+                } => {
+                    if let Some(current_offset) = self.batch_mapping.get_mut(&peer_id) {
+                        match offset_sender.send(*current_offset) {
+                            Ok(_) => {
+                                tracing::info!(
+                                    "Sending newer offset and updating the current offset"
+                                );
+                                *current_offset = *current_offset + batch_size;
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                error=?error, "Error while updating and sending it to request channel due to - "
+                                );
+                            }
+                        };
+                    } else {
+                        self.batch_mapping.insert(peer_id, IBD_BATCH_SIZE);
+                        match offset_sender.send(IBD_BATCH_SIZE) {
+                            Ok(_) => {
+                                tracing::info!("Sent newly initialized offset to request channel");
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    error,"Error while intiating batch offset and sending it to request channel due to - "
+                                );
+                            }
+                        }
+                    }
+                }
+                IBDCommands::UpdateIBDGetBeadCache {
+                    get_bead_response,
+                    peer_id,
+                } => {
+                    self.get_bead_mapping.insert(peer_id, get_bead_response);
+                }
+                IBDCommands::UpdateIBDTipsCache {
+                    received_tips,
+                    peer_id,
+                } => {
+                    self.tips_mapping.insert(peer_id, received_tips);
+                }
+                IBDCommands::FetchCachedTips {
+                    peer_id,
+                    tips_sender,
+                } => {
+                    if let Some(cached_tips) = self.tips_mapping.get(&peer_id) {
+                        match tips_sender.send(cached_tips.clone()) {
+                            Ok(_) => {
+                                tracing::info!("Cached tips sent successfully to swarm event loop");
+                            }
+                            Err(_error) => {
+                                tracing::error!("Tips not sent");
+                            }
+                        };
+                    };
+                }
+                IBDCommands::FetchGetBeadCache {
+                    peer_id,
+                    beadhash_sender,
+                } => {
+                    if let Some(cached_hashes) = self.get_bead_mapping.get(&peer_id) {
+                        match beadhash_sender.send(cached_hashes.clone()) {
+                            Ok(_) => {
+                                tracing::info!(
+                                    "Cached get bead hashes sent successfully to swarm event loop"
+                                );
+                            }
+                            Err(_error) => {
+                                tracing::error!("Beadhashes not sent");
+                            }
+                        };
+                    };
+                }
+            }
+        }
+    }
+}

--- a/node/src/ibd_manager/mod.rs
+++ b/node/src/ibd_manager/mod.rs
@@ -224,7 +224,15 @@ impl IBDManager {
                             {
                                 //Aborting the previous handle
                                 if let Some(ibd_incoming_handle) = &mapped_tuple.1 {
-                                    ibd_incoming_handle.abort();
+                                    if ibd_incoming_handle.is_finished() {
+                                        tracing::info!("Previous IBD incoming handle for peer {} already finished", peer_id);
+                                    } else {
+                                        ibd_incoming_handle.abort();
+                                        tracing::info!(
+                                            "Aborted previous IBD incoming handle for peer {}",
+                                            peer_id
+                                        );
+                                    }
                                 }
                                 //Updating retry count and setting newer handle to None
                                 *mapped_tuple = (mapped_tuple.0 + 1, None);

--- a/node/src/ibd_manager/mod.rs
+++ b/node/src/ibd_manager/mod.rs
@@ -1,38 +1,59 @@
-use std::collections::HashMap;
+use std::{collections::HashMap, u64};
+
+use libp2p::PeerId;
+use tokio::task::JoinHandle;
 
 use crate::utils::BeadHash;
-//Beads fetching will be done with batch size
-pub const IBD_BATCH_SIZE: usize = 100;
+pub const IBD_BATCH_SIZE: usize = 50;
+pub const MAX_IBD_RETRIES: u64 = 10;
+pub const IBD_TRIGGER_AFTER: u64 = 20;
+pub const MAX_IBD_INCOMING_THRESHOLD: u64 = 20;
 
-//Storing tips mapping received from peers during `GetTips`
-//that will be flushed out after IBD is done hence no complete dependency
 #[derive(Debug)]
 pub enum IBDCommands {
-    //Updating tips received from various sync peers that will act as the stopping window for IBD
-    UpdateIBDTipsCache {
+    UpdateIBDTipsMapping {
         received_tips: Vec<BeadHash>,
         peer_id: String,
     },
-    //Caching the received beadhashes received during `GetBead` request which will be used to fetch and extend beads in batches via `GetBead`
-    UpdateIBDGetBeadCache {
+    UpdateIncoming {
         get_bead_response: Vec<BeadHash>,
         peer_id: String,
     },
-    //Update the batch offset and fetch newer batch offset window will become [offset*batchsize,(offset*batchsize)+batchsize]
     UpdateAndFetchBatchOffset {
         peer_id: String,
         offset_sender: tokio::sync::oneshot::Sender<usize>,
         batch_size: usize,
     },
-    //Fetching the cached Tips
     FetchCachedTips {
         peer_id: String,
         tips_sender: tokio::sync::oneshot::Sender<Vec<BeadHash>>,
     },
-    //Fetching cached beadshashes received during GetBeads
-    FetchGetBeadCache {
+    FetchGetBeadMapping {
         peer_id: String,
         beadhash_sender: tokio::sync::oneshot::Sender<Vec<BeadHash>>,
+    },
+    UpdateTimestampMapping {
+        peer_id: String,
+        end_timestamp: u64,
+    },
+    FetchTimestamp {
+        peer_id: String,
+        timestamp_sender: tokio::sync::oneshot::Sender<u64>,
+    },
+    FetchAllTimestamps {
+        sender: tokio::sync::oneshot::Sender<HashMap<String, u64>>,
+    },
+    UpdateIncomingBeadMapping {
+        peer_id: PeerId,
+        handle: Option<JoinHandle<()>>,
+        retry_or_not: bool,
+    },
+    GetIncomingBeadRetryCount {
+        peer_id: PeerId,
+        retry_sender: tokio::sync::oneshot::Sender<u64>,
+    },
+    AbortWaitHandle {
+        peer_id: PeerId,
     },
 }
 pub struct IBDManager {
@@ -40,6 +61,9 @@ pub struct IBDManager {
     batch_mapping: HashMap<String, usize>,
     get_bead_mapping: HashMap<String, Vec<BeadHash>>,
     command_receiver: tokio::sync::mpsc::Receiver<IBDCommands>,
+    timestamp_mapping: HashMap<String, u64>,
+    //(PeerId ---->(retries done wrt to given sync peer,thread_handler))
+    incoming_bead_mapping: HashMap<PeerId, (u64, Option<JoinHandle<()>>)>,
 }
 impl IBDManager {
     pub fn new() -> (Self, tokio::sync::mpsc::Sender<IBDCommands>) {
@@ -50,6 +74,8 @@ impl IBDManager {
                 batch_mapping: HashMap::new(),
                 get_bead_mapping: HashMap::new(),
                 command_receiver: ibd_rx,
+                timestamp_mapping: HashMap::new(),
+                incoming_bead_mapping: HashMap::new(),
             },
             ibd_tx,
         )
@@ -84,19 +110,19 @@ impl IBDManager {
                             }
                             Err(error) => {
                                 tracing::error!(
-                                    error,"Error while initiating batch offset and sending it to request channel"
+                                    error=?error,"Error while initiating batch offset and sending it to request channel"
                                 );
                             }
                         }
                     }
                 }
-                IBDCommands::UpdateIBDGetBeadCache {
+                IBDCommands::UpdateIncoming {
                     get_bead_response,
                     peer_id,
                 } => {
                     self.get_bead_mapping.insert(peer_id, get_bead_response);
                 }
-                IBDCommands::UpdateIBDTipsCache {
+                IBDCommands::UpdateIBDTipsMapping {
                     received_tips,
                     peer_id,
                 } => {
@@ -111,13 +137,13 @@ impl IBDManager {
                             Ok(_) => {
                                 tracing::info!("Cached tips sent successfully to swarm event loop");
                             }
-                            Err(_error) => {
-                                tracing::error!("Tips not sent");
+                            Err(error) => {
+                                tracing::error!(error=?error,"Tips not sent");
                             }
                         };
                     };
                 }
-                IBDCommands::FetchGetBeadCache {
+                IBDCommands::FetchGetBeadMapping {
                     peer_id,
                     beadhash_sender,
                 } => {
@@ -128,10 +154,112 @@ impl IBDManager {
                                     "Cached get bead hashes sent successfully to swarm event loop"
                                 );
                             }
-                            Err(_error) => {
-                                tracing::error!("Beadhashes not sent");
+                            Err(error) => {
+                                tracing::error!(error=?error,"Beadhashes not sent");
                             }
                         };
+                    };
+                }
+                IBDCommands::UpdateTimestampMapping {
+                    peer_id,
+                    end_timestamp,
+                } => {
+                    if self.timestamp_mapping.contains_key(&peer_id) {
+                        if let Some(prev_timestamp) = self.timestamp_mapping.get(&peer_id) {
+                            if *prev_timestamp == end_timestamp {
+                                tracing::info!("Timestamp already exists");
+                            } else {
+                                //It is a retry request for IBD can be caused due to failure in any of the case
+                                //hence timestamp must be updated
+                                self.timestamp_mapping.insert(peer_id, end_timestamp);
+                            }
+                        };
+                    } else {
+                        tracing::info!("Timestamp received after receiving last batch of beads requested by peer from sync node");
+                        self.timestamp_mapping.insert(peer_id, end_timestamp);
+                    }
+                }
+                IBDCommands::FetchTimestamp {
+                    peer_id,
+                    timestamp_sender,
+                } => {
+                    if let Some(current_ts) = self.timestamp_mapping.get(&peer_id) {
+                        match timestamp_sender.send(*current_ts) {
+                            Ok(_) => {
+                                tracing::info!("Fetched existing timestamp for peer");
+                            }
+                            Err(error) => {
+                                tracing::error!(
+                                    error=?error,
+                                    "Error while sending existing timestamp to request channel"
+                                );
+                            }
+                        }
+                    } else {
+                        tracing::error!("No timestamp found corresponding to the peer id");
+                    }
+                }
+                IBDCommands::FetchAllTimestamps { sender } => {
+                    let timestamps_clone = self.timestamp_mapping.clone();
+                    match sender.send(timestamps_clone) {
+                        Ok(_) => {
+                            tracing::info!("Sent entire timestamp mapping to requester");
+                        }
+                        Err(error) => {
+                            tracing::error!(
+                                error=?error,
+                                "Error while sending timestamp mapping to requester"
+                            );
+                        }
+                    }
+                }
+                IBDCommands::UpdateIncomingBeadMapping {
+                    peer_id,
+                    handle,
+                    retry_or_not,
+                } => {
+                    if self.incoming_bead_mapping.contains_key(&peer_id) {
+                        if retry_or_not {
+                            if let Some(mapped_tuple) = self.incoming_bead_mapping.get_mut(&peer_id)
+                            {
+                                //Aborting the previous handle
+                                if let Some(ibd_incoming_handle) = &mapped_tuple.1 {
+                                    ibd_incoming_handle.abort();
+                                }
+                                //Updating retry count and setting newer handle to None
+                                *mapped_tuple = (mapped_tuple.0 + 1, None);
+                            }
+                        } else {
+                            //If it is not a retry then we can use the previously stored value
+                            if let Some(mapped_tuple) = self.incoming_bead_mapping.get_mut(&peer_id)
+                            {
+                                *mapped_tuple = (mapped_tuple.0, handle);
+                            }
+                        }
+                    } else {
+                        self.incoming_bead_mapping.insert(peer_id, (0, None));
+                    }
+                }
+                IBDCommands::GetIncomingBeadRetryCount {
+                    peer_id,
+                    retry_sender,
+                } => {
+                    let retries = self
+                        .incoming_bead_mapping
+                        .get(&peer_id)
+                        .map(|entry| entry.0)
+                        .unwrap_or(u64::MAX);
+
+                    let _ = retry_sender.send(retries);
+
+                    tracing::debug!("Fetched retry count for peer {} -> {}", peer_id, retries);
+                }
+                IBDCommands::AbortWaitHandle { peer_id } => {
+                    if let Some(incoming_mapping) = self.incoming_bead_mapping.get_mut(&peer_id) {
+                        if let Some(ibd_wait_handle) = &incoming_mapping.1 {
+                            ibd_wait_handle.abort();
+                        }
+                        incoming_mapping.1 = None;
                     };
                 }
             }

--- a/node/src/ibd_manager/mod.rs
+++ b/node/src/ibd_manager/mod.rs
@@ -4,9 +4,10 @@ use libp2p::PeerId;
 use tokio::task::JoinHandle;
 
 use crate::utils::BeadHash;
-pub const IBD_BATCH_SIZE: usize = 50;
+pub const IBD_BATCH_SIZE: usize = 500;
 pub const MAX_IBD_RETRIES: u64 = 10;
 pub const IBD_TRIGGER_AFTER: u64 = 20;
+/// We wait for incoming beads with the range [current_timestamp,current_timestamp + MAX_IBD_INCOMING_THRESHOLD]
 pub const MAX_IBD_INCOMING_THRESHOLD: u64 = 20;
 
 #[derive(Debug)]
@@ -24,7 +25,7 @@ pub enum IBDCommands {
         offset_sender: tokio::sync::oneshot::Sender<usize>,
         batch_size: usize,
     },
-    FetchCachedTips {
+    FetchTips {
         peer_id: String,
         tips_sender: tokio::sync::oneshot::Sender<Vec<BeadHash>>,
     },
@@ -56,13 +57,50 @@ pub enum IBDCommands {
         peer_id: PeerId,
     },
 }
+/// The `IBDManager` is responsible for coordinating all state and bookkeeping
+/// required during the Initial Block Download (IBD) phase.
+///
+/// It receives asynchronous `IBDCommands` through an internal channel and
+/// maintains multiple internal mappings used to:
+///
+/// - Track per-peer batch offsets for batched bead requests  
+/// - Store tips in memory received from sync peers  
+/// - Store bead in memory responses mapped by peer  
+/// - Track per-peer timestamps for sequencing IBD batches  
+/// - Maintain retry counts and async handles for incoming bead-processing tasks  
+///
+/// The manager runs a dedicated event loop (see `run_ibd_handler`) which
+/// consumes commands and mutates internal state accordingly.
+///
+/// This component is intentionally single-threaded (through the event loop),
+/// ensuring safe mutation of maps without additional synchronization.
 pub struct IBDManager {
+    /// Tracks the most recent tips received from each peer during IBD.
+    /// (peer_id --> Vec<BeadHash>)
     tips_mapping: HashMap<String, Vec<BeadHash>>,
+
+    /// Tracks the current batch offset for each peer when requesting batched beads.
+    /// (peer_id --> current offset)
     batch_mapping: HashMap<String, usize>,
+
+    /// Stores bead hashes obtained by GetBead requests from each peer.
+    /// (peer_id --> Vec<BeadHash>)
     get_bead_mapping: HashMap<String, Vec<BeadHash>>,
+
+    /// The internal channel receiver for all IBD-related commands.
     command_receiver: tokio::sync::mpsc::Receiver<IBDCommands>,
+
+    /// Stores the timestamp associated with the last successfully processed batch
+    /// for each peer.
+    /// (peer_id --> timestamp)
     timestamp_mapping: HashMap<String, u64>,
-    //(PeerId ---->(retries done wrt to given sync peer,thread_handler))
+
+    /// Tracks retry counts and associated join handles for incoming bead
+    /// processing tasks.
+    ///
+    /// (peer_id --> (retry_count, Option<JoinHandle>))
+    ///
+    /// A retry count increments when an incoming bead handler must be restarted.
     incoming_bead_mapping: HashMap<PeerId, (u64, Option<JoinHandle<()>>)>,
 }
 impl IBDManager {
@@ -80,7 +118,7 @@ impl IBDManager {
             ibd_tx,
         )
     }
-    pub async fn handle_ibd_command(&mut self) {
+    pub async fn run_ibd_handler(&mut self) {
         while let Some(ibd_command) = self.command_receiver.recv().await {
             match ibd_command {
                 IBDCommands::UpdateAndFetchBatchOffset {
@@ -128,7 +166,7 @@ impl IBDManager {
                 } => {
                     self.tips_mapping.insert(peer_id, received_tips);
                 }
-                IBDCommands::FetchCachedTips {
+                IBDCommands::FetchTips {
                     peer_id,
                     tips_sender,
                 } => {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -42,6 +42,7 @@ pub mod committed_metadata;
 pub mod config;
 pub mod db;
 pub mod error;
+pub mod ibd_manager;
 pub mod ipc;
 pub mod peer_manager;
 pub mod rpc_server;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -247,6 +247,8 @@ pub async fn ipc_template_consumer(
 }
 pub enum SwarmCommand {
     PropagateValidBead { bead_bytes: Vec<u8> },
+    //Intiate IBD after waiting for connection_mapping to be populated via peer discovery
+    InitiateIBD,
 }
 pub struct SwarmHandler {
     pub command_sender: Sender<SwarmCommand>,

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,4 +1,5 @@
 //These implementations must be defined under lib.rs as they are required for intergration tests
+use crate::db::db_handlers::prepare_bead_tuple_data;
 use bitcoin::{
     consensus::encode::deserialize, ecdsa::Signature, pow::CompactTargetExt, BlockHash,
     CompactTarget, EcdsaSighashType, Txid,
@@ -375,11 +376,27 @@ impl SwarmHandler {
                     "Failed to extend Braid")
             }
         }
+
+        //Considering the index of the beads in braid will be same as the (insertion ids-1)
+        let bead_id = braid_data
+            .bead_index_mapping
+            .get(&weak_share.block_header.block_hash())
+            .unwrap();
+        let (txs_json, relative_json, parent_timestamp_json) = prepare_bead_tuple_data(
+            &braid_data.beads,
+            &braid_data.bead_index_mapping,
+            &weak_share,
+        )
+        .unwrap();
         let _db_insertion_command = match self
             .db_command_sender
             .send(BraidpoolDBTypes::InsertTupleTypes {
                 query: db::InsertTupleTypes::InsertBeadSequentially {
                     bead_to_insert: weak_share.clone(),
+                    txs_json: txs_json,
+                    relative_json: relative_json,
+                    parent_timestamp_json: parent_timestamp_json,
+                    bead_id: *bead_id,
                 },
             })
             .await

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -34,6 +34,8 @@ use crate::{
     uncommitted_metadata::UnCommittedMetadata,
 };
 use std::error::Error;
+#[macro_use]
+pub mod macros;
 pub mod bead;
 pub mod behaviour;
 pub mod braid;
@@ -247,7 +249,7 @@ pub async fn ipc_template_consumer(
 }
 pub enum SwarmCommand {
     PropagateValidBead { bead_bytes: Vec<u8> },
-    //Intiate IBD after waiting for connection_mapping to be populated via peer discovery
+    //Initiate IBD after waiting for connection_mapping to be populated via peer discovery
     InitiateIBD,
 }
 pub struct SwarmHandler {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -370,73 +370,72 @@ impl SwarmHandler {
                     new_tips = ?new_tips,
                     "Braid extended successfully"
                 );
+                //Considering the index of the beads in braid will be same as the (insertion ids-1)
+                let bead_id = braid_data
+                    .bead_index_mapping
+                    .get(&weak_share.block_header.block_hash())
+                    .unwrap();
+                let (txs_json, relative_json, parent_timestamp_json) = prepare_bead_tuple_data(
+                    &braid_data.beads,
+                    &braid_data.bead_index_mapping,
+                    &weak_share,
+                )
+                .unwrap();
+                let _db_insertion_command = match self
+                    .db_command_sender
+                    .send(BraidpoolDBTypes::InsertTupleTypes {
+                        query: db::InsertTupleTypes::InsertBeadSequentially {
+                            bead_to_insert: weak_share.clone(),
+                            txs_json: txs_json,
+                            relative_json: relative_json,
+                            parent_timestamp_json: parent_timestamp_json,
+                            bead_id: *bead_id,
+                        },
+                    })
+                    .await
+                {
+                    Ok(_) => {
+                        debug!(
+                            hash = %weak_share.block_header.block_hash(),
+                            "InsertBeadSequentially sent to DB thread"
+                        );
+                    }
+                    Err(error) => {
+                        error!(error = ?error, "Database insertion command failed");
+                    }
+                };
+                let serialized_weak_share_bytes = bitcoin::consensus::serialize(&weak_share);
+                //After validation of the candidate block constructed by the downstream node sending it to swarm for further propogation
+                match self
+                    .command_sender
+                    .send(SwarmCommand::PropagateValidBead {
+                        bead_bytes: serialized_weak_share_bytes,
+                    })
+                    .await
+                {
+                    Ok(_) => {
+                        info!(
+                            hash = %weak_share.block_header.block_hash(),
+                            "Bead sent to swarm"
+                        );
+                    }
+                    Err(e) => {
+                        error!(
+                            hash = %weak_share.block_header.block_hash(),
+                            error = %e,
+                            "Failed to send candidate block to swarm"
+                        );
+                        return Err(StratumErrors::CandidateBlockNotSent {
+                            error: e.to_string(),
+                        });
+                    }
+                };
             }
             _ => {
                 warn!(status = ?status, hash = %weak_share.block_header.block_hash(),
                     "Failed to extend Braid")
             }
         }
-
-        //Considering the index of the beads in braid will be same as the (insertion ids-1)
-        let bead_id = braid_data
-            .bead_index_mapping
-            .get(&weak_share.block_header.block_hash())
-            .unwrap();
-        let (txs_json, relative_json, parent_timestamp_json) = prepare_bead_tuple_data(
-            &braid_data.beads,
-            &braid_data.bead_index_mapping,
-            &weak_share,
-        )
-        .unwrap();
-        let _db_insertion_command = match self
-            .db_command_sender
-            .send(BraidpoolDBTypes::InsertTupleTypes {
-                query: db::InsertTupleTypes::InsertBeadSequentially {
-                    bead_to_insert: weak_share.clone(),
-                    txs_json: txs_json,
-                    relative_json: relative_json,
-                    parent_timestamp_json: parent_timestamp_json,
-                    bead_id: *bead_id,
-                },
-            })
-            .await
-        {
-            Ok(_) => {
-                debug!(
-                    hash = %weak_share.block_header.block_hash(),
-                    "InsertBeadSequentially sent to DB thread"
-                );
-            }
-            Err(error) => {
-                error!(error = ?error, "Database insertion command failed");
-            }
-        };
-        let serialized_weak_share_bytes = bitcoin::consensus::serialize(&weak_share);
-        //After validation of the candidate block constructed by the downstream node sending it to swarm for further propogation
-        match self
-            .command_sender
-            .send(SwarmCommand::PropagateValidBead {
-                bead_bytes: serialized_weak_share_bytes,
-            })
-            .await
-        {
-            Ok(_) => {
-                info!(
-                    hash = %weak_share.block_header.block_hash(),
-                    "Bead sent to swarm"
-                );
-            }
-            Err(e) => {
-                error!(
-                    hash = %weak_share.block_header.block_hash(),
-                    error = %e,
-                    "Failed to send candidate block to swarm"
-                );
-                return Err(StratumErrors::CandidateBlockNotSent {
-                    error: e.to_string(),
-                });
-            }
-        };
         Ok(())
     }
 }

--- a/node/src/macros.rs
+++ b/node/src/macros.rs
@@ -1,0 +1,483 @@
+//! Macros for generating protocol enums with data-carrying variants
+
+/// Generates protocol enums with automatic consensus encoding/decoding implementations.
+/// Supports both unit variants and data-carrying variants.
+///
+/// This is intended for P2P messages which will be sent over the wire and assists in
+/// creating an enum for a category of requests or responses.
+///
+/// Each generated enum has a `msg_id()` method that returns the discriminant value.
+///
+/// **Syntax:**
+/// ```text
+/// braidpool_protocol! {
+///     pub enum MyProtocol {
+///         FirstMessage            = 0,            // unit variant
+///         SecondMessage(String)   = 1             // data-carrying with type
+///     }
+/// }
+///
+/// // Usage:
+/// let msg = MyProtocol::FirstMessage;
+/// assert_eq!(msg.msg_id(), 0);
+/// ```
+macro_rules! braidpool_protocol {
+    // Entry point - generate full enum with all implementations
+    (
+        $(#[$meta:meta])*
+        pub enum $name:ident {
+            $($variants:tt)*
+        }
+    ) => {
+        braidpool_protocol!(@generate
+            [$(#[$meta])*]
+            $name
+            $($variants)*
+        );
+    };
+
+    // Generate the enum and all implementations
+    (@generate
+        [$($meta:tt)*]
+        $name:ident
+        $($variants:tt)*
+    ) => {
+        $($meta)*
+        #[derive(Clone, Debug, PartialEq)]
+        #[repr(u8)]
+        pub enum $name {
+            $($variants)*
+        }
+
+        impl $name {
+            pub fn msg_id(&self) -> u8 {
+                braidpool_protocol!(@msg_id self, $name, $($variants)*)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Encodable for $name {
+            fn consensus_encode<W: bitcoin::io::Write + ?Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin::io::Error> {
+                let mut len = 0;
+                braidpool_protocol!(@encode self, w, len, $name, $($variants)*)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Decodable for $name {
+            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::Error> {
+                let discriminant = u8::consensus_decode(r)?;
+                braidpool_protocol!(@decode discriminant, r, $name, $($variants)*)
+            }
+        }
+    };
+
+    // Message ID matching
+    (@msg_id $self:ident, $name:ident,) => {
+        panic!("Unreachable: All variants should be covered")
+    };
+    // Fallback for last element without trailing comma
+    (@msg_id $self:ident, $name:ident, $variant:ident = $discrim:literal) => {
+        $discrim
+    };
+    (@msg_id $self:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal) => {
+        $discrim
+    };
+    // Standard case with rest
+    (@msg_id $self:ident, $name:ident, $variant:ident = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant = $self {
+            $discrim
+        } else {
+            braidpool_protocol!(@msg_id $self, $name, $($rest)*)
+        }
+    };
+    (@msg_id $self:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant(_) = $self {
+            $discrim
+        } else {
+            braidpool_protocol!(@msg_id $self, $name, $($rest)*)
+        }
+    };
+
+    // Encode implementation
+    (@encode $self:ident, $w:ident, $len:ident, $name:ident, $($rest:tt)*) => {
+        braidpool_protocol!(@encode_match $self, $w, $len, $name, $($rest)*)
+    };
+
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant = $self {
+            $len += ($discrim as u8).consensus_encode($w)?;
+            Ok($len)
+        } else {
+            braidpool_protocol!(@encode_match $self, $w, $len, $name, $($rest)*)
+        }
+    };
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant(data) = $self {
+            $len += ($discrim as u8).consensus_encode($w)?;
+            $len += data.consensus_encode($w)?;
+            Ok($len)
+        } else {
+            braidpool_protocol!(@encode_match $self, $w, $len, $name, $($rest)*)
+        }
+    };
+    // Fallback for last element without trailing comma
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident = $discrim:literal) => {
+        $len += ($discrim as u8).consensus_encode($w)?;
+        Ok($len)
+    };
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal) => {
+        if let $name::$variant(data) = $self {
+            $len += ($discrim as u8).consensus_encode($w)?;
+            $len += data.consensus_encode($w)?;
+            Ok($len)
+        } else {
+            panic!("Unreachable: All variants should be covered")
+        }
+    };
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $($rest:tt)*) => {
+        panic!("Unreachable: All variants should be covered")
+    };
+
+    // Decode implementation
+    (@decode $discrim:ident, $r:ident, $name:ident, $($rest:tt)*) => {
+        braidpool_protocol!(@decode_match $discrim, $r, $name, $($rest)*)
+    };
+
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident = $expected:literal, $($rest:tt)*) => {
+        if $discrim == $expected {
+            Ok($name::$variant)
+        } else {
+            braidpool_protocol!(@decode_match $discrim, $r, $name, $($rest)*)
+        }
+    };
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident($type:ty) = $expected:literal, $($rest:tt)*) => {
+        if $discrim == $expected {
+            Ok($name::$variant(<$type as bitcoin::consensus::encode::Decodable>::consensus_decode($r)?))
+        } else {
+            braidpool_protocol!(@decode_match $discrim, $r, $name, $($rest)*)
+        }
+    };
+    // Fallback for last element without trailing comma
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident = $expected:literal) => {
+        if $discrim == $expected {
+            Ok($name::$variant)
+        } else {
+            Err(bitcoin::consensus::Error::from(bitcoin::io::Error::new(
+                bitcoin::io::ErrorKind::InvalidData,
+                concat!("Invalid message id for ", stringify!($name)),
+            )))
+        }
+    };
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident($type:ty) = $expected:literal) => {
+        if $discrim == $expected {
+            Ok($name::$variant(<$type as bitcoin::consensus::encode::Decodable>::consensus_decode($r)?))
+        } else {
+            Err(bitcoin::consensus::Error::from(bitcoin::io::Error::new(
+                bitcoin::io::ErrorKind::InvalidData,
+                concat!("Invalid message id for ", stringify!($name)),
+            )))
+        }
+    };
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $($rest:tt)*) => {
+        Err(bitcoin::consensus::Error::from(bitcoin::io::Error::new(
+            bitcoin::io::ErrorKind::InvalidData,
+            concat!("Invalid message id for ", stringify!($name)),
+        )))
+    };
+}
+
+/// Implements Bitcoin consensus encoding for structs with named fields.
+///
+/// This macro generates `Encodable` and `Decodable` trait implementations that encode/decode
+/// struct fields sequentially in the order specified. Includes OOM protection via `MAX_VEC_SIZE`.
+///
+/// **Syntax:** `impl_consensus_encoding!(StructName, field1, field2, field3);`
+///
+/// **Example:**
+/// ```text
+/// pub struct Transaction {
+///     pub version: u32,
+///     pub inputs: Vec<TxIn>,
+///     pub outputs: Vec<TxOut>,
+/// }
+///
+/// impl_consensus_encoding!(Transaction, version, inputs, outputs);
+/// ```
+///
+/// Based on rust-bitcoin's implementation pattern:
+/// <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/p2p/src/consensus.rs>
+macro_rules! impl_consensus_encoding {
+    ($thing:ident, $($field:ident),+) => {
+        impl bitcoin::consensus::encode::Encodable for $thing {
+            #[inline]
+            fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, bitcoin::io::Error> {
+                let mut len = 0;
+                $(len += self.$field.consensus_encode(w)?;)+
+                Ok(len)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Decodable for $thing {
+            #[inline]
+            fn consensus_decode_from_finite_reader<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$thing, bitcoin::consensus::encode::Error> {
+                Ok($thing {
+                    $($field: bitcoin::consensus::encode::Decodable::consensus_decode_from_finite_reader(r)?),+
+                })
+            }
+
+            #[inline]
+            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$thing, bitcoin::consensus::encode::Error> {
+                use bitcoin::io::Read;
+                let mut r = Read::take(r, bitcoin::consensus::encode::MAX_VEC_SIZE as u64);
+                Ok($thing {
+                    $($field: bitcoin::consensus::encode::Decodable::consensus_decode(&mut r)?),+
+                })
+            }
+        }
+    };
+}
+
+/// Implements traits for newtype wrappers around `Vec<T>`.
+///
+/// This macro generates implementations for wrapper types around `Vec<T>` to work around
+/// Rust's orphan rule. It provides:
+/// - `Deref` to `Vec<T>` for automatic method access
+/// - `IntoIterator` for use in `for` loops
+/// - `From<Vec<T>>` and `From<Wrapper>` for conversions
+/// - `Encodable` and `Decodable` with OOM protection
+///
+/// **Syntax:** `impl_vec_wrapper!(WrapperName, ElementType);`
+///
+/// **Example:**
+/// ```text
+/// #[derive(Clone, Debug, PartialEq)]
+/// pub struct Transactions(pub Vec<Transaction>);
+///
+/// impl_vec_wrapper!(Transactions, Transaction);
+///
+/// // Now you can use:
+/// let txs: Transactions = vec![tx1, tx2].into();
+/// for tx in txs { ... }
+/// txs.len();  // Via Deref
+/// ```
+///
+/// Based on rust-bitcoin's orphan rule workaround pattern:
+/// <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/p2p/src/consensus.rs>
+macro_rules! impl_vec_wrapper {
+    ($wrapper: ident, $type: ty) => {
+        impl std::ops::Deref for $wrapper {
+            type Target = Vec<$type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl IntoIterator for $wrapper {
+            type Item = $type;
+            type IntoIter = std::vec::IntoIter<$type>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.0.into_iter()
+            }
+        }
+
+        impl From<Vec<$type>> for $wrapper {
+            fn from(v: Vec<$type>) -> Self {
+                $wrapper(v)
+            }
+        }
+
+        impl From<$wrapper> for Vec<$type> {
+            fn from(w: $wrapper) -> Self {
+                w.0
+            }
+        }
+
+        impl bitcoin::consensus::encode::Encodable for $wrapper {
+            #[inline]
+            fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, bitcoin::io::Error> {
+                use bitcoin::consensus::WriteExt;
+                let mut len = 0;
+                len += w.emit_compact_size(self.0.len())?;
+                for c in self.0.iter() {
+                    len += c.consensus_encode(w)?;
+                }
+                Ok(len)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Decodable for $wrapper {
+            #[inline]
+            fn consensus_decode_from_finite_reader<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$wrapper, bitcoin::consensus::encode::Error> {
+                use bitcoin::consensus::ReadExt;
+                let len = r.read_compact_size()?;
+                // Limit the initial vec allocation to at most 8,000 bytes, which is
+                // sufficient for most use cases. We don't allocate more space upfront
+                // than this, since `len` is an untrusted allocation capacity. If the
+                // vector does overflow the initial capacity `push` will just reallocate.
+                // Note: OOM protection relies on reader eventually running out of
+                // data to feed us.
+                let max_init_capacity = 8000 / core::mem::size_of::<$type>();
+                let mut ret = Vec::with_capacity(core::cmp::min(len as usize, max_init_capacity));
+                for _ in 0..len {
+                    ret.push(<$type as bitcoin::consensus::encode::Decodable>::consensus_decode_from_finite_reader(r)?);
+                }
+                Ok($wrapper(ret))
+            }
+
+            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$wrapper, bitcoin::consensus::encode::Error> {
+                Self::consensus_decode_from_finite_reader(r)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::BeadHash as TestBeadHash;
+    use bitcoin::consensus::encode::{Decodable, Encodable};
+    use std::str::FromStr;
+
+    // Test 1: Unit variants only
+    braidpool_protocol! {
+        pub enum TestProtocol {
+            Variant1 = 0,
+            Variant2 = 1,
+            Variant3 = 2,
+        }
+    }
+
+    #[test]
+    fn test_unit_variants() {
+        let v1 = TestProtocol::Variant1;
+        assert_eq!(v1.msg_id(), 0);
+
+        let v2 = TestProtocol::Variant2;
+        assert_eq!(v2.msg_id(), 1);
+
+        let v3 = TestProtocol::Variant3;
+        assert_eq!(v3.msg_id(), 2);
+    }
+
+    // Test 2: Data-carrying variants
+    braidpool_protocol! {
+        pub enum DataProtocol {
+            Empty = 0,
+            Value(u32) = 5,
+            Text(String) = 10,
+        }
+    }
+
+    #[test]
+    fn test_data_carrying_variants() {
+        let d1 = DataProtocol::Empty;
+        assert_eq!(d1.msg_id(), 0);
+
+        let d2 = DataProtocol::Value(42);
+        assert_eq!(d2.msg_id(), 5);
+
+        let d3 = DataProtocol::Text("hello".to_string());
+        assert_eq!(d3.msg_id(), 10);
+    }
+
+    #[test]
+    fn test_encode_decode_unit() {
+        let original = TestProtocol::Variant2;
+        let mut encoded = Vec::new();
+        let len = original.consensus_encode(&mut encoded).unwrap();
+        assert!(len > 0);
+
+        let decoded = TestProtocol::consensus_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded.msg_id(), original.msg_id());
+        assert_eq!(decoded, TestProtocol::Variant2);
+    }
+
+    #[test]
+    fn test_encode_decode_data() {
+        let original = DataProtocol::Value(123);
+        let mut encoded = Vec::new();
+        let len = original.consensus_encode(&mut encoded).unwrap();
+        assert!(len > 0);
+
+        let decoded = DataProtocol::consensus_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded.msg_id(), original.msg_id());
+
+        if let DataProtocol::Value(val) = decoded {
+            assert_eq!(val, 123);
+        } else {
+            panic!("Expected Value variant");
+        }
+    }
+
+    // Test 3: BeadRequest pattern with Vec instead of HashSet for simplicity
+    braidpool_protocol! {
+        pub enum TestBeadRequest {
+            GetBeads(Vec<TestBeadHash>) = 0,
+            GetTips = 1,
+            GetGenesis = 2,
+        }
+    }
+
+    #[test]
+    fn test_bead_request_pattern() {
+        let mut hashes = Vec::new();
+        hashes.push(
+            TestBeadHash::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+
+        let req = TestBeadRequest::GetBeads(hashes.clone());
+        assert_eq!(req.msg_id(), 0);
+
+        let req2 = TestBeadRequest::GetTips;
+        assert_eq!(req2.msg_id(), 1);
+
+        let mut encoded = Vec::new();
+        req.consensus_encode(&mut encoded).unwrap();
+
+        let decoded = TestBeadRequest::consensus_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded.msg_id(), req.msg_id());
+    }
+
+    #[test]
+    fn test_all_variant_types() {
+        // Test we can create different variants
+        let _p1 = TestProtocol::Variant1;
+        let _p2 = TestProtocol::Variant2;
+        let _p3 = TestProtocol::Variant3;
+
+        let _d1 = DataProtocol::Empty;
+        let _d2 = DataProtocol::Value(42);
+        let _d3 = DataProtocol::Text("hello".to_string());
+
+        let mut hashes = Vec::new();
+        hashes.push(
+            TestBeadHash::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+        let _br1 = TestBeadRequest::GetBeads(hashes);
+        let _br2 = TestBeadRequest::GetTips;
+        let _br3 = TestBeadRequest::GetGenesis;
+
+        // Just verify compilation - all enums can be created
+        assert!(true);
+    }
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -15,12 +15,14 @@ use libp2p::{
     PeerId,
 };
 use node::db::db_handlers::fetch_beads_in_batch;
+use node::utils::BeadHash;
 use node::SwarmHandler;
 use node::{
     bead::{self, Bead, BeadRequest, BeadSyncError},
     behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
     braid, cli,
     db::db_handlers::DBHandler,
+    ibd_manager::{IBDCommands, IBDManager, IBD_BATCH_SIZE},
     ipc_template_consumer,
     peer_manager::PeerManager,
     rpc_server::{parse_arguments, run_rpc_server},
@@ -28,13 +30,12 @@ use node::{
     stratum::{BlockTemplate, ConnectionMapping, Notifier, NotifyCmd, Server, StratumServerConfig},
     SwarmCommand, TemplateId,
 };
+use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
+use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::{
-    collections::{HashMap, HashSet},
-    error::Error,
-};
+use std::{collections::HashMap, error::Error};
 use std::{fs, time::Duration};
 use tokio_util::sync::CancellationToken;
 #[allow(unused_imports)]
@@ -54,9 +55,16 @@ use tokio::sync::{
     mpsc::{self},
     RwLock,
 };
-
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
+    //IBD cache handler
+    let _ibd_handler = tokio::spawn(async move {
+        ibd_manager.handle_ibd_command().await;
+    });
+
+    let ibd_or_not: AtomicBool = AtomicBool::new(false);
+    let ibd_spinlock = Arc::new(ibd_or_not);
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
     let genesis_beads = Vec::from([]);
@@ -137,12 +145,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .await;
     });
     //Running the stratum service
+    let spin_lock_ref = ibd_spinlock.clone();
     tokio::spawn(async move {
         let _res = stratum_server
             .run_stratum_service(
                 mining_job_map,
                 notification_tx_clone,
                 swarm_handler_arc.clone(),
+                spin_lock_ref,
             )
             .await;
     });
@@ -471,10 +481,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      // update score of the peer and adding to local db store
                                      let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
                                         Ok(_)=>{
-                                            log::info!("Insert command sent successfully to db handler after receiving bead from peer");
+                                            info!("Insert command sent successfully to db handler after receiving bead from peer");
                                         },
                                         Err(error)=>{
-                                            log::error!("An error occurred while sending insert bead command received from peer - {:?} due to - {:?} ",message.source,error.0);
+                                            error!(
+                                                source = ?message.source,
+                                                err = ?error.0,
+                                                "An error occurred while sending insert bead command received from peer"
+                                            );
                                         }
                                      };
                                      peer_manager.update_score(&message.source, 1.0);
@@ -573,7 +587,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                      SwarmEvent::ConnectionEstablished {
                          peer_id, endpoint, ..
                      } => {
-                        //Triggering IBD and atomic boolean for starting mining or not depending on state of IBD .
 
                          // Add the peer to the peer manager
                          let remote_addr = endpoint.get_remote_address();
@@ -595,10 +608,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                          });
                          peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
                          info!(
-                             peer_id = ?peer_id,
-                             remote_addr = ?remote_addr,
-                             "Connection established to peer"
-                         );
+                            peer_id = ?peer_id,
+                            remote_addr = ?remote_addr,
+                            "Connection established to peer"
+                        );
+                         //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
+                         let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                         swarm.behaviour_mut().bead_sync.send_request(&peer_id, sync_start_request);
                      }
                      SwarmEvent::ConnectionClosed {
                          peer_id,
@@ -650,6 +666,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             }
                                         }
                                     }
+                                    //Sending all the beads requested in the hashes supplied during `GetData` request
                                     swarm.behaviour_mut().respond_with_beads(channel, beads);
                                 }
                                 bead::BeadRequest::GetTips => {
@@ -691,9 +708,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 bead::BeadRequest::GetBeadsAfter(hashes) => {
                                     let beads = braid.read().await.get_beads_after(hashes);
                                     if let Some(response_beads) = beads {
+                                        let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
+                                        for bead in response_beads.into_iter(){
+                                            computed_beads_hashes.push(bead.block_header.block_hash());
+                                        }
+                                        //Sending the corresponding bead hashes requested by the new peer for IBD that will
+                                        //be after the new peer's `Tips`.
                                         swarm
                                             .behaviour_mut()
-                                            .respond_with_beads(channel, response_beads);
+                                            .respond_with_beadhashes(channel, computed_beads_hashes);
                                     } else {
                                         swarm.behaviour_mut().respond_with_error(
                                             channel,
@@ -711,23 +734,135 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         } => {
                             match response {
                                 bead::BeadResponse::Beads(beads)
-                                | bead::BeadResponse::GetAllBeads(beads)
-                                | bead::BeadResponse::GetBeadsAfter(beads) => {
+                                | bead::BeadResponse::GetAllBeads(beads) => {
+                                    let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
+                                    //Fetching the pruned bead-hashes received during `GetBeadAfter` request
+                                    ibd_command_tx.send(IBDCommands::FetchGetBeadCache { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await.unwrap();
+                                    let pruned_beads = beads_rx.await.expect("Error in response branch of GETALLBEADS");
                                     let mut braid_lock = braid.write().await;
-                                    for bead in beads {
+                                    for bead in beads.into_iter() {
                                         let status = braid_lock.extend(&bead);
+                                        let curr_beadhash = bead.block_header.block_hash().to_string();
                                         if let braid::AddBeadStatus::InvalidBead = status {
                                             // update the peer manager about the invalid bead
                                             peer_manager.penalize_for_invalid_bead(&peer);
                                         } else if let braid::AddBeadStatus::BeadAdded = status {
                                             // update score of the peer
                                             peer_manager.update_score(&peer, 1.0);
+                                            //persisting the recived beads from peer onto DB(disk)
+                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
+                                                Ok(_)=>{
+                                                    info!(beadhash=?curr_beadhash,"Bead recieved in IBD persisted over disk with beadhash and status BeadAdded");
+                                                },
+                                                Err(error)=>{
+                                                    tracing::error!(
+                                                        peer = %peer,
+                                                        err = ?error.0,
+                                                        "An error occurred while persisting received bead from peer"
+                                                    );
+                                                }
+                                            };
                                         }
                                     }
+                                    //Preparing next batch request to be sent to the sync node
+                                    let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
+                                    ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await.unwrap();
+                                    let next_batch_offset = batch_rx.await.expect("Next branch offset");
+                                    if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)< pruned_beads.len()){
+                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..(next_batch_offset+IBD_BATCH_SIZE)].to_vec());
+                                    }
+                                    else if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)>=pruned_beads.len()){
+                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..].to_vec());
+
+                                    }
+                                    else{
+                                        //IBD completed
+                                        tracing::info!(
+                                            peer = %peer,
+                                            "IBD has been completed with respect to peer"
+                                        );
+                                        ibd_spinlock.store(false, std::sync::atomic::Ordering::SeqCst);
+                                        continue;
+                                    }
                                 }
-                                // no use of this arm as of now
+                                 bead::BeadResponse::GetBeadsAfter(bead_hashes)=>{
+                                    //Getting all the beadhashes after the common oldest in both the peers
+                                    let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
+                                    ibd_command_tx.send(IBDCommands::FetchCachedTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await.unwrap();
+                                    let received_tips = tips_rx.await.expect("Error in GetBeadsAfter IBD");
+                                    //Pruning the hashes wrt cached `Tips`
+                                    let mut found_tips = HashSet::new();
+                                    let mut pruned = Vec::new();
+                                    let tips_set: HashSet<_> = received_tips.into_iter().collect();
+                                    for hash in bead_hashes {
+                                        if tips_set.contains(&hash) {
+                                            found_tips.insert(hash.clone());
+                                        }
+                                        pruned.push(hash);
+                                        // Stop once all tips have been matched
+                                        if found_tips.len() == tips_set.len() {
+                                            break;
+                                        }
+                                    }
+                                    let pruned_ref = pruned.clone();
+                                    // Storing them in cache
+                                    ibd_command_tx.send(IBDCommands::UpdateIBDGetBeadCache { get_bead_response: pruned, peer_id: peer.to_string() }).await.unwrap();
+                                    // Initiating `GetBead` request cycle
+                                    if pruned_ref.len() <= IBD_BATCH_SIZE{
+                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref);
+                                    }
+                                    else{
+                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref[0..IBD_BATCH_SIZE].to_vec());
+                                    }
+
+                                }
                                 bead::BeadResponse::Tips(tips) => {
                                     info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
+                                    //If received tips are already present in the local braid arc then we can stop
+                                    //IBD and continue with mining
+                                    //Initializing the batch offset for the corresponding sync peer
+                                    let (ibd_bridge_tx, _ibd_bridge_rx) = tokio::sync::oneshot::channel::<usize>();
+                                    ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await.unwrap();
+                                    let _val = _ibd_bridge_rx.await.unwrap();
+                                    let braid_data = braid.read().await;
+
+                                    let bead_hash_set: HashSet<BeadHash> = braid_data
+                                    .beads
+                                    .iter()
+                                    .map(|b| b.block_header.block_hash())
+                                    .collect();
+
+                                    let flag = tips.iter().all(|tip_hash| bead_hash_set.contains(tip_hash));
+
+                                    if flag == true{
+                                        //No need to proceed further and continue to next event
+                                        info!("Peer already synced to tip");
+                                        continue;
+                                    }
+                                    //IBD flag can be set  as the current bead is already synced//
+                                    ibd_spinlock.store(true, std::sync::atomic::Ordering::SeqCst);
+                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsCache { received_tips: tips, peer_id: peer.to_string() }).await{
+                                    Ok(_)=>{
+                                        info!("Tip cache update successfully");
+                                    },
+                                    Err(error)=>{
+                                        tracing::error!(
+                                            err = ?error,
+                                            "Error while sending update cache command"
+                                        );
+                                    }
+                                  };
+                                    //After storing tips we will issue `GetBeads` command that will find the oldest
+                                    //common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
+                                    //the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
+                                    let mut current_tip_hashes = Vec::new();
+                                    let _ = braid_data.tips.iter().for_each(|curr_bead_idx|{
+                                       let current_bead = braid_data.beads.get(*curr_bead_idx).unwrap();
+                                       current_tip_hashes.push(current_bead.block_header.block_hash());
+                                    });
+                                    //Sending the current bead hashes for the receiving of beads to start in batches
+                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(current_tip_hashes);
+                                    swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
 
                                 }
                                 bead::BeadResponse::Genesis(genesis) => {
@@ -741,12 +876,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             info!("Genesis beads are valid");
                                         }
                                         braid::GenesisCheckStatus::MissingGenesisBead => {
-                                            let genesis_hashes =
-                                                genesis.into_iter().collect::<HashSet<_>>();
-                                                warn!(peer = %peer, "Missing genesis bead");
+                                            warn!(peer = %peer, "Missing genesis bead");
                                             swarm
                                                 .behaviour_mut()
-                                                .request_beads(peer, genesis_hashes);
+                                                .request_beads(peer, &genesis);
                                         }
                                         braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
                                             warn!(
@@ -789,6 +922,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                      }
                  }
              }
+
+
+
+
             }
         }
     });

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -103,7 +103,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //One will go into the IPC and the other will go to the `notifier`
     let (notification_tx, notification_rx) = mpsc::channel::<NotifyCmd>(1024);
     //Communication bridge between stratum and network swarm and swarm commands also, for communicating share population and propogating them further
-    let (swarm_handler, mut swarm_command_receiver) = SwarmHandler::new(Arc::clone(&braid), db_tx);
+    let (swarm_handler, mut swarm_command_receiver) =
+        SwarmHandler::new(Arc::clone(&braid), db_tx.clone());
     let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
     //cloning the channel to be sent across different interfaces
     let notification_tx_clone = notification_tx.clone();
@@ -467,7 +468,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      // update the peer manager about the invalid bead
                                      peer_manager.penalize_for_invalid_bead(&message.source);
                                  } else if let braid::AddBeadStatus::BeadAdded = status {
-                                     // update score of the peer
+                                     // update score of the peer and adding to local db store
+                                     let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
+                                        Ok(_)=>{
+                                            log::info!("Insert command sent successfully to db handler after receiving bead from peer");
+                                        },
+                                        Err(error)=>{
+                                            log::error!("An error occurred while sending insert bead command received from peer - {:?} due to - {:?} ",message.source,error.0);
+                                        }
+                                     };
                                      peer_manager.update_score(&message.source, 1.0);
                                  }
                              }
@@ -564,6 +573,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                      SwarmEvent::ConnectionEstablished {
                          peer_id, endpoint, ..
                      } => {
+                        //Triggering IBD and atomic boolean for starting mining or not depending on state of IBD .
+
                          // Add the peer to the peer manager
                          let remote_addr = endpoint.get_remote_address();
                          swarm.behaviour_mut().kademlia.add_address(&peer_id,remote_addr.clone());

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -17,7 +17,7 @@ use libp2p::{
 use node::db::db_handlers::fetch_beads_in_batch;
 use node::SwarmHandler;
 use node::{
-    bead::{self, Bead, BeadRequest},
+    bead::{self, Bead, BeadRequest, BeadSyncError},
     behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
     braid, cli,
     db::db_handlers::DBHandler,
@@ -31,7 +31,7 @@ use node::{
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
-use std::{collections::HashMap, error::Error};
+use std::{collections::{HashMap,HashSet}, error::Error};
 use std::{fs, time::Duration};
 use tokio_util::sync::CancellationToken;
 #[allow(unused_imports)]
@@ -604,12 +604,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              connection_id,
                          },
                      )) => {
-                         info!(
-                             peer = %peer,
-                             message = ?message,
-                             connection = ?connection_id,
-                             "Bead sync message received"
-                         );
+                        info!(
+                            peer = %peer,
+                            message = ?message,
+                            connection = ?connection_id,
+                            "Bead sync message received"
+                        );
                          match message {
                              request_response::Message::Request {
                                  request,
@@ -670,6 +670,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                          }
                                          swarm.behaviour_mut().respond_with_beads(channel, all_beads);
                                      }
+                                     bead::BeadRequest::GetBeadsAfter(hashes) => {
+                                        let beads = braid.read().await.get_beads_after(hashes);
+                                        if let Some(response_beads) = beads {
+                                            swarm
+                                                .behaviour_mut()
+                                                .respond_with_beads(channel, response_beads);
+                                        } else {
+                                            swarm.behaviour_mut().respond_with_error(
+                                                channel,
+                                                BeadSyncError::GenesisMismatch,
+                                            );
+                                        }
+                                    }
                                  }
                              }
                              request_response::Message::Response {
@@ -678,7 +691,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              } => {
                                  match response {
                                      bead::BeadResponse::Beads(beads)
-                                     | bead::BeadResponse::GetAllBeads(beads) => {
+                                     | bead::BeadResponse::GetAllBeads(beads)
+                                     | bead::BeadResponse::GetBeadsAfter(beads) => {
                                          let mut braid_lock = braid.write().await;
                                          for bead in beads {
                                              let status = braid_lock.extend(&bead);
@@ -693,34 +707,44 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      }
                                      // no use of this arm as of now
                                      bead::BeadResponse::Tips(tips) => {
-                                         info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
+                                        info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
                                      }
                                      bead::BeadResponse::Genesis(genesis) => {
-                                         info!(genesis = ?genesis, genesis_count = %genesis.len(), "Received genesis beads");
+                                         info!(genesis=?genesis,"Received genesis beads: ");
                                          let status = {
                                              let braid_lock = braid.read().await;
                                              braid_lock.check_genesis_beads(&genesis)
                                          };
                                          match status {
                                              braid::GenesisCheckStatus::GenesisBeadsValid => {
-                                                 info!(count = %genesis.len(), "Genesis beads validated");
+                                                 info!("Genesis beads are valid");
                                              }
                                              braid::GenesisCheckStatus::MissingGenesisBead => {
-                                                 warn!(peer = %peer, "Missing genesis bead");
+                                                let genesis_hashes =
+                                                genesis.into_iter().collect::<HashSet<_>>();
+                                                warn!(peer = %peer, "Missing genesis bead");
+                                            swarm
+                                                .behaviour_mut()
+                                                .request_beads(peer, genesis_hashes);
                                              }
                                              braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
-                                                 warn!(
-                                                     received = %genesis.len(),
-                                                     peer = %peer,
-                                                     "Genesis bead count mismatch"
-                                                 );
+                                                warn!(
+                                                    received = %genesis.len(),
+                                                    peer = %peer,
+                                                    "Genesis bead count mismatch"
+                                                );
                                              }
                                          }
                                      }
-                                     bead::BeadResponse::Error(error) => {
-                                         error!(error = ?error, "Bead sync response error");
-                                         peer_manager.update_score(&peer, -1.0);
-                                     }
+                                     bead::BeadResponse::Error(error) => match error {
+                                        BeadSyncError::GenesisMismatch => {
+                                            warn!("Genesis mismatch error received");
+                                            swarm.behaviour_mut().request_genesis(peer.clone());
+                                        }
+                                        BeadSyncError::Other(ref err_msg) => {
+                                            error!(err_msg=?err_msg,"Error in bead sync response:");
+                                        }
+                                    },
                                  };
                              }
                          }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -31,7 +31,10 @@ use node::{
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::Arc;
-use std::{collections::{HashMap,HashSet}, error::Error};
+use std::{
+    collections::{HashMap, HashSet},
+    error::Error,
+};
 use std::{fs, time::Duration};
 use tokio_util::sync::CancellationToken;
 #[allow(unused_imports)]
@@ -450,7 +453,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                          swarm.behaviour_mut().bead_sync.send_request(
                                              &peer,
                                              BeadRequest::GetBeads(
-                                                 bead.committed_metadata.parents.clone(),
+                                                 bead.committed_metadata
+                                                     .parents
+                                                     .clone()
+                                                     .into_iter()
+                                                     .collect(),
                                              ),
                                          );
                                      } else {
@@ -598,157 +605,160 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              .remove_address(&peer_id, endpoint.get_remote_address());
                      }
                      SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadSync(
-                         request_response::Event::Message {
-                             peer,
-                             message,
-                             connection_id,
-                         },
-                     )) => {
-                        info!(
-                            peer = %peer,
-                            message = ?message,
-                            connection = ?connection_id,
-                            "Bead sync message received"
-                        );
-                         match message {
-                             request_response::Message::Request {
-                                 request,
-                                 request_id: _,
-                                 channel,
-                             } => {
-                                 // Handle the bead sync request here
-                                 match request {
-                                     bead::BeadRequest::GetBeads(hashes) => {
-                                         let mut beads = Vec::new();
-                                         {
-                                             let braid_lock = braid.read().await;
-                                             for hash in hashes.iter() {
-                                                 if let Some(index) =
-                                                     braid_lock.bead_index_mapping.get(hash)
-                                                 {
-                                                     if let Some(bead) = braid_lock.beads.get(*index) {
-                                                         beads.push(bead.clone());
-                                                     }
-                                                 }
-                                             }
-                                         }
-                                         swarm.behaviour_mut().respond_with_beads(channel, beads);
-                                     }
-                                     bead::BeadRequest::GetTips => {
-                                         let tips;
-                                         {
-                                             let braid_lock = braid.read().await;
-                                             tips = braid_lock
-                                                 .tips
-                                                 .iter()
-                                                 .filter_map(|index| braid_lock.beads.get(*index))
-                                                 .cloned()
-                                                 .map(|bead| bead.block_header.block_hash())
-                                                 .collect();
-                                         }
-                                         swarm.behaviour_mut().respond_with_tips(channel, tips);
-                                     }
-                                     bead::BeadRequest::GetGenesis => {
-                                         let genesis;
-                                         {
-                                             let braid_lock = braid.read().await;
-                                             genesis = braid_lock
-                                                 .genesis_beads
-                                                 .iter()
-                                                 .filter_map(|index| braid_lock.beads.get(*index))
-                                                 .cloned()
-                                                 .map(|bead| bead.block_header.block_hash())
-                                                 .collect();
-                                         }
-                                         swarm.behaviour_mut().respond_with_genesis(channel, genesis);
-                                     }
-                                     bead::BeadRequest::GetAllBeads => {
-                                         let all_beads;
-                                         {
-                                             let braid_lock = braid.read().await;
-                                             all_beads = braid_lock.beads.iter().cloned().collect();
-                                         }
-                                         swarm.behaviour_mut().respond_with_beads(channel, all_beads);
-                                     }
-                                     bead::BeadRequest::GetBeadsAfter(hashes) => {
-                                        let beads = braid.read().await.get_beads_after(hashes);
-                                        if let Some(response_beads) = beads {
-                                            swarm
-                                                .behaviour_mut()
-                                                .respond_with_beads(channel, response_beads);
-                                        } else {
-                                            swarm.behaviour_mut().respond_with_error(
-                                                channel,
-                                                BeadSyncError::GenesisMismatch,
-                                            );
+                    request_response::Event::Message {
+                        peer,
+                        message,
+                        connection_id,
+                    },
+                )) => {
+                    info!(
+                        peer = %peer,
+                        message = ?message,
+                        connection = ?connection_id,
+                        "Bead sync message received"
+                    );
+                    match message {
+                        request_response::Message::Request {
+                            request,
+                            request_id: _,
+                            channel,
+                        } => {
+                            // Handle the bead sync request here
+                            match request {
+                                bead::BeadRequest::GetBeads(hashes) => {
+                                    let mut beads = Vec::new();
+                                    {
+                                        let braid_lock = braid.read().await;
+                                        for hash in hashes.iter() {
+                                            if let Some(index) =
+                                                braid_lock.bead_index_mapping.get(hash)
+                                            {
+                                                if let Some(bead) = braid_lock.beads.get(*index) {
+                                                    beads.push(bead.clone());
+                                                }
+                                            }
                                         }
                                     }
-                                 }
-                             }
-                             request_response::Message::Response {
-                                 request_id: _,
-                                 response,
-                             } => {
-                                 match response {
-                                     bead::BeadResponse::Beads(beads)
-                                     | bead::BeadResponse::GetAllBeads(beads)
-                                     | bead::BeadResponse::GetBeadsAfter(beads) => {
-                                         let mut braid_lock = braid.write().await;
-                                         for bead in beads {
-                                             let status = braid_lock.extend(&bead);
-                                             if let braid::AddBeadStatus::InvalidBead = status {
-                                                 // update the peer manager about the invalid bead
-                                                 peer_manager.penalize_for_invalid_bead(&peer);
-                                             } else if let braid::AddBeadStatus::BeadAdded = status {
-                                                 // update score of the peer
-                                                 peer_manager.update_score(&peer, 1.0);
-                                             }
-                                         }
-                                     }
-                                     // no use of this arm as of now
-                                     bead::BeadResponse::Tips(tips) => {
-                                        info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
-                                     }
-                                     bead::BeadResponse::Genesis(genesis) => {
-                                         info!(genesis=?genesis,"Received genesis beads: ");
-                                         let status = {
-                                             let braid_lock = braid.read().await;
-                                             braid_lock.check_genesis_beads(&genesis)
-                                         };
-                                         match status {
-                                             braid::GenesisCheckStatus::GenesisBeadsValid => {
-                                                 info!("Genesis beads are valid");
-                                             }
-                                             braid::GenesisCheckStatus::MissingGenesisBead => {
-                                                let genesis_hashes =
+                                    swarm.behaviour_mut().respond_with_beads(channel, beads);
+                                }
+                                bead::BeadRequest::GetTips => {
+                                    let tips;
+                                    {
+                                        let braid_lock = braid.read().await;
+                                        tips = braid_lock
+                                            .tips
+                                            .iter()
+                                            .filter_map(|index| braid_lock.beads.get(*index))
+                                            .cloned()
+                                            .map(|bead| bead.block_header.block_hash())
+                                            .collect();
+                                    }
+                                    swarm.behaviour_mut().respond_with_tips(channel, tips);
+                                }
+                                bead::BeadRequest::GetGenesis => {
+                                    let genesis;
+                                    {
+                                        let braid_lock = braid.read().await;
+                                        genesis = braid_lock
+                                            .genesis_beads
+                                            .iter()
+                                            .filter_map(|index| braid_lock.beads.get(*index))
+                                            .cloned()
+                                            .map(|bead| bead.block_header.block_hash())
+                                            .collect();
+                                    }
+                                    swarm.behaviour_mut().respond_with_genesis(channel, genesis);
+                                }
+                                bead::BeadRequest::GetAllBeads => {
+                                    let all_beads;
+                                    {
+                                        let braid_lock = braid.read().await;
+                                        all_beads = braid_lock.beads.iter().cloned().collect();
+                                    }
+                                    swarm.behaviour_mut().respond_with_beads(channel, all_beads);
+                                }
+                                bead::BeadRequest::GetBeadsAfter(hashes) => {
+                                    let beads = braid.read().await.get_beads_after(hashes);
+                                    if let Some(response_beads) = beads {
+                                        swarm
+                                            .behaviour_mut()
+                                            .respond_with_beads(channel, response_beads);
+                                    } else {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::Other(String::from(
+                                                "provided hashes not found",
+                                            )),
+                                        );
+                                    }
+                                }
+                            }
+                        }
+                        request_response::Message::Response {
+                            request_id: _,
+                            response,
+                        } => {
+                            match response {
+                                bead::BeadResponse::Beads(beads)
+                                | bead::BeadResponse::GetAllBeads(beads)
+                                | bead::BeadResponse::GetBeadsAfter(beads) => {
+                                    let mut braid_lock = braid.write().await;
+                                    for bead in beads {
+                                        let status = braid_lock.extend(&bead);
+                                        if let braid::AddBeadStatus::InvalidBead = status {
+                                            // update the peer manager about the invalid bead
+                                            peer_manager.penalize_for_invalid_bead(&peer);
+                                        } else if let braid::AddBeadStatus::BeadAdded = status {
+                                            // update score of the peer
+                                            peer_manager.update_score(&peer, 1.0);
+                                        }
+                                    }
+                                }
+                                // no use of this arm as of now
+                                bead::BeadResponse::Tips(tips) => {
+                                    info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
+
+                                }
+                                bead::BeadResponse::Genesis(genesis) => {
+                                    info!(genesis=?genesis,"Received genesis beads: ");
+                                    let status = {
+                                        let braid_lock = braid.read().await;
+                                        braid_lock.check_genesis_beads(&genesis)
+                                    };
+                                    match status {
+                                        braid::GenesisCheckStatus::GenesisBeadsValid => {
+                                            info!("Genesis beads are valid");
+                                        }
+                                        braid::GenesisCheckStatus::MissingGenesisBead => {
+                                            let genesis_hashes =
                                                 genesis.into_iter().collect::<HashSet<_>>();
                                                 warn!(peer = %peer, "Missing genesis bead");
                                             swarm
                                                 .behaviour_mut()
                                                 .request_beads(peer, genesis_hashes);
-                                             }
-                                             braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
-                                                warn!(
-                                                    received = %genesis.len(),
-                                                    peer = %peer,
-                                                    "Genesis bead count mismatch"
-                                                );
-                                             }
-                                         }
-                                     }
-                                     bead::BeadResponse::Error(error) => match error {
-                                        BeadSyncError::GenesisMismatch => {
-                                            warn!("Genesis mismatch error received");
-                                            swarm.behaviour_mut().request_genesis(peer.clone());
                                         }
-                                        BeadSyncError::Other(ref err_msg) => {
-                                            error!(err_msg=?err_msg,"Error in bead sync response:");
+                                        braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
+                                            warn!(
+                                                received = %genesis.len(),
+                                                peer = %peer,
+                                                "Genesis bead count mismatch"
+                                            );
                                         }
-                                    },
-                                 };
-                             }
-                         }
-                     }
+                                    }
+                                }
+                                bead::BeadResponse::Error(error) => match error {
+                                    BeadSyncError::GenesisMismatch => {
+                                        warn!("Genesis mismatch error received");
+                                        swarm.behaviour_mut().request_genesis(peer.clone());
+                                    }
+                                    BeadSyncError::Other(ref err_msg) => {
+                                        error!(err_msg=?err_msg,"Error in bead sync response:");
+                                    }
+                                },
+                            };
+                        }
+                    }
+                }
                      other_event=>{
                              debug!(event = ?other_event, "Other swarm event");
                      }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -737,8 +737,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 | bead::BeadResponse::GetAllBeads(beads) => {
                                     let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
                                     //Fetching the pruned bead-hashes received during `GetBeadAfter` request
-                                    ibd_command_tx.send(IBDCommands::FetchGetBeadCache { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await.unwrap();
-                                    let pruned_beads = beads_rx.await.expect("Error in response branch of GETALLBEADS");
+                                    match ibd_command_tx.send(IBDCommands::FetchGetBeadCache { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
+                                        Ok(_)=>{
+                                            info!("IBD command sent to handler successfully !");
+                                        },
+                                        Err(error)=>{
+                                            //Re-initiating IBD
+                                            error!("An error occurred while sending ibd command to ibd_handler - {:?}, re-trying IBD",error.0);
+                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
+                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            continue;
+                                        }
+                                    };
+                                    let pruned_beads = match beads_rx.await{
+                                        Ok(received_beads)=>{
+                                            received_beads
+                                        },
+                                        Err(error)=>{
+                                            error!(error=?error.to_string(),"An ERROR occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
+                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
+                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            continue;
+                                        }
+                                    };
                                     let mut braid_lock = braid.write().await;
                                     for bead in beads.into_iter() {
                                         let status = braid_lock.extend(&bead);
@@ -766,8 +787,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
                                     //Preparing next batch request to be sent to the sync node
                                     let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await.unwrap();
-                                    let next_batch_offset = batch_rx.await.expect("Next branch offset");
+                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await{
+                                            Ok(_)=>{
+                                                info!("Offset Updated");
+                                            },
+                                            Err(error)=>{
+                                                error!(error=?error,"An error occurred while sending the offset update command, re-trying IBD");
+                                                let sync_retry_request:BeadRequest = BeadRequest::GetTips;
+                                                swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                                continue;
+                                            }
+                                    };
+                                    let next_batch_offset = match batch_rx.await{
+                                        Ok(next_offset)=>{
+                                            info!(next_offset=?next_offset,"Newer offset for batch request received successfully val ");
+                                            next_offset
+                                        },
+                                        Err(error)=>{
+                                            error!(error=?error,"An error occurred while receving the offset, re-trying IBD");
+                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
+                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            continue;
+                                        }
+                                    };
                                     if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)< pruned_beads.len()){
                                         swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..(next_batch_offset+IBD_BATCH_SIZE)].to_vec());
                                     }
@@ -788,8 +830,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                  bead::BeadResponse::GetBeadsAfter(bead_hashes)=>{
                                     //Getting all the beadhashes after the common oldest in both the peers
                                     let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    ibd_command_tx.send(IBDCommands::FetchCachedTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await.unwrap();
-                                    let received_tips = tips_rx.await.expect("Error in GetBeadsAfter IBD");
+                                    match ibd_command_tx.send(IBDCommands::FetchCachedTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
+                                        Ok(_)=>{
+                                            info!("Cached Tips received successfully.");
+                                        },
+                                        Err(error)=>{
+                                            error!(error=?error,"Error occurred while receiving tips, re-trying IBD");
+                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
+                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            continue;
+                                        }
+                                    };
+                                    let received_tips = match tips_rx.await{
+                                        Ok(received_tips)=>{
+                                            received_tips
+                                        },
+                                        Err(error)=>{
+                                            error!(error=?error,"An error occurred while receving the Tips, re-trying IBD");
+                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
+                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            continue;
+                                        }
+                                    };
                                     //Pruning the hashes wrt cached `Tips`
                                     let mut found_tips = HashSet::new();
                                     let mut pruned = Vec::new();
@@ -806,7 +868,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
                                     let pruned_ref = pruned.clone();
                                     // Storing them in cache
-                                    ibd_command_tx.send(IBDCommands::UpdateIBDGetBeadCache { get_bead_response: pruned, peer_id: peer.to_string() }).await.unwrap();
+                                    match ibd_command_tx.send(IBDCommands::UpdateIBDGetBeadCache { get_bead_response: pruned, peer_id: peer.to_string() }).await{
+                                        Ok(_)=>{
+                                            info!("Received beads to be fetched in GetBeads saved successfully");
+                                        },
+                                        Err(error)=>{
+                                            error!(error=?error,"An error occurred while Caching pruned beadhashes to be fetched in GetBeads");
+                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
+                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            continue;
+                                        }
+                                    };
                                     // Initiating `GetBead` request cycle
                                     if pruned_ref.len() <= IBD_BATCH_SIZE{
                                         swarm.behaviour_mut().request_beads(peer, &pruned_ref);
@@ -822,7 +894,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     //IBD and continue with mining
                                     //Initializing the batch offset for the corresponding sync peer
                                     let (ibd_bridge_tx, _ibd_bridge_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await.unwrap();
+                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await{
+                                        Ok(_)=>{
+                                            info!("Offset Initialized successfully");
+                                        },
+                                        Err(_error)=>{
+                                            error!("An error occurred while sending offset initalization command to ibd_handler");
+                                            continue;
+                                        }
+                                    };
                                     let _val = _ibd_bridge_rx.await.unwrap();
                                     let braid_data = braid.read().await;
 
@@ -850,6 +930,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             err = ?error,
                                             "Error while sending update cache command"
                                         );
+                                        continue;
                                     }
                                   };
                                     //After storing tips we will issue `GetBeads` command that will find the oldest

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -14,7 +14,7 @@ use libp2p::{
     swarm::SwarmEvent,
     PeerId,
 };
-use node::db::db_handlers::fetch_beads_in_batch;
+use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
 use node::SwarmHandler;
@@ -60,21 +60,21 @@ use tokio::sync::{
 };
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    // Initialize tracing with colors and module prefixes
+    setup_tracing()?;
     let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
     //IBD cache handler
     let _ibd_handler = tokio::spawn(async move {
-        ibd_manager.handle_ibd_command().await;
+        ibd_manager.run_ibd_handler().await;
     });
     //False if not under ibd otherwise true at start will be in IBD by default
     let ibd_or_not: AtomicBool = AtomicBool::new(true);
     let ibd_spinlock = Arc::new(ibd_or_not);
-    // Initialize tracing with colors and module prefixes
-    setup_tracing()?;
     // Initializing the braid object with read write lock
     //for supporting concurrent readers and single writer
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
     //Initializing DB and db command handler
-    let (mut _db_handler, db_tx) = DBHandler::new(Arc::clone(&braid)).await.unwrap();
+    let (mut _db_handler, db_tx) = DBHandler::new().await.unwrap();
     let db_connection_pool = _db_handler.db_connection_pool.clone();
     //Reconstructing local braid upon startup
     let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
@@ -472,9 +472,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              Ok(bead) => {
                                 info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
                                 // Handle the received bead here
+                                let mut braid_data = braid.write().await;
                                 let status = {
-                                     let mut braid_lock = braid.write().await;
-                                     braid_lock.extend(&bead)
+                                     braid_data.extend(&bead)
                                  };
                                  if ibd_spinlock.load(Ordering::SeqCst){
                                     let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
@@ -515,10 +515,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         // update the peer manager about the invalid bead
                                         peer_manager.penalize_for_invalid_bead(&message.source);
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
+                                     //Considering the index of the beads in braid will be same as the (insertion ids-1)
+                                        let bead_id = braid_data
+                                        .bead_index_mapping
+                                        .get(&bead.block_header.block_hash())
+                                        .unwrap();
+                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                            &braid_data.beads,
+                                            &braid_data.bead_index_mapping,
+                                            &bead,
+                                        ){
+                                            Ok(received_tuples)=>received_tuples,
+                                            Err(error)=>{
+                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                continue;
+                                            }
+                                        };
                                         // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
+                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
                                            Ok(_)=>{
-                                               info!("Insert command sent successfully to db handler after receiving bead from peer");
+                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
                                            },
                                            Err(error)=>{
                                                error!(
@@ -541,7 +557,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 //Aborting/evicting the wait_ibd handler corresponding to the sync peer
                                                 match ibd_command_tx.send(IBDCommands::AbortWaitHandle { peer_id:sync_peer_id }).await{
                                                     Ok(_)=>{
-                                                        info!("Abort handle and evicting handler corresponding to sync peer sent successfully");
+                                                        warn!("Abort handle and evicting handler corresponding to sync peer sent successfully");
                                                     },
                                                     Err(error)=>{
                                                         error!(error=?error,"An error occurred while sending abort handler wrt sync peer due to -");
@@ -550,7 +566,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 // If result is invalid then reinitiate IBD
                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                     Ok(_)=>{
-                                                        info!("Reinitiating IBD command sent to swarm handler");
+                                                        warn!("Reinitiating IBD command sent to swarm handler");
                                                     },
                                                     Err(error)=>{
                                                         error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
@@ -595,10 +611,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         // update the peer manager about the invalid bead
                                         peer_manager.penalize_for_invalid_bead(&message.source);
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
+                                        let bead_id = braid_data
+                                        .bead_index_mapping
+                                        .get(&bead.block_header.block_hash())
+                                        .unwrap();
+                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                            &braid_data.beads,
+                                            &braid_data.bead_index_mapping,
+                                            &bead,
+                                        ){
+                                            Ok(received_tuples)=>received_tuples,
+                                            Err(error)=>{
+                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                continue;
+                                            }
+                                        };
                                         // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
-                                           Ok(_)=>{
-                                               info!("Insert command sent successfully to db handler after receiving bead from peer");
+                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
+                                            Ok(_)=>{
+                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
                                            },
                                            Err(error)=>{
                                                error!(
@@ -732,6 +763,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             remote_addr = ?remote_addr,
                             "Connection established to peer"
                         );
+
                      }
                      SwarmEvent::ConnectionClosed {
                          peer_id,
@@ -770,13 +802,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             // Handle the bead sync request here
                             match request {
                                 BeadRequest::GetBeads(hashes) => {
-                                    // Check if we're still in IBD
-                                    if ibd_spinlock.load(Ordering::SeqCst) {
-                                        swarm.behaviour_mut().respond_with_error(
-                                            channel,
-                                            BeadSyncError::PeerSyncing,
-                                        );
-                                    } else {
                                         let mut beads = Vec::new();
                                         {
                                             let braid_lock = braid.read().await;
@@ -792,16 +817,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         }
                                         //Sending all the beads requested in the hashes supplied during `GetData` request
                                         swarm.behaviour_mut().respond_with_beads(channel, beads);
-                                    }
                                 }
                                 BeadRequest::GetTips => {
-                                    // Check if we're still in IBD
-                                    if ibd_spinlock.load(Ordering::SeqCst) {
-                                        swarm.behaviour_mut().respond_with_error(
-                                            channel,
-                                            BeadSyncError::PeerSyncing,
-                                        );
-                                    } else {
                                         let tips;
                                         {
                                             let braid_lock = braid.read().await;
@@ -814,16 +831,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 .collect();
                                         }
                                         swarm.behaviour_mut().respond_with_tips(channel, tips);
-                                    }
                                 }
                                 BeadRequest::GetGenesis => {
-                                    // Check if we're still in IBD
-                                    if ibd_spinlock.load(Ordering::SeqCst) {
-                                        swarm.behaviour_mut().respond_with_error(
-                                            channel,
-                                            BeadSyncError::PeerSyncing,
-                                        );
-                                    } else {
                                         let genesis;
                                         {
                                             let braid_lock = braid.read().await;
@@ -836,32 +845,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 .collect();
                                         }
                                         swarm.behaviour_mut().respond_with_genesis(channel, genesis);
-                                    }
                                 }
                                 BeadRequest::GetAllBeads => {
-                                    // Check if we're still in IBD
-                                    if ibd_spinlock.load(Ordering::SeqCst) {
-                                        swarm.behaviour_mut().respond_with_error(
-                                            channel,
-                                            BeadSyncError::PeerSyncing,
-                                        );
-                                    } else {
+
                                         let all_beads;
                                         {
                                             let braid_lock = braid.read().await;
                                             all_beads = braid_lock.beads.iter().cloned().collect();
                                         }
                                         swarm.behaviour_mut().respond_with_beads(channel, all_beads);
-                                    }
                                 }
                                 BeadRequest::GetBeadsAfter(hashes) => {
-                                    // Check if we're still in IBD
-                                    if ibd_spinlock.load(Ordering::SeqCst) {
-                                        swarm.behaviour_mut().respond_with_error(
-                                            channel,
-                                            BeadSyncError::PeerSyncing,
-                                        );
-                                    } else {
                                         let beads = braid.read().await.get_beads_after(hashes.into());
                                         if let Some(response_beads) = beads {
                                             let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
@@ -879,7 +873,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 BeadSyncError::BeadHashNotFound,
                                             );
                                         }
-                                    }
                                 }
                             }
                         }
@@ -894,14 +887,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     //Fetching the pruned bead-hashes received during `GetBeadAfter` request
                                     match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
                                         Ok(_)=>{
-                                            info!("IBD command sent to handler successfully !");
+                                            debug!("IBD command sent to handler successfully !");
                                         },
                                         Err(error)=>{
                                             //Re-initiating IBD
                                             error!("An error occurred while sending ibd command to ibd_handler - {:?}, re-trying IBD",error.0);
                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                 Ok(_)=>{
-                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                    warn!("Reinitiating IBD command sent to swarm handler");
                                                 },
                                                 Err(error)=>{
                                                     error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
@@ -918,7 +911,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             error!(error=?error.to_string(),"An error occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                 Ok(_)=>{
-                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                    warn!("Reinitiating IBD command sent to swarm handler");
                                                 },
                                                 Err(error)=>{
                                                     error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
@@ -927,20 +920,35 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             continue;
                                         }
                                     };
-                                    let mut braid_lock = braid.write().await;
                                     for bead in beads.into_iter() {
-                                        let status = braid_lock.extend(&bead);
+                                        let mut braid_data = braid.write().await;
+                                        let status = braid_data.extend(&bead);
                                         let curr_beadhash = bead.block_header.block_hash().to_string();
                                         if let braid::AddBeadStatus::InvalidBead = status {
                                             // update the peer manager about the invalid bead
                                             peer_manager.penalize_for_invalid_bead(&peer);
                                         } else if let braid::AddBeadStatus::BeadAdded = status {
+                                            let bead_id = braid_data
+                                            .bead_index_mapping
+                                            .get(&bead.block_header.block_hash())
+                                            .unwrap();
+                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                                &braid_data.beads,
+                                                &braid_data.bead_index_mapping,
+                                                &bead,
+                                            ){
+                                                Ok(received_tuples)=>received_tuples,
+                                                Err(error)=>{
+                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
+                                                    continue;
+                                                }
+                                            };
                                             // update score of the peer
                                             peer_manager.update_score(&peer, 1.0);
                                             //persisting the received beads from peer onto DB(disk)
-                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
+                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
                                                 Ok(_)=>{
-                                                    info!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
+                                                    debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
                                                 },
                                                 Err(error)=>{
                                                     tracing::error!(
@@ -956,13 +964,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
                                     match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await{
                                             Ok(_)=>{
-                                                info!("Offset Updated");
+                                                debug!("Offset Updated");
                                             },
                                             Err(error)=>{
                                                 error!(error=?error,"An error occurred while sending the offset update command, re-trying IBD");
                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                     Ok(_)=>{
-                                                        info!("Reinitiating IBD command sent to swarm handler");
+                                                        warn!("Reinitiating IBD command sent to swarm handler");
                                                     },
                                                     Err(error)=>{
                                                         error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
@@ -973,14 +981,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     };
                                     let next_batch_offset = match batch_rx.await{
                                         Ok(next_offset)=>{
-                                            info!(next_offset=?next_offset,"Newer offset for batch request received successfully val ");
+                                            debug!(next_offset=?next_offset,"Newer offset for batch request received successfully ");
                                             next_offset
                                         },
                                         Err(error)=>{
                                             error!(error=?error,"An error occurred while receiving the offset, re-trying IBD");
                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                 Ok(_)=>{
-                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                    warn!("Reinitiating IBD command sent to swarm handler");
                                                 },
                                                 Err(error)=>{
                                                     error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
@@ -990,17 +998,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         }
                                     };
                                     if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)< pruned_beads.len()){
+                                        info!("Received beads within batch range");
                                         swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..(next_batch_offset+IBD_BATCH_SIZE)].to_vec());
                                     }
                                     else if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)>=pruned_beads.len()){
+                                        info!("Received beads within batch range");
                                         swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..].to_vec());
 
                                     }
                                     else{
                                         //IBD completed
-                                        tracing::info!(
+                                        info!(
                                             peer = %peer,
-                                            "IBD has been completed with respect to peer"
+                                            "Initial IBD has been completed with respect to peer"
                                         );
                                         // Get current time and create recent timestamps (within last hour)
                                         let current_time = SystemTime::now()
@@ -1009,7 +1019,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         .as_secs();
                                         match ibd_command_tx.send(IBDCommands::UpdateTimestampMapping { peer_id: peer.to_string(), end_timestamp: current_time }).await{
                                             Ok(_)=>{
-                                                info!("Timestamp updated command sent successfully");
+                                                debug!("Timestamp updated command sent successfully");
                                                 //Scheduling a corresponding watcher task that will check after a latency period
                                                 //if no incoming is received during the instance of [initial_headers_fetched,(initial_headers_fetched+(alpha*10))]
                                                 let ibd_spinlock_ref = ibd_spinlock.clone();
@@ -1028,7 +1038,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 //At retry we will have to abort and evict the corresponding sync-peers's wait handle
                                                 match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:peer,retry_or_not:false,handle:Some(ibd_incoming_handler)}).await{
                                                     Ok(_)=>{
-                                                        info!("Incoming bead command sent successfully");
+                                                        debug!("Incoming bead command sent successfully");
                                                     },
                                                     Err(error)=>{
                                                         error!(error=?error,"An error occurred while sending Update Incoming due to ");
@@ -1044,15 +1054,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                  BeadResponse::GetBeadsAfter(bead_hashes)=>{
                                     //Getting all the beadhashes after the common oldest in both the peers
                                     let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    match ibd_command_tx.send(IBDCommands::FetchCachedTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
+                                    match ibd_command_tx.send(IBDCommands::FetchTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
                                         Ok(_)=>{
-                                            info!("Cached Tips received successfully.");
+                                            debug!("Sync peer Tips received successfully.");
                                         },
                                         Err(error)=>{
                                             error!(error=?error,"Error occurred while receiving tips, re-trying IBD");
                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                 Ok(_)=>{
-                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                    warn!("Reinitiating IBD command sent to swarm handler");
                                                 },
                                                 Err(error)=>{
                                                     error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
@@ -1069,7 +1079,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             error!(error=?error,"An error occurred while receiving the Tips, re-trying IBD");
                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                 Ok(_)=>{
-                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                    warn!("Reinitiating IBD command sent to swarm handler");
                                                 },
                                                 Err(error)=>{
                                                     error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
@@ -1096,13 +1106,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     // Storing them in cache
                                     match ibd_command_tx.send(IBDCommands::UpdateIncoming { get_bead_response: pruned, peer_id: peer.to_string() }).await{
                                         Ok(_)=>{
-                                            info!("Received beads to be fetched in GetBeads saved successfully");
+                                            debug!("Received beads to be fetched in GetBeads saved successfully");
                                         },
                                         Err(error)=>{
                                             error!(error=?error,"An error occurred while Caching pruned beadhashes to be fetched in GetBeads");
                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                 Ok(_)=>{
-                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                    warn!("Reinitiating IBD command sent to swarm handler");
                                                 },
                                                 Err(error)=>{
                                                     error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
@@ -1128,7 +1138,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     let (ibd_bridge_tx, _ibd_bridge_rx) = tokio::sync::oneshot::channel::<usize>();
                                     match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await{
                                         Ok(_)=>{
-                                            info!("Offset Initialized successfully");
+                                            debug!("Offset Initialized successfully");
                                         },
                                         Err(_error)=>{
                                             error!("An error occurred while sending offset initalization command to ibd_handler");
@@ -1155,7 +1165,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
                                   let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips.0, peer_id: peer.to_string() }).await{
                                     Ok(_)=>{
-                                        info!("Tip cache update successfully");
+                                        debug!("Sync peers Tip mapping update successfully");
                                     },
                                     Err(error)=>{
                                         tracing::error!(
@@ -1165,15 +1175,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         continue;
                                     }
                                   };
-                                    //After storing tips we will issue `GetBeads` command that will find the oldest
-                                    //common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
-                                    //the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
+                                    // After storing tips we will issue `GetBeads` command that will find the oldest
+                                    // common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
+                                    // the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
                                     let mut current_tip_hashes = Vec::new();
                                     let _ = braid_data.tips.iter().for_each(|curr_bead_idx|{
                                        let current_bead = braid_data.beads.get(*curr_bead_idx).unwrap();
                                        current_tip_hashes.push(current_bead.block_header.block_hash());
                                     });
-                                    //Sending the current bead hashes for the receiving of beads to start in batches
+                                    // Sending the current bead hashes for the receiving of beads to start in batches
                                     let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
                                     swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
 
@@ -1211,11 +1221,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     BeadSyncError::BeadHashNotFound => {
                                         warn!("Peer requested bead hashes not found in local store");
                                     }
-                                    BeadSyncError::PeerSyncing => {
-                                        warn!("Peer is still in IBD, retry with different peer");
-                                        // FIXME Could retry with different peer or wait
-                                        // For now, log and continue
-                                    }
                                 },
                             };
                         }
@@ -1244,59 +1249,101 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         let peer_ids = peer_manager.get_top_k_peers_for_propagation(1);
                         if peer_ids.len() == 0 {
                             warn!("No peer available for syncing to take place");
-                            //TODO: A fallback should be there to save all the connections and revert to a reachable connection which is established in future
-                            continue;
+                                tokio::spawn({
+                                    let swarm_command_sender = swarm_command_sender.clone();
+                                    //Retrying at fixed interval in case of no sync peers being available
+                                    async move {
+                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
+                                            Ok(_) => {
+                                                info!("Retrying IBD when no sync peers are available");
+                                            }
+                                            Err(error) => {
+                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
+                                            }
+                                        }
+                                    }
+                                });
                         }
                         else{
-                            let lowest_latency_peer = peer_ids.get(0).unwrap();
-                            let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
-                            match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:*lowest_latency_peer,retry_sender:retry_count_tx}).await{
-                                Ok(_)=>{
-                                    info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
-                                },
-                                Err(error)=>{
-                                    error!(error=?error,"An error occurred while sending retry count to IBDHandler");
+                            let mut sync_request_sent = false;
+                            for lowest_latency_peer in peer_ids.into_iter(){
+                                let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
+                                match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:lowest_latency_peer,retry_sender:retry_count_tx}).await{
+                                    Ok(_)=>{
+                                        info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
+                                    },
+                                    Err(error)=>{
+                                        error!(error=?error,"An error occurred while sending retry count to IBDHandler");
+                                    }
                                 }
-                            }
-                            let retry_cnt = match retry_count_rx.await {
-                                Ok(cnt) => cnt,
-                                Err(e) => {
-                                    error!(error=?e, "Failed to receive retry count from IBDHandler, channel closed or sender dropped");
+                                let retry_cnt = match retry_count_rx.await {
+                                    Ok(cnt) => cnt,
+                                    Err(e) => {
+                                        error!(error=?e, "Failed to receive retry count from IBDHandler, channel closed or sender dropped");
+                                        continue;
+                                    }
+                                };
+                                if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
+                                    warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
                                     continue;
                                 }
-                            };
-                            if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
-                                warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
+                                else if retry_cnt == u64::MAX{
+                                    //First time syncing is being done wrt the provided peer
+                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:false,handle:None}).await{
+                                        Ok(_)=>{
+                                            info!("Incoming bead command sent successfully");
+                                            let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                                            swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                                        },
+                                        Err(error)=>{
+                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                        }
+                                    };
+                                    sync_request_sent = true;
+                                    break;
+                                }
+                                else{
+                                    //Case of retry is there
+                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:true,handle:None}).await{
+                                        Ok(_)=>{
+                                            info!("Incoming bead command sent successfully");
+                                        },
+                                        Err(error)=>{
+                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                        }
+                                    };
+                                    //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
+                                    let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                                    swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                                    sync_request_sent = true;
+                                    break;
+                                }
+
+                            }
+                            if sync_request_sent{
+                                //The lowest latency avaialble sync peer whose retry count is not exceeded has been selected and requested to initiate IBD
                                 continue;
                             }
-                            else if retry_cnt == u64::MAX{
-                                //First time syncing is being done wrt the provided peer
-                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:false,handle:None}).await{
-                                    Ok(_)=>{
-                                        info!("Incoming bead command sent successfully");
-                                        let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                        swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                    },
-                                    Err(error)=>{
-                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                    }
-                                };
-                            }
                             else{
-                                //Case of retry is there
-                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:true,handle:None}).await{
-                                    Ok(_)=>{
-                                        info!("Incoming bead command sent successfully");
-                                    },
-                                    Err(error)=>{
-                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                warn!("Retry count for all the available sync peers exceeded waiting for new peer connections");
+                                tokio::spawn({
+                                    let swarm_command_sender = swarm_command_sender.clone();
+                                    //Retrying at fixed interval in case of all available sync peer retry count has exceeded
+                                    //Probe at fixed interval for any new peer
+                                    async move {
+                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
+                                            Ok(_) => {
+                                                info!("Retrying IBD when no sync peers are available");
+                                            }
+                                            Err(error) => {
+                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
+                                            }
+                                        }
                                     }
-                                };
-                                //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
-                                let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                                });
                             }
-
                         }
                      }
                  }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -15,6 +15,7 @@ use libp2p::{
     PeerId,
 };
 use node::db::db_handlers::fetch_beads_in_batch;
+use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
 use node::SwarmHandler;
 use node::{
@@ -35,6 +36,7 @@ use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, error::Error};
 use std::{fs, time::Duration};
 use tokio_util::sync::CancellationToken;
@@ -44,6 +46,7 @@ use tracing::{debug, error, info, trace, warn};
 use behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent};
 
 use crate::behaviour::KADPROTOCOLNAME;
+const LATENCY_ALPHA: u64 = 10;
 //boot nodes peerIds
 const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
 //dns NS
@@ -62,8 +65,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let _ibd_handler = tokio::spawn(async move {
         ibd_manager.handle_ibd_command().await;
     });
-
-    let ibd_or_not: AtomicBool = AtomicBool::new(false);
+    //False if not under ibd otherwise true
+    let ibd_or_not: AtomicBool = AtomicBool::new(true);
     let ibd_spinlock = Arc::new(ibd_or_not);
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
@@ -113,6 +116,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //Communication bridge between stratum and network swarm and swarm commands also, for communicating share population and propogating them further
     let (swarm_handler, mut swarm_command_receiver) =
         SwarmHandler::new(Arc::clone(&braid), db_tx.clone());
+    //Swarm command sender
+    let swarm_command_sender = swarm_handler.command_sender.clone();
     let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
     //cloning the channel to be sent across different interfaces
     let notification_tx_clone = notification_tx.clone();
@@ -126,7 +131,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let stratum_config: StratumServerConfig = StratumServerConfig::default();
     let (block_submission_tx, block_submission_rx) =
         tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
-
+    //IBD notifier task after peer_discovery
+    let swarm_command_sender_ref = swarm_command_sender.clone();
+    let _ibd_trigger_handler = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+        //Sending IBD initiating command
+        match swarm_command_sender_ref
+            .send(SwarmCommand::InitiateIBD)
+            .await
+        {
+            Ok(_) => {
+                info!("IBD trigger sent");
+            }
+            Err(error) => {
+                error!(error=?error,"An error occurred while initiating IBD after waiting for peer discovery - ");
+            }
+        };
+    });
     //Initializing stratum server
     let mut stratum_server = Server::new(
         stratum_config,
@@ -447,52 +468,147 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              size_bytes = %message.data.len(),
                              "Floodsub message received"
                          );
-                         let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> =
-                             deserialize(&message.data);
+                         let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&message.data);
                          match result_bead {
                              Ok(bead) => {
-                                 info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
-                                 // Handle the received bead here
-                                 let status = {
+                                info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
+                                // Handle the received bead here
+                                let status = {
                                      let mut braid_lock = braid.write().await;
                                      braid_lock.extend(&bead)
                                  };
-                                 if let braid::AddBeadStatus::ParentsNotYetReceived = status {
-                                     //request the parents using request response protocol
-                                     let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
-                                     if let Some(peer) = peer_id.first() {
-                                         swarm.behaviour_mut().bead_sync.send_request(
-                                             &peer,
-                                             BeadRequest::GetBeads(
-                                                 bead.committed_metadata
-                                                     .parents
-                                                     .clone()
-                                                     .into_iter()
-                                                     .collect(),
-                                             ),
-                                         );
-                                     } else {
-                                         warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
-                                     }
-                                 } else if let braid::AddBeadStatus::InvalidBead = status {
-                                     // update the peer manager about the invalid bead
-                                     peer_manager.penalize_for_invalid_bead(&message.source);
-                                 } else if let braid::AddBeadStatus::BeadAdded = status {
-                                     // update score of the peer and adding to local db store
-                                     let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
-                                        Ok(_)=>{
-                                            info!("Insert command sent successfully to db handler after receiving bead from peer");
-                                        },
-                                        Err(error)=>{
-                                            error!(
-                                                source = ?message.source,
-                                                err = ?error.0,
-                                                "An error occurred while sending insert bead command received from peer"
-                                            );
+                                 if ibd_spinlock.load(std::sync::atomic::Ordering::SeqCst){
+                                    let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
+                                    let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
+                                    if let Err(e) = ibd_command_tx
+                                        .send(IBDCommands::FetchAllTimestamps { sender: ts_tx })
+                                        .await {
+                                        tracing::warn!("Failed to request timestamp map: {:?}", e);
+                                    }
+                                    let timestamp_map = match ts_rx.await {
+                                        Ok(map) => map,
+                                        Err(_) => {
+                                            tracing::warn!("Failed to receive timestamp map");
+                                            return;
                                         }
-                                     };
-                                     peer_manager.update_score(&message.source, 1.0);
-                                 }
+                                    };
+                                      //If the received  bead exceeds the timestamp of ibd completion wrt to a sync node
+                                      if let braid::AddBeadStatus::ParentsNotYetReceived = status {
+                                        //request the parents using request response protocol
+                                        let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
+                                        if let Some(peer) = peer_id.first() {
+                                            swarm.behaviour_mut().bead_sync.send_request(
+                                                &peer,
+                                                BeadRequest::GetBeads(
+                                                    bead.committed_metadata
+                                                        .parents
+                                                        .clone()
+                                                        .into_iter()
+                                                        .collect(),
+                                                ),
+                                            );
+                                        } else {
+                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
+                                        }
+                                    } else if let braid::AddBeadStatus::InvalidBead = status {
+                                        // update the peer manager about the invalid bead
+                                        peer_manager.penalize_for_invalid_bead(&message.source);
+                                    } else if let braid::AddBeadStatus::BeadAdded = status {
+                                        // update score of the peer and adding to local db store
+                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
+                                           Ok(_)=>{
+                                               info!("Insert command sent successfully to db handler after receiving bead from peer");
+                                           },
+                                           Err(error)=>{
+                                               error!(
+                                                   source = ?message.source,
+                                                   err = ?error.0,
+                                                   "An error occurred while sending insert bead command received from peer"
+                                               );
+                                           }
+                                        };
+                                        peer_manager.update_score(&message.source, 1.0);
+                                    }
+                                    for (sync_peer, ibd_ts) in timestamp_map.iter() {
+                                        let threshold = *ibd_ts + LATENCY_ALPHA * 10;
+                                        let sync_peer_id = sync_peer.parse::<PeerId>().unwrap();
+                                        // broadcast_timestamp < timestamp + alpha * 10
+                                        if broadcast_ts  < threshold as u32 {
+                                            info!("Incoming BEAD received during IBD within threshold limit with broadcast timestamp - {:?} and threshold is - {:?}",broadcast_ts,threshold);
+                                           match status{
+                                            braid::AddBeadStatus::InvalidBead | braid::AddBeadStatus::ParentsNotYetReceived=>{
+                                                //Aborting/evicting the wait_ibd handler corresponding to the sync peer
+                                                match ibd_command_tx.send(IBDCommands::AbortWaitHandle { peer_id:sync_peer_id }).await{
+                                                    Ok(_)=>{
+                                                        info!("Abort handle and evicting handler corresponding to sync peer sent successfully");
+                                                    },
+                                                    Err(error)=>{
+                                                        error!(error=?error,"An error occurred while sending abort handler wrt sync peer due to -");
+                                                    }
+                                                };
+                                                // If result is invalid then reinitiate IBD
+                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                    Ok(_)=>{
+                                                        info!("Reinitiating IBD command sent to swarm handler");
+                                                    },
+                                                    Err(error)=>{
+                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                    }
+                                                }
+                                                continue;
+                                            },
+                                            braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
+                                                ibd_spinlock.store(false,std::sync::atomic::Ordering::SeqCst);
+                                                continue;
+                                            },
+                                           }
+
+                                        }
+                                        else{
+                                            ibd_spinlock.store(false,std::sync::atomic::Ordering::SeqCst);
+                                            continue;
+                                        }
+                                    }
+                                }
+                                else{
+                                    if let braid::AddBeadStatus::ParentsNotYetReceived = status {
+                                        //request the parents using request response protocol
+                                        let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
+                                        if let Some(peer) = peer_id.first() {
+                                            swarm.behaviour_mut().bead_sync.send_request(
+                                                &peer,
+                                                BeadRequest::GetBeads(
+                                                    bead.committed_metadata
+                                                        .parents
+                                                        .clone()
+                                                        .into_iter()
+                                                        .collect(),
+                                                ),
+                                            );
+                                        } else {
+                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
+                                        }
+                                    } else if let braid::AddBeadStatus::InvalidBead = status {
+                                        // update the peer manager about the invalid bead
+                                        peer_manager.penalize_for_invalid_bead(&message.source);
+                                    } else if let braid::AddBeadStatus::BeadAdded = status {
+                                        // update score of the peer and adding to local db store
+                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
+                                           Ok(_)=>{
+                                               info!("Insert command sent successfully to db handler after receiving bead from peer");
+                                           },
+                                           Err(error)=>{
+                                               error!(
+                                                   source = ?message.source,
+                                                   err = ?error.0,
+                                                   "An error occurred while sending insert bead command received from peer"
+                                               );
+                                           }
+                                        };
+                                        peer_manager.update_score(&message.source, 1.0);
+                                    }
+                                }
+
                              }
                              Err(e) => {
                                  error!(error = %e, "Failed to deserialize bead");
@@ -574,6 +690,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      latency_ms = %latency.as_millis(),
                                      "Ping"
                                  );
+                                peer_manager.update_latency(&peer,latency);
                              }
                              Err(err) => {
                                  warn!(
@@ -612,9 +729,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             remote_addr = ?remote_addr,
                             "Connection established to peer"
                         );
-                         //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
-                         let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                         swarm.behaviour_mut().bead_sync.send_request(&peer_id, sync_start_request);
                      }
                      SwarmEvent::ConnectionClosed {
                          peer_id,
@@ -737,15 +851,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 | bead::BeadResponse::GetAllBeads(beads) => {
                                     let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
                                     //Fetching the pruned bead-hashes received during `GetBeadAfter` request
-                                    match ibd_command_tx.send(IBDCommands::FetchGetBeadCache { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
+                                    match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
                                         Ok(_)=>{
                                             info!("IBD command sent to handler successfully !");
                                         },
                                         Err(error)=>{
                                             //Re-initiating IBD
                                             error!("An error occurred while sending ibd command to ibd_handler - {:?}, re-trying IBD",error.0);
-                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                Ok(_)=>{
+                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                },
+                                                Err(error)=>{
+                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                }
+                                            }
                                             continue;
                                         }
                                     };
@@ -755,8 +875,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         },
                                         Err(error)=>{
                                             error!(error=?error.to_string(),"An ERROR occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
-                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                Ok(_)=>{
+                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                },
+                                                Err(error)=>{
+                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                }
+                                            }
                                             continue;
                                         }
                                     };
@@ -773,7 +899,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             //persisting the recived beads from peer onto DB(disk)
                                             match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
                                                 Ok(_)=>{
-                                                    info!(beadhash=?curr_beadhash,"Bead recieved in IBD persisted over disk with beadhash and status BeadAdded");
+                                                    info!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
                                                 },
                                                 Err(error)=>{
                                                     tracing::error!(
@@ -793,8 +919,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             },
                                             Err(error)=>{
                                                 error!(error=?error,"An error occurred while sending the offset update command, re-trying IBD");
-                                                let sync_retry_request:BeadRequest = BeadRequest::GetTips;
-                                                swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                    Ok(_)=>{
+                                                        info!("Reinitiating IBD command sent to swarm handler");
+                                                    },
+                                                    Err(error)=>{
+                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                    }
+                                                }
                                                 continue;
                                             }
                                     };
@@ -804,9 +936,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             next_offset
                                         },
                                         Err(error)=>{
-                                            error!(error=?error,"An error occurred while receving the offset, re-trying IBD");
-                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            error!(error=?error,"An error occurred while receiving the offset, re-trying IBD");
+                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                Ok(_)=>{
+                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                },
+                                                Err(error)=>{
+                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                }
+                                            }
                                             continue;
                                         }
                                     };
@@ -823,8 +961,43 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             peer = %peer,
                                             "IBD has been completed with respect to peer"
                                         );
-                                        ibd_spinlock.store(false, std::sync::atomic::Ordering::SeqCst);
-                                        continue;
+                                        // Get current time and create recent timestamps (within last hour)
+                                        let current_time = SystemTime::now()
+                                        .duration_since(UNIX_EPOCH)
+                                        .unwrap()
+                                        .as_secs();
+                                        match ibd_command_tx.send(IBDCommands::UpdateTimestampMapping { peer_id: peer.to_string(), end_timestamp: current_time }).await{
+                                            Ok(_)=>{
+                                                info!("Timestamp updated command sent successfully");
+                                                //Scheduling a corresponding watcher task that will check after a latency period
+                                                //if no incoming is received during the instance of [initial_headers_fetched,(initial_headers_fetched+(alpha*10))]
+                                                let ibd_spinlock_ref = ibd_spinlock.clone();
+                                                let ibd_incoming_handler = tokio::spawn(async move{
+                                                    //Sleeping for a fixed duration to be set according to statistical estimates
+                                                    tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
+                                                    //We will check if no bead is `incoming` after the duration of 600 seconds then we will reset/set ibd_flag accordingly
+                                                    if ibd_spinlock_ref.load(std::sync::atomic::Ordering::SeqCst) == true{
+                                                        //If no incoming is received during the period then we can say
+                                                        //that ibd wrt the given sync node is successfully completed
+                                                        ibd_spinlock_ref.store(false,std::sync::atomic::Ordering::SeqCst);
+                                                        warn!("Maximum threshold wrt IBD incoming exceeded thus ibd_flag being set to false");
+                                                    }
+
+                                                });
+                                                //At retry we will have to abort and evict the corresponding sync-peers's wait handle
+                                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:peer,retry_or_not:false,handle:Some(ibd_incoming_handler)}).await{
+                                                    Ok(_)=>{
+                                                        info!("Incoming bead command sent successfully");
+                                                    },
+                                                    Err(error)=>{
+                                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                                    }
+                                                };
+                                            },
+                                            Err(error)=>{
+                                                error!(error=?error,"An error occurred while sending timestamp update command for the given sync node");
+                                            }
+                                        };
                                     }
                                 }
                                  bead::BeadResponse::GetBeadsAfter(bead_hashes)=>{
@@ -836,8 +1009,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         },
                                         Err(error)=>{
                                             error!(error=?error,"Error occurred while receiving tips, re-trying IBD");
-                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                Ok(_)=>{
+                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                },
+                                                Err(error)=>{
+                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
+                                                }
+                                            }
                                             continue;
                                         }
                                     };
@@ -846,9 +1025,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             received_tips
                                         },
                                         Err(error)=>{
-                                            error!(error=?error,"An error occurred while receving the Tips, re-trying IBD");
-                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            error!(error=?error,"An error occurred while receiving the Tips, re-trying IBD");
+                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                Ok(_)=>{
+                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                },
+                                                Err(error)=>{
+                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
+                                                }
+                                            }
                                             continue;
                                         }
                                     };
@@ -868,14 +1053,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
                                     let pruned_ref = pruned.clone();
                                     // Storing them in cache
-                                    match ibd_command_tx.send(IBDCommands::UpdateIBDGetBeadCache { get_bead_response: pruned, peer_id: peer.to_string() }).await{
+                                    match ibd_command_tx.send(IBDCommands::UpdateIncoming { get_bead_response: pruned, peer_id: peer.to_string() }).await{
                                         Ok(_)=>{
                                             info!("Received beads to be fetched in GetBeads saved successfully");
                                         },
                                         Err(error)=>{
                                             error!(error=?error,"An error occurred while Caching pruned beadhashes to be fetched in GetBeads");
-                                            let sync_retry_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&peer, sync_retry_request);
+                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                Ok(_)=>{
+                                                    info!("Reinitiating IBD command sent to swarm handler");
+                                                },
+                                                Err(error)=>{
+                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
+                                                }
+                                            }
                                             continue;
                                         }
                                     };
@@ -917,11 +1108,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     if flag == true{
                                         //No need to proceed further and continue to next event
                                         info!("Peer already synced to tip");
+                                        //IBD flag can be set  as the current bead is already synced//
+                                        ibd_spinlock.store(false, std::sync::atomic::Ordering::SeqCst);
                                         continue;
                                     }
-                                    //IBD flag can be set  as the current bead is already synced//
-                                    ibd_spinlock.store(true, std::sync::atomic::Ordering::SeqCst);
-                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsCache { received_tips: tips, peer_id: peer.to_string() }).await{
+                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips, peer_id: peer.to_string() }).await{
                                     Ok(_)=>{
                                         info!("Tip cache update successfully");
                                     },
@@ -1000,6 +1191,53 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              .bead_announce
                              .publish(current_broadcast_topic.clone(), bead_bytes);
                         info!(topic = ?current_broadcast_topic, "Published bead to floodsub topic");
+                     },
+                     SwarmCommand::InitiateIBD=>{
+                        info!("Initiating IBD after peer discovery and selecting peer with lowest latency score");
+                        //Evicting lowest latency peer id
+                        let peer_ids = peer_manager.get_top_k_peers_for_propagation(1);
+                        let lowest_latency_peer = peer_ids.get(0).unwrap();
+                        let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
+                        match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:*lowest_latency_peer,retry_sender:retry_count_tx}).await{
+                            Ok(_)=>{
+                                info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
+                            },
+                            Err(error)=>{
+                                error!(error=?error,"An error occurred while sending retry count to IBDHandler");
+                            }
+                        }
+                        let retry_cnt = retry_count_rx.await.unwrap();
+                        if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
+                            warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
+                            continue;
+                        }
+                        else if retry_cnt == u64::MAX{
+                            //First time syncing is being done wrt the provided peer
+                            match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:false,handle:None}).await{
+                                Ok(_)=>{
+                                    info!("Incoming bead command sent successfully");
+                                    let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                                    swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                                },
+                                Err(error)=>{
+                                    error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                }
+                            };
+                        }
+                        else{
+                            //Case of retry is there
+                            match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:true,handle:None}).await{
+                                Ok(_)=>{
+                                    info!("Incoming bead command sent successfully");
+                                },
+                                Err(error)=>{
+                                    error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                }
+                            };
+                            //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
+                            let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                            swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                        }
                      }
                  }
              }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -19,7 +19,7 @@ use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_R
 use node::utils::BeadHash;
 use node::SwarmHandler;
 use node::{
-    bead::{self, Bead, BeadRequest, BeadSyncError},
+    bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
     behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
     braid, cli,
     db::db_handlers::DBHandler,
@@ -34,7 +34,7 @@ use node::{
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, error::Error};
@@ -46,8 +46,8 @@ use tracing::{debug, error, info, trace, warn};
 use behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent};
 
 use crate::behaviour::KADPROTOCOLNAME;
-const LATENCY_ALPHA: u64 = 10;
-//boot nodes peerIds
+const LATENCY_ALPHA: u64 = 10; // seconds
+                               //boot nodes peerIds
 const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
 //dns NS
 const SEED_DNS: &str = "/dnsaddr/french.braidpool.net";
@@ -65,15 +65,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let _ibd_handler = tokio::spawn(async move {
         ibd_manager.handle_ibd_command().await;
     });
-    //False if not under ibd otherwise true
+    //False if not under ibd otherwise true at start will be in IBD by default
     let ibd_or_not: AtomicBool = AtomicBool::new(true);
     let ibd_spinlock = Arc::new(ibd_or_not);
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
-    let genesis_beads = Vec::from([]);
     // Initializing the braid object with read write lock
     //for supporting concurrent readers and single writer
-    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
     //Initializing DB and db command handler
     let (mut _db_handler, db_tx) = DBHandler::new(Arc::clone(&braid)).await.unwrap();
     let db_connection_pool = _db_handler.db_connection_pool.clone();
@@ -477,7 +476,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      let mut braid_lock = braid.write().await;
                                      braid_lock.extend(&bead)
                                  };
-                                 if ibd_spinlock.load(std::sync::atomic::Ordering::SeqCst){
+                                 if ibd_spinlock.load(Ordering::SeqCst){
                                     let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
                                     let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
                                     if let Err(e) = ibd_command_tx
@@ -488,8 +487,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     let timestamp_map = match ts_rx.await {
                                         Ok(map) => map,
                                         Err(_) => {
-                                            tracing::warn!("Failed to receive timestamp map");
-                                            return;
+                                            tracing::error!("Failed to receive timestamp map");
+                                            continue;
                                         }
                                     };
                                       //If the received  bead exceeds the timestamp of ibd completion wrt to a sync node
@@ -500,11 +499,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             swarm.behaviour_mut().bead_sync.send_request(
                                                 &peer,
                                                 BeadRequest::GetBeads(
-                                                    bead.committed_metadata
-                                                        .parents
-                                                        .clone()
-                                                        .into_iter()
-                                                        .collect(),
+                                                    BeadHashes(
+                                                        bead.committed_metadata
+                                                            .parents
+                                                            .clone()
+                                                            .into_iter()
+                                                            .collect(),
+                                                    )
                                                 ),
                                             );
                                         } else {
@@ -558,14 +559,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 continue;
                                             },
                                             braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
-                                                ibd_spinlock.store(false,std::sync::atomic::Ordering::SeqCst);
+                                                ibd_spinlock.store(false,Ordering::SeqCst);
                                                 continue;
                                             },
                                            }
 
                                         }
                                         else{
-                                            ibd_spinlock.store(false,std::sync::atomic::Ordering::SeqCst);
+                                            ibd_spinlock.store(false,Ordering::SeqCst);
                                             continue;
                                         }
                                     }
@@ -578,11 +579,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             swarm.behaviour_mut().bead_sync.send_request(
                                                 &peer,
                                                 BeadRequest::GetBeads(
-                                                    bead.committed_metadata
-                                                        .parents
-                                                        .clone()
-                                                        .into_iter()
-                                                        .collect(),
+                                                    BeadHashes(
+                                                        bead.committed_metadata
+                                                            .parents
+                                                            .clone()
+                                                            .into_iter()
+                                                            .collect(),
+                                                    )
                                                 ),
                                             );
                                         } else {
@@ -766,78 +769,116 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         } => {
                             // Handle the bead sync request here
                             match request {
-                                bead::BeadRequest::GetBeads(hashes) => {
-                                    let mut beads = Vec::new();
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        for hash in hashes.iter() {
-                                            if let Some(index) =
-                                                braid_lock.bead_index_mapping.get(hash)
-                                            {
-                                                if let Some(bead) = braid_lock.beads.get(*index) {
-                                                    beads.push(bead.clone());
+                                BeadRequest::GetBeads(hashes) => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let mut beads = Vec::new();
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            for hash in hashes.iter() {
+                                                if let Some(index) =
+                                                    braid_lock.bead_index_mapping.get(hash)
+                                                {
+                                                    if let Some(bead) = braid_lock.beads.get(*index) {
+                                                        beads.push(bead.clone());
+                                                    }
                                                 }
                                             }
                                         }
+                                        //Sending all the beads requested in the hashes supplied during `GetData` request
+                                        swarm.behaviour_mut().respond_with_beads(channel, beads);
                                     }
-                                    //Sending all the beads requested in the hashes supplied during `GetData` request
-                                    swarm.behaviour_mut().respond_with_beads(channel, beads);
                                 }
-                                bead::BeadRequest::GetTips => {
-                                    let tips;
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        tips = braid_lock
-                                            .tips
-                                            .iter()
-                                            .filter_map(|index| braid_lock.beads.get(*index))
-                                            .cloned()
-                                            .map(|bead| bead.block_header.block_hash())
-                                            .collect();
-                                    }
-                                    swarm.behaviour_mut().respond_with_tips(channel, tips);
-                                }
-                                bead::BeadRequest::GetGenesis => {
-                                    let genesis;
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        genesis = braid_lock
-                                            .genesis_beads
-                                            .iter()
-                                            .filter_map(|index| braid_lock.beads.get(*index))
-                                            .cloned()
-                                            .map(|bead| bead.block_header.block_hash())
-                                            .collect();
-                                    }
-                                    swarm.behaviour_mut().respond_with_genesis(channel, genesis);
-                                }
-                                bead::BeadRequest::GetAllBeads => {
-                                    let all_beads;
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        all_beads = braid_lock.beads.iter().cloned().collect();
-                                    }
-                                    swarm.behaviour_mut().respond_with_beads(channel, all_beads);
-                                }
-                                bead::BeadRequest::GetBeadsAfter(hashes) => {
-                                    let beads = braid.read().await.get_beads_after(hashes);
-                                    if let Some(response_beads) = beads {
-                                        let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
-                                        for bead in response_beads.into_iter(){
-                                            computed_beads_hashes.push(bead.block_header.block_hash());
-                                        }
-                                        //Sending the corresponding bead hashes requested by the new peer for IBD that will
-                                        //be after the new peer's `Tips`.
-                                        swarm
-                                            .behaviour_mut()
-                                            .respond_with_beadhashes(channel, computed_beads_hashes);
-                                    } else {
+                                BeadRequest::GetTips => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
                                         swarm.behaviour_mut().respond_with_error(
                                             channel,
-                                            BeadSyncError::Other(String::from(
-                                                "provided hashes not found",
-                                            )),
+                                            BeadSyncError::PeerSyncing,
                                         );
+                                    } else {
+                                        let tips;
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            tips = braid_lock
+                                                .tips
+                                                .iter()
+                                                .filter_map(|index| braid_lock.beads.get(*index))
+                                                .cloned()
+                                                .map(|bead| bead.block_header.block_hash())
+                                                .collect();
+                                        }
+                                        swarm.behaviour_mut().respond_with_tips(channel, tips);
+                                    }
+                                }
+                                BeadRequest::GetGenesis => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let genesis;
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            genesis = braid_lock
+                                                .genesis_beads
+                                                .iter()
+                                                .filter_map(|index| braid_lock.beads.get(*index))
+                                                .cloned()
+                                                .map(|bead| bead.block_header.block_hash())
+                                                .collect();
+                                        }
+                                        swarm.behaviour_mut().respond_with_genesis(channel, genesis);
+                                    }
+                                }
+                                BeadRequest::GetAllBeads => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let all_beads;
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            all_beads = braid_lock.beads.iter().cloned().collect();
+                                        }
+                                        swarm.behaviour_mut().respond_with_beads(channel, all_beads);
+                                    }
+                                }
+                                BeadRequest::GetBeadsAfter(hashes) => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let beads = braid.read().await.get_beads_after(hashes.into());
+                                        if let Some(response_beads) = beads {
+                                            let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
+                                            for bead in response_beads.into_iter(){
+                                                computed_beads_hashes.push(bead.block_header.block_hash());
+                                            }
+                                            //Sending the corresponding bead hashes requested by the new peer for IBD that will
+                                            //be after the new peer's `Tips`.
+                                            swarm
+                                                .behaviour_mut()
+                                                .respond_with_beadhashes(channel, computed_beads_hashes);
+                                        } else {
+                                            swarm.behaviour_mut().respond_with_error(
+                                                channel,
+                                                BeadSyncError::BeadHashNotFound,
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -847,8 +888,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             response,
                         } => {
                             match response {
-                                bead::BeadResponse::Beads(beads)
-                                | bead::BeadResponse::GetAllBeads(beads) => {
+                                BeadResponse::Beads(beads)
+                                | BeadResponse::GetAllBeads(beads) => {
                                     let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
                                     //Fetching the pruned bead-hashes received during `GetBeadAfter` request
                                     match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
@@ -874,7 +915,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             received_beads
                                         },
                                         Err(error)=>{
-                                            error!(error=?error.to_string(),"An ERROR occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
+                                            error!(error=?error.to_string(),"An error occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
                                                 Ok(_)=>{
                                                     info!("Reinitiating IBD command sent to swarm handler");
@@ -896,7 +937,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         } else if let braid::AddBeadStatus::BeadAdded = status {
                                             // update score of the peer
                                             peer_manager.update_score(&peer, 1.0);
-                                            //persisting the recived beads from peer onto DB(disk)
+                                            //persisting the received beads from peer onto DB(disk)
                                             match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead } }).await{
                                                 Ok(_)=>{
                                                     info!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
@@ -976,10 +1017,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     //Sleeping for a fixed duration to be set according to statistical estimates
                                                     tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
                                                     //We will check if no bead is `incoming` after the duration of 600 seconds then we will reset/set ibd_flag accordingly
-                                                    if ibd_spinlock_ref.load(std::sync::atomic::Ordering::SeqCst) == true{
+                                                    if ibd_spinlock_ref.load(Ordering::SeqCst){
                                                         //If no incoming is received during the period then we can say
                                                         //that ibd wrt the given sync node is successfully completed
-                                                        ibd_spinlock_ref.store(false,std::sync::atomic::Ordering::SeqCst);
+                                                        ibd_spinlock_ref.store(false,Ordering::SeqCst);
                                                         warn!("Maximum threshold wrt IBD incoming exceeded thus ibd_flag being set to false");
                                                     }
 
@@ -1000,7 +1041,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         };
                                     }
                                 }
-                                 bead::BeadResponse::GetBeadsAfter(bead_hashes)=>{
+                                 BeadResponse::GetBeadsAfter(bead_hashes)=>{
                                     //Getting all the beadhashes after the common oldest in both the peers
                                     let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
                                     match ibd_command_tx.send(IBDCommands::FetchCachedTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
@@ -1079,7 +1120,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
 
                                 }
-                                bead::BeadResponse::Tips(tips) => {
+                                BeadResponse::Tips(tips) => {
                                     info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
                                     //If received tips are already present in the local braid arc then we can stop
                                     //IBD and continue with mining
@@ -1105,14 +1146,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
                                     let flag = tips.iter().all(|tip_hash| bead_hash_set.contains(tip_hash));
 
-                                    if flag == true{
+                                    if flag{
                                         //No need to proceed further and continue to next event
                                         info!("Peer already synced to tip");
                                         //IBD flag can be set  as the current bead is already synced//
-                                        ibd_spinlock.store(false, std::sync::atomic::Ordering::SeqCst);
+                                        ibd_spinlock.store(false, Ordering::SeqCst);
                                         continue;
                                     }
-                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips, peer_id: peer.to_string() }).await{
+                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips.0, peer_id: peer.to_string() }).await{
                                     Ok(_)=>{
                                         info!("Tip cache update successfully");
                                     },
@@ -1133,15 +1174,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                        current_tip_hashes.push(current_bead.block_header.block_hash());
                                     });
                                     //Sending the current bead hashes for the receiving of beads to start in batches
-                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(current_tip_hashes);
+                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
                                     swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
 
                                 }
-                                bead::BeadResponse::Genesis(genesis) => {
+                                BeadResponse::Genesis(genesis) => {
                                     info!(genesis=?genesis,"Received genesis beads: ");
                                     let status = {
                                         let braid_lock = braid.read().await;
-                                        braid_lock.check_genesis_beads(&genesis)
+                                        braid_lock.check_genesis_beads(&genesis.0)
                                     };
                                     match status {
                                         braid::GenesisCheckStatus::GenesisBeadsValid => {
@@ -1151,24 +1192,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             warn!(peer = %peer, "Missing genesis bead");
                                             swarm
                                                 .behaviour_mut()
-                                                .request_beads(peer, &genesis);
+                                                .request_beads(peer, &genesis.0);
                                         }
                                         braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
                                             warn!(
-                                                received = %genesis.len(),
+                                                received = %genesis.0.len(),
                                                 peer = %peer,
                                                 "Genesis bead count mismatch"
                                             );
                                         }
                                     }
                                 }
-                                bead::BeadResponse::Error(error) => match error {
+                                BeadResponse::Error(error) => match error {
                                     BeadSyncError::GenesisMismatch => {
                                         warn!("Genesis mismatch error received");
                                         swarm.behaviour_mut().request_genesis(peer.clone());
                                     }
-                                    BeadSyncError::Other(ref err_msg) => {
-                                        error!(err_msg=?err_msg,"Error in bead sync response:");
+                                    BeadSyncError::BeadHashNotFound => {
+                                        warn!("Peer requested bead hashes not found in local store");
+                                    }
+                                    BeadSyncError::PeerSyncing => {
+                                        warn!("Peer is still in IBD, retry with different peer");
+                                        // FIXME Could retry with different peer or wait
+                                        // For now, log and continue
                                     }
                                 },
                             };
@@ -1196,47 +1242,61 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         info!("Initiating IBD after peer discovery and selecting peer with lowest latency score");
                         //Evicting lowest latency peer id
                         let peer_ids = peer_manager.get_top_k_peers_for_propagation(1);
-                        let lowest_latency_peer = peer_ids.get(0).unwrap();
-                        let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
-                        match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:*lowest_latency_peer,retry_sender:retry_count_tx}).await{
-                            Ok(_)=>{
-                                info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
-                            },
-                            Err(error)=>{
-                                error!(error=?error,"An error occurred while sending retry count to IBDHandler");
-                            }
-                        }
-                        let retry_cnt = retry_count_rx.await.unwrap();
-                        if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
-                            warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
+                        if peer_ids.len() == 0 {
+                            warn!("No peer available for syncing to take place");
+                            //TODO: A fallback should be there to save all the connections and revert to a reachable connection which is established in future
                             continue;
                         }
-                        else if retry_cnt == u64::MAX{
-                            //First time syncing is being done wrt the provided peer
-                            match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:false,handle:None}).await{
-                                Ok(_)=>{
-                                    info!("Incoming bead command sent successfully");
-                                    let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                    swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                },
-                                Err(error)=>{
-                                    error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                }
-                            };
-                        }
                         else{
-                            //Case of retry is there
-                            match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:true,handle:None}).await{
+                            let lowest_latency_peer = peer_ids.get(0).unwrap();
+                            let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
+                            match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:*lowest_latency_peer,retry_sender:retry_count_tx}).await{
                                 Ok(_)=>{
-                                    info!("Incoming bead command sent successfully");
+                                    info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
                                 },
                                 Err(error)=>{
-                                    error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                    error!(error=?error,"An error occurred while sending retry count to IBDHandler");
+                                }
+                            }
+                            let retry_cnt = match retry_count_rx.await {
+                                Ok(cnt) => cnt,
+                                Err(e) => {
+                                    error!(error=?e, "Failed to receive retry count from IBDHandler, channel closed or sender dropped");
+                                    continue;
                                 }
                             };
-                            //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
-                            let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                            swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                            if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
+                                warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
+                                continue;
+                            }
+                            else if retry_cnt == u64::MAX{
+                                //First time syncing is being done wrt the provided peer
+                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:false,handle:None}).await{
+                                    Ok(_)=>{
+                                        info!("Incoming bead command sent successfully");
+                                        let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                                        swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                                    },
+                                    Err(error)=>{
+                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                    }
+                                };
+                            }
+                            else{
+                                //Case of retry is there
+                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:*lowest_latency_peer,retry_or_not:true,handle:None}).await{
+                                    Ok(_)=>{
+                                        info!("Incoming bead command sent successfully");
+                                    },
+                                    Err(error)=>{
+                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                    }
+                                };
+                                //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
+                                let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                                swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                            }
+
                         }
                      }
                  }

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -54,7 +54,7 @@ pub enum RpcCommand {
 //parsing the inital rpc command line all
 pub async fn parse_arguments(cli_command: RpcCommand, server_addr: SocketAddr) -> () {
     // //initializing a client associated with the current node
-    // //for receving the response from the server
+    // //for receiving the response from the server
     let target_uri = format!("http://{}", server_addr.to_string());
     let client_res: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1752,7 +1752,7 @@ impl Server {
             tokio::select! {
                     event = listener.accept()=>{
                         //Currently we do not accept connections from downstream during IBD wrt to sync nodes
-                        if ibd_or_not.clone().load(std::sync::atomic::Ordering::SeqCst) == true{
+                        if ibd_or_not.load(std::sync::atomic::Ordering::SeqCst) == true{
                         warn!("Braid node not synced and is under IBD thus skipping the connection from downstream.");
                             continue;
                         }

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -11,6 +11,7 @@ use num::ToPrimitive;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::sync::atomic::AtomicBool;
 use std::time::UNIX_EPOCH;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use tokio::{
@@ -1716,6 +1717,7 @@ impl Server {
         mining_job_map: Arc<Mutex<HashMap<String, Arc<Mutex<MiningJobMap>>>>>,
         notification_sender: mpsc::Sender<NotifyCmd>,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
+        ibd_or_not: Arc<AtomicBool>,
     ) -> Result<(), Box<std::io::Error>> {
         debug!("Starting stratum server");
         let bind_address = format!(
@@ -1748,82 +1750,89 @@ impl Server {
         }
         loop {
             tokio::select! {
-                event = listener.accept()=>{
-                    //shared ownership across all tasks and spawning a seperate downstream for each new connection
-                    let self_ = Arc::new(Mutex::new(DownstreamClient::default()));
-                    let (connection_id, connection_id_hex) = {
-                        let mut client = self_.lock().await;
-                        if let Some(ref submission_tx) = self.block_submission_tx {
-                            client.block_submission_tx = Some(submission_tx.clone());
+                    event = listener.accept()=>{
+                        //Currently we do not accept connections from downstream during IBD wrt to sync nodes
+                        if ibd_or_not.clone().load(std::sync::atomic::Ordering::SeqCst) == true{
+                        warn!("Braid node not synced and is under IBD thus skipping the connection from downstream.");
+                            continue;
                         }
-                        let id = client.connection_id;
-                        (id, format!("{:x}", id))
-                    };
-                    //downstream miner mapping for associated jobs for a specific channel for downstream
-                    let self_mining_map = Arc::new(Mutex::new(MiningJobMap::new()));
-                    match event{
-                        Ok((stream,peer_addr))=>{
-                            let (reader, writer) = stream.into_split();
-                            //Notification sender to the `Notifier` task
-                            let notification_sender = notification_sender.clone();
-                            //Communication bridge between swarm and stratum service
-                            let swarm_handler_arc_ref = Arc::clone(&swarm_handler);
-                            //Adding the downstream mining map to global mapper
-                            mining_job_map.lock().await.insert(peer_addr.to_string(), self_mining_map.clone());
-                            //downstream channel for server2client communication to take place
-                            let (downstream_tx,mut downstream_rx) = mpsc::channel(1024);
-                            //adding the new connection to the connection map
-                            self.downstream_connection_mapping
-                                .lock()
-                                .await
-                                .new_connection(peer_addr.to_string(), connection_id, downstream_tx.clone());
-                            info!(
-                                connection_id = %connection_id_hex,
-                                peer = %peer_addr,
-                                "Miner connected"
-                            );
-                            self_.lock().await.downstream_ip = peer_addr.to_string();
-
-                            let connection_mapping_clone = Arc::clone(&self.downstream_connection_mapping);
-                            let mining_job_map_clone = Arc::clone(&mining_job_map);
-                            let peer_addr_string = peer_addr.to_string();
-
-                            // catering each new connection as seperate process
-                            tokio::spawn(async move{
-                                let _=  Self::handle_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref).await;
-                                debug!(
+                        else{
+                 //shared ownership across all tasks and spawning a seperate downstream for each new connection
+                 let self_ = Arc::new(Mutex::new(DownstreamClient::default()));
+                        let (connection_id, connection_id_hex) = {
+                            let mut client = self_.lock().await;
+                    if let Some(ref submission_tx) = self.block_submission_tx {
+                         client.block_submission_tx = Some(submission_tx.clone());
+                     }
+                            let id = client.connection_id;
+                            (id, format!("{:x}", id))
+                        };
+                 //downstream miner mapping for associated jobs for a specific channel for downstream
+                 let self_mining_map = Arc::new(Mutex::new(MiningJobMap::new()));
+                 match event{
+                     Ok((stream,peer_addr))=>{
+                         let (reader, writer) = stream.into_split();
+                         //Notification sender to the `Notifier` task
+                         let notification_sender = notification_sender.clone();
+                         //Communication bridge between swarm and stratum service
+                         let swarm_handler_arc_ref = Arc::clone(&swarm_handler);
+                         //Adding the downstream mining map to global mapper
+                         mining_job_map.lock().await.insert(peer_addr.to_string(), self_mining_map.clone());
+                         //downstream channel for server2client communication to take place
+                         let (downstream_tx,mut downstream_rx) = mpsc::channel(1024);
+                         //adding the new connection to the connection map
+                         self.downstream_connection_mapping
+                                    .lock()
+                                    .await
+                                    .new_connection(peer_addr.to_string(), connection_id, downstream_tx.clone());
+                         info!(
                                     connection_id = %connection_id_hex,
-                                    peer = %peer_addr_string,
-                                    "Cleaning up disconnected miner"
+                                    peer = %peer_addr,
+                                    "Miner connected"
                                 );
+                         self_.lock().await.downstream_ip = peer_addr.to_string();
 
-                                // cleanup after connection closes, remove from connection mapping
-                                connection_mapping_clone
-                                        .lock()
-                                        .await
-                                        .downstream_channel_mapping
-                                        .remove(&peer_addr_string);
+                         let connection_mapping_clone = Arc::clone(&self.downstream_connection_mapping);
+                         let mining_job_map_clone = Arc::clone(&mining_job_map);
+                         let peer_addr_string = peer_addr.to_string();
 
-                                // Remove from job mapping
-                                    mining_job_map_clone
-                                        .lock()
-                                        .await
-                                        .remove(&peer_addr_string);
+                         // catering each new connection as seperate process
+                         tokio::spawn(async move{
+                             let _=  Self::handle_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref).await;
+                             debug!(
+                                        connection_id = %connection_id_hex,
+                                        peer = %peer_addr_string,
+                                        "Cleaning up disconnected miner"
+                                    );
 
-                                debug!(
+                             // cleanup after connection closes, remove from connection mapping
+                             connection_mapping_clone
+                                     .lock()
+                                     .await
+                                     .downstream_channel_mapping
+                                     .remove(&peer_addr_string);
+
+                             // Remove from job mapping
+                                 mining_job_map_clone
+                                     .lock()
+                                     .await
+                                     .remove(&peer_addr_string);
+
+                                    debug!(
+                                        connection_id = %connection_id_hex,
+                                        peer = %peer_addr_string,
+                                        "Miner cleanup complete"
+                                    );
+
+                                });
+                            }
+                            Err(error)=>{
+                                info!(
                                     connection_id = %connection_id_hex,
-                                    peer = %peer_addr_string,
-                                    "Miner cleanup complete"
+                                    error = ?error,
+                                    "Connection failed"
                                 );
-
-                            });
-                        }
-                        Err(error)=>{
-                            info!(
-                                connection_id = %connection_id_hex,
-                                error = ?error,
-                                "Connection failed"
-                            );
+                            }
                         }
                     }
                 }
@@ -1996,6 +2005,8 @@ mod test {
 
     #[tokio::test]
     pub async fn server_start_test() {
+        let ibd_or_not: AtomicBool = AtomicBool::new(false);
+        let test_ibd_spinlock = Arc::new(ibd_or_not);
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
@@ -2016,7 +2027,12 @@ mod test {
 
         let server_task = tokio::spawn(async move {
             let _ = server
-                .run_stratum_service(mining_job_map, notify_tx, swarm_handler_arc)
+                .run_stratum_service(
+                    mining_job_map,
+                    notify_tx,
+                    swarm_handler_arc,
+                    test_ibd_spinlock.clone(),
+                )
                 .await;
         });
 
@@ -2054,6 +2070,8 @@ mod test {
 
     #[tokio::test]
     pub async fn server_subscribe_response() {
+        let ibd_or_not: AtomicBool = AtomicBool::new(false);
+        let test_ibd_spinlock = Arc::new(ibd_or_not);
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
@@ -2075,7 +2093,12 @@ mod test {
 
         let server_task = tokio::spawn(async move {
             let _ = server
-                .run_stratum_service(mining_job_map, notify_tx, swarm_handler_arc)
+                .run_stratum_service(
+                    mining_job_map,
+                    notify_tx,
+                    swarm_handler_arc,
+                    test_ibd_spinlock,
+                )
                 .await;
         });
 
@@ -2097,6 +2120,8 @@ mod test {
     }
     #[tokio::test]
     async fn test_mining_authorize_response() {
+        let ibd_or_not: AtomicBool = AtomicBool::new(false);
+        let ibd_spinlock = Arc::new(ibd_or_not);
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
@@ -2117,7 +2142,12 @@ mod test {
         let mut server = Server::new(config, connection_mapping, None);
         tokio::spawn(async move {
             let _ = server
-                .run_stratum_service(mining_job_map, notify_tx, swarm_handler_arc)
+                .run_stratum_service(
+                    mining_job_map,
+                    notify_tx,
+                    swarm_handler_arc,
+                    ibd_spinlock.clone(),
+                )
                 .await;
         });
 
@@ -2141,6 +2171,8 @@ mod test {
     }
     #[tokio::test]
     async fn test_mining_set_difficulty_response() {
+        let ibd_or_not: AtomicBool = AtomicBool::new(false);
+        let ibd_spinlock = Arc::new(ibd_or_not);
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
@@ -2160,7 +2192,12 @@ mod test {
         let mut server = Server::new(config, connection_mapping, None);
         tokio::spawn(async move {
             let _ = server
-                .run_stratum_service(mining_job_map, notify_tx, swarm_handler_arc)
+                .run_stratum_service(
+                    mining_job_map,
+                    notify_tx,
+                    swarm_handler_arc,
+                    ibd_spinlock.clone(),
+                )
                 .await;
         });
         tokio::time::sleep(Duration::from_millis(300)).await;
@@ -2177,6 +2214,8 @@ mod test {
     }
     #[tokio::test]
     async fn test_invalid_json() {
+        let ibd_or_not: AtomicBool = AtomicBool::new(false);
+        let ibd_spinlock = Arc::new(ibd_or_not);
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
@@ -2199,7 +2238,12 @@ mod test {
         let notify_tx_clone = notify_tx.clone();
         tokio::spawn(async move {
             server
-                .run_stratum_service(mining_job_map_clone, notify_tx_clone, swarm_handler_arc)
+                .run_stratum_service(
+                    mining_job_map_clone,
+                    notify_tx_clone,
+                    swarm_handler_arc,
+                    ibd_spinlock,
+                )
                 .await
                 .unwrap();
         });

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -37,18 +37,6 @@ pub struct BlockSubmissionRequest {
     pub coinbase_transaction: bitcoin::Transaction,
 }
 
-/*
-1)Creating a `notifier` struct that will contain a notification sender along with another attribute of `notification` which will contain all the fields related to mining.notify endpoint from server2client method in stratumcontaining functions such as building
-notification for a given block template received
-2)Running a notifier in a separate task listening for new `templates` and after recieving those a new notification is constructed i.e. a valid job format and sent
-to the downstream node .
-3)A bifurcation of commands such as send to all clients and send to a particular downstream node that will be enabled via a command sender and command reciever, command sender will be passed
-for each new connection and event mapped into the handle_connection function will serve for writing to the tcp_stream .
-4)All the jobs currently will have to be mapped with all its data sent to a downstream and also the modified values received from the downstream node pertaining for the reconstruction of a valid
-weak_share or `Bead` in case of braidpool is concerned hence a mapping required for storing all the jobs along with their job_id as well as the template used for generating that job by a valid downstream
-node . Which further can be accessed by all the downstream nodes for methods such as mining.getjob(job_id) .
-*/
-
 /// Represents the `getblocktemplate` RPC response from Bitcoin Core.
 ///
 /// Based on [BIP-0022](https://github.com/bitcoin/bips/blob/master/bip-0022.mediawiki) and
@@ -2013,7 +2001,7 @@ mod test {
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
         let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
-        let (_test_db_handler, test_db_tx) = DBHandler::new(Arc::clone(&test_braid)).await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -2077,7 +2065,7 @@ mod test {
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let (_test_db_handler, test_db_tx) = DBHandler::new(Arc::clone(&test_braid)).await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -2128,7 +2116,7 @@ mod test {
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
         let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
-        let (_test_db_handler, test_db_tx) = DBHandler::new(Arc::clone(&test_braid)).await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -2177,7 +2165,7 @@ mod test {
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
-        let (_test_db_handler, test_db_tx) = DBHandler::new(Arc::clone(&test_braid)).await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
         let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
         let (swarm_handler, mut swarm_command_receiver) =
@@ -2220,7 +2208,7 @@ mod test {
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
-        let (_test_db_handler, test_db_tx) = DBHandler::new(Arc::clone(&test_braid)).await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let mining_job_map: Arc<Mutex<HashMap<String, Arc<Mutex<MiningJobMap>>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let (notify_tx, _notify_rx) = mpsc::channel::<NotifyCmd>(32);
@@ -2288,7 +2276,7 @@ mod test {
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
-        let (_test_db_handler, test_db_tx) = DBHandler::new(Arc::clone(&test_braid)).await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -37,12 +37,6 @@ pub(crate) fn vec_to_hashset(vec: Vec<BeadHash>) -> HashSet<BeadHash> {
     vec.iter().cloned().collect()
 }
 
-pub(crate) fn retrieve_bead(_beadhash: BeadHash) -> Option<Bead> {
-    // This function is a placeholder for the actual retrieval logic.
-    // In a real implementation, this would fetch the bead from a database or other storage.
-    None
-}
-
 /// Get list of actual local IPv4 addresses for servers binding to 0.0.0.0
 ///
 /// Returns all IPv4 addresses found on network interfaces.


### PR DESCRIPTION
## Additional changes made
- Added helper functions (reset , get_beads_after) in braid/mod.rs .
- Added tests for verifying correct serialisation and deserialisation of enum variants in bead/mod.rs .
- Added extensive tests for get_beads_after() function .
- Added better error handling by introducing BeadSyncError enum .
- Complete `IBD` functionality following the flow as `GetTips` ---> `GetBeads` ----> `GetData` along with acknowledgement.
- `IBDHandler` for managing the cache requirements corresponding to `IBD` .
- Tested over the cases such as 
  * A new node is spawned containing zero beads and undergoes IBD from a sync node .
  * A new node was spawned and after syncing but it has not mined and the sync node also didn't mined .
  * A new node after syncing mined beads and the peer node was also connected .
  * A new node after syncing mined beads and the peer got disconnected and reconnected to undergo IBD wrt new node which mined some beads during the time the sync node got disconnected .
  * Vice-versa of 4th just mining being done at the end of peer node instead of new node .

### NOTE: Algorithm works only if Braid::cohorts vector is topologically sorted
I have read the extend function and it seems that the above condition is always true, please review this once again for any edge cases. 

