### PR TITLE
Beads explorer refactor

### DIFF
--- a/dashboard/src/components/BeadsTab/BeadRow.tsx
+++ b/dashboard/src/components/BeadsTab/BeadRow.tsx
@@ -21,7 +21,7 @@ export default function BeadRow({
   return (
     <div className="border-b border-gray-800/80">
       <div
-        className="grid max-sm:grid-cols-3 md:grid-cols-5 gap-2 p-4 cursor-pointer hover:bg-gray-600"
+        className="grid max-md:grid-cols-3 md:grid-cols-5 gap-2 p-4 cursor-pointer hover:bg-gray-600"
         onClick={() => onToggle(bead.id)}
         onKeyDown={handleKeyToggle}
         role="button"
@@ -51,12 +51,12 @@ export default function BeadRow({
         </div>
 
         {/* Transactions */}
-        <div className="text-white font-medium text-sm sm:text-base">
+        <div className="text-white font-medium text-sm sm:text-base max-md:hidden">
           {bead.transactions}
         </div>
 
         {/* Reward */}
-        <div className="text-white font-medium text-sm sm:text-base">
+        <div className="text-white font-medium text-sm sm:text-base max-md:hidden">
           {`${bead.reward.toFixed(2)} BTC`}
         </div>
       </div>

--- a/dashboard/src/components/BeadsTab/MinedSharesExplorer.tsx
+++ b/dashboard/src/components/BeadsTab/MinedSharesExplorer.tsx
@@ -162,17 +162,20 @@ export default function MinedSharesExplorer() {
               <div className=" rounded-sm overflow-hidden">
                 {/* Table header */}
                 <div
-                  className="grid max-sm:grid-cols-3 md:grid-cols-5  p-4 border-b text-xs sm:text-sm md:text-base
+                  className="grid max-md:grid-cols-3 md:grid-cols-5  p-4 border-b text-xs sm:text-sm md:text-base
  gap-4 border-gray-800/80 font-medium"
                 >
                   {[
-                    'Bead Hash',
-                    'Timestamp',
-                    'Work',
-                    'Transactions',
-                    'Rewards',
-                  ].map((label) => (
-                    <div key={label} className="text-white font-semibold">
+                    { label: 'Bead Hash' },
+                    { label: 'Timestamp' },
+                    { label: 'Work' },
+                    { label: 'Transactions', className: 'max-md:hidden' },
+                    { label: 'Rewards', className: 'max-md:hidden' },
+                  ].map(({ label, className }) => (
+                    <div
+                      key={label}
+                      className={`text-white font-semibold ${className || ''}`}
+                    >
                       {label}
                     </div>
                   ))}


### PR DESCRIPTION
This PR fixes a minor UI bug in the beads explorer tab
- Earlier all 5 columns showed up on small/medium/large screens, making the table hard to read/interpret and were shown vertically instead of horizontally in some instances
- Now the transactions and rewards columns are hidden on small/medium screens for better viewability/access
- All 5 columns are shown on large screens/desktop viewports

**screenshots:**

Large
<img width="1761" height="323" alt="Screenshot 2025-10-01 120141" src="https://github.com/user-attachments/assets/ec7e2d62-b741-4e74-94a4-99c5a9f5ac11" />

Small
<img width="440" height="480" alt="Screenshot 2025-10-01 120248" src="https://github.com/user-attachments/assets/97525ee3-aa9e-4808-8c22-3f474b2a648f" />

Medium
<img width="795" height="414" alt="Screenshot 2025-10-01 120236" src="https://github.com/user-attachments/assets/32b26a08-e37b-4bbf-96ef-827efdf2ad44" />
