### PR TITLE
feat: block submission and template caching system

### DIFF
--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -40,7 +40,8 @@ pub enum StratumErrors {
         method: String,
     },
     MiningJobNotFound {
-        job_id: u64,
+        job_id: Option<u64>,
+        template_id: Option<String>,
     },
     MiningJobInsertError {
         mining_job: JobDetails,
@@ -212,11 +213,14 @@ impl fmt::Display for StratumErrors {
                     method
                 )
             }
-            StratumErrors::MiningJobNotFound { job_id } => {
+            StratumErrors::MiningJobNotFound {
+                job_id,
+                template_id,
+            } => {
                 write!(
                     f,
-                    "No mining job found with the provided job id - {:?}",
-                    job_id
+                    "No mining job found with the provided job id - {:?} and template id - {:?}",
+                    job_id, template_id
                 )
             }
             StratumErrors::MiningJobInsertError { mining_job } => {


### PR DESCRIPTION
This PR introduces a block submission system that accepts the block from the stratum mining server and submits the valid solution to the Bitcoin node through the IPC channel. This way a miner can directly submit blocks to the Bitcoin network. The implementation introduces a caching mechanism, asynchronous submission handling, and full integration with the existing IPC architecture.

### Background
Previously, the Stratum server could validate miner submissions and determine if they met proof-of-work requirements but lacked the infrastructure to actually submit valid blocks to Bitcoin Core. Miners could find valid blocks, but there was no path to propagate them to the network. Additionally, job validation during `[mining.submit]`required access to the original template data, but templates were ephemeral and not persisted beyond initial job creation. This PR solves both problems by introducing a complete submission pipeline and persistent template storage.

### New Behaviour
`Block Submission Request Structure`:  Added a new `BlockSubmissionRequest` struct that encapsulates all the data needed to reconstruct and submit a valid block. This allows the submission handler to reconstruct the whole block from cached template data, without requiring the whole block data to be passed through channels. This is because of the design of the `submitSolution` method exposed through IPC by the Bitcoin node, but we need to keep track of each block template instance we called using the `get_block_template_components`, because each unique call to this function creates a unique block instance at the Bitcoin server side. Thus, if `miner A ` finds a solution using `template_1`, let's suppose, and after that we call for the new block template (`template_2`) and give this to `miner B`, in the meantime `miner A` wants to submit his valid block solution which he finds using `template_1` but we have the different last block template instance (`template_2`) now if we try to submit the solution using the `template_2` instance, its an invalid attempt; we need to call this the `template_1` template instance to submit the solution. This problem is solved by "Template Caching System" discussed below.

`Template Caching System`:  This implements a global template cache for which each template received from the Bitcoin node via IPC is assigned a unique, monotonically-increasing numeric ID. Templates are stored in this cache with a maximum capacity of 500 entries (the limit is totally arbitrary for now; a discussion is needed on this later on). The important thing is the number of cached templates directly affects the RAM storage, so choosing a correct number is important here (automatically evicting the oldest templates when the limit is reached). This ensures that when a miner submits a solution referencing a specific template ID, the server can retrieve the original template data to reconstruct the complete block for submission to the Bitcoin node.

`IPC Submit Solution function:` This introduces a new function called `submit_solution` to call the Bitcoin node to submit the block solution. The method accepts the template interface, version, timestamp, nonce, and serialized coinbase transaction, returning a `SubmitBlockResult` indicating success or failure with detailed reason strings.