### PR TITLE
Switch logging to the tracing library

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,9 +4,9 @@ version = 4
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
+checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
 dependencies = [
  "memchr",
 ]
@@ -118,7 +118,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -130,7 +130,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -251,7 +251,7 @@ checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -294,7 +294,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -612,8 +612,8 @@ dependencies = [
 
 [[package]]
 name = "bitcoincore-zmq"
-version = "1.5.2"
-source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#2372056ff4044da3a522092ed2af190e5a0cbc83"
+version = "1.5.4"
+source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#7a523bd0578db2294403d663cc7e7c84aad3aae9"
 dependencies = [
  "async_zmq",
  "bitcoin 0.32.7",
@@ -728,9 +728,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.41"
+version = "1.2.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac9fe6cdbb24b6ade63616c0a0688e45bb56732262c158df3c0c4bea4ca47cb7"
+checksum = "35900b6c8d709fb1d854671ae27aeaa9eec2f8b01b364e1619a40da3e6fe2afe"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -785,9 +785,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.50"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c2cfd7bf8a6017ddaa4e32ffe7403d547790db06bd171c1c53926faab501623"
+checksum = "4c26d721170e0295f191a69bd9a1f93efcdb0aff38684b61ab5750468972e5f5"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -795,9 +795,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.50"
+version = "4.5.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0a4c05b9e80c5ccd3a7ef080ad7b6ba7d6fc00a985b8b157197075677c82c7a0"
+checksum = "75835f0c7bf681bfd05abe44e965760fea999a5286c6eb2d59883634fd02011a"
 dependencies = [
  "anstream",
  "anstyle",
@@ -814,7 +814,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1026,7 +1026,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1052,7 +1052,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1082,9 +1082,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.4"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a41953f86f8a05768a6cda24def994fd2f424b04ec5c719cf89989779f199071"
+checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
 dependencies = [
  "powerfmt",
 ]
@@ -1141,7 +1141,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1204,30 +1204,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.107",
-]
-
-[[package]]
-name = "env_filter"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
-dependencies = [
- "log",
- "regex",
-]
-
-[[package]]
-name = "env_logger"
-version = "0.11.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
-dependencies = [
- "anstream",
- "anstyle",
- "env_filter",
- "jiff",
- "log",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1478,7 +1455,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -1799,11 +1776,11 @@ dependencies = [
 
 [[package]]
 name = "home"
-version = "0.5.11"
+version = "0.5.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "589533453244b0995c858700322199b2becb13b627df2851f64a2775d024abcf"
+checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1950,9 +1927,9 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "200072f5d0e3614556f94a9930d5dc3e0662a652823904c3a75dc3b0af7fee47"
+checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
 dependencies = [
  "displaydoc",
  "potential_utf",
@@ -1963,9 +1940,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cde2700ccaed3872079a65fb1a78f6c0a36c91570f28755dda67bc8f7d9f00a"
+checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1976,11 +1953,10 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "436880e8e18df4d7bbc06d58432329d6458cc84531f7ac5f024e93deadb37979"
+checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
@@ -1991,42 +1967,38 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00210d6893afc98edb752b664b8890f0ef174c8adbb8d0be9710fa66fbbf72d3"
+checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
 
 [[package]]
 name = "icu_properties"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "016c619c1eeb94efb86809b015c58f479963de65bdb6253345c1a1276f22e32b"
+checksum = "e93fcd3157766c0c8da2f8cff6ce651a31f0810eaa1c51ec363ef790bbb5fb99"
 dependencies = [
- "displaydoc",
  "icu_collections",
  "icu_locale_core",
  "icu_properties_data",
  "icu_provider",
- "potential_utf",
  "zerotrie",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.0.1"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "298459143998310acd25ffe6810ed544932242d3f07083eee1084d83a71bd632"
+checksum = "02845b3647bb045f1100ecd6480ff52f34c35f82d9880e029d329c21d1054899"
 
 [[package]]
 name = "icu_provider"
-version = "2.0.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03c80da27b5f4187909049ee2d72f276f0d9f99a42c306bd0131ecfe04d8e5af"
+checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
- "stable_deref_trait",
- "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
@@ -2168,39 +2140,15 @@ checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
+checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
-
-[[package]]
-name = "jiff"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1f93b8b1eb69c77f24bbb0afdf66f54b632ee39af40ca21c4365a1d7347e49"
-dependencies = [
- "jiff-static",
- "log",
- "portable-atomic",
- "portable-atomic-util",
- "serde",
-]
-
-[[package]]
-name = "jiff-static"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03343451ff899767262ec32146f6d559dd759fdadf42ff0e227c7c48f72594b4"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.107",
-]
 
 [[package]]
 name = "jni"
@@ -2236,9 +2184,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec48937a97411dcb524a265206ccd4c90bb711fca92b2792c407f268825b9305"
+checksum = "b011eec8cc36da2aab2d5cff675ec18454fad408585853910a202391cf9f8e65"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2360,7 +2308,7 @@ dependencies = [
  "proc-macro-crate 3.4.0",
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2786,7 +2734,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -2875,9 +2823,9 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
+checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
 
 [[package]]
 name = "lock_api"
@@ -3182,13 +3130,11 @@ dependencies = [
  "capnp-rpc",
  "capnpc",
  "clap",
- "env_logger",
  "flexbuffers",
  "futures",
  "hex",
  "jsonrpsee",
  "libp2p",
- "log",
  "num",
  "rand 0.8.5",
  "secp256k1 0.30.0",
@@ -3196,6 +3142,7 @@ dependencies = [
  "serde_json",
  "shellexpand",
  "sqlx",
+ "strum",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -3251,11 +3198,10 @@ dependencies = [
 
 [[package]]
 name = "num-bigint-dig"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc84195820f291c7697304f3cbdadd1cb7199c0efc917ff5eafd71225c136151"
+checksum = "82c79c15c05d4bf82b6f5ef163104cc81a760d8e874d38ac50ab67c8877b647b"
 dependencies = [
- "byteorder",
  "lazy_static",
  "libm",
  "num-integer",
@@ -3373,9 +3319,9 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "once_cell_polyfill"
-version = "1.70.1"
+version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4895175b425cb1f87721b59f0f286c2092bd4af812243672510e1ac53e2e0ad"
+checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl-probe"
@@ -3466,7 +3412,7 @@ checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3556,19 +3502,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f84267b20a16ea918e43c6a88433c2d54fa145c92a811b5b047ccbe153674483"
 
 [[package]]
-name = "portable-atomic-util"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8a2f0d8d040d7848a709caf78912debcc3f33ee4b3cac47d73d1e1069e83507"
-dependencies = [
- "portable-atomic",
-]
-
-[[package]]
 name = "potential_utf"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84df19adbe5b5a0782edcab45899906947ab039ccf4573713735ee7de1e6b08a"
+checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
 dependencies = [
  "zerovec",
 ]
@@ -3609,9 +3546,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.101"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ae43fd86e4158d6db51ad8e2b80f313af9cc74f5c0e03ccb87de09998732de"
+checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
 dependencies = [
  "unicode-ident",
 ]
@@ -3636,7 +3573,7 @@ checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -3719,9 +3656,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.41"
+version = "1.0.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce25767e7b499d1b604768e7cde645d14cc8584231ea6b295e9c9eb22c02e1d1"
+checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
 dependencies = [
  "proc-macro2",
 ]
@@ -4031,9 +3968,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.33"
+version = "0.23.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
+checksum = "533f54bc6a7d4f647e46ad909549eda97bf5afc1585190ef692b4286b198bd8f"
 dependencies = [
  "log",
  "once_cell",
@@ -4058,9 +3995,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.12.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229a4a4c221013e7e1f1a043678c5cc39fe5171437c88fb47151a21e6f5b5c79"
+checksum = "94182ad936a0c91c324cd46c6511b9510ed16af436d7b5bab34beab0afd55f7a"
 dependencies = [
  "web-time",
  "zeroize",
@@ -4095,9 +4032,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.7"
+version = "0.103.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
+checksum = "2ffdfa2f5286e2247234e03f680868ac2815974dc39e00ea15adc445d0aafe52"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4246,7 +4183,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4489,7 +4426,7 @@ dependencies = [
  "quote",
  "sqlx-core",
  "sqlx-macros-core",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4513,7 +4450,7 @@ dependencies = [
  "sqlx-mysql",
  "sqlx-postgres",
  "sqlx-sqlite",
- "syn 2.0.107",
+ "syn 2.0.110",
  "tokio",
  "url",
 ]
@@ -4658,6 +4595,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.26.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn 2.0.110",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4676,9 +4635,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.107"
+version = "2.0.110"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a26dbd934e5451d21ef060c018dae56fc073894c5a7896f882928a76e6d081b"
+checksum = "a99801b5bd34ede4cf3fc688c5919368fea4e4814a4664359503e6015b280aea"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4699,7 +4658,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4774,7 +4733,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4785,7 +4744,7 @@ checksum = "3ff15c8ecd7de3849db632e14d18d2571fa09dfc5ed93479bc4485c7a517c913"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4830,9 +4789,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d4f6d1145dcb577acf783d4e601bc1d76a13337bb54e6233add580b07344c8b"
+checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4878,7 +4837,7 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -4905,9 +4864,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.16"
+version = "0.7.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14307c986784f72ef81c89db7d9e28d6ac26d16213b109ea501696195e6e3ce5"
+checksum = "2efa149fe76073d6e8fd97ef4f4eca7b67f599660115591483572e406e165594"
 dependencies = [
  "bytes",
  "futures-core",
@@ -5048,7 +5007,7 @@ checksum = "81383ab64e72a7a8b8e13130c49e3dab29def6d0c7d76a03087b3cf71c5c6903"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5121,24 +5080,24 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.20"
+version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "462eeb75aeb73aea900253ce739c8e18a67423fadf006037cd3ff27e82748a06"
+checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
 
 [[package]]
 name = "unicode-normalization"
-version = "0.1.24"
+version = "0.1.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5033c97c4262335cded6d6fc3e5c18ab755e1a3dc96376350f3d8e9f009ad956"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
 dependencies = [
  "tinyvec",
 ]
 
 [[package]]
 name = "unicode-properties"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e70f2a8b45122e719eb623c01822704c4e0907e7e426a05927e1a1cfff5b75d0"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unsigned-varint"
@@ -5213,9 +5172,9 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "852e951cb7832cb45cb1169900d19760cfa39b82bc0ea9c0e5a14ae88411c98b"
+checksum = "03c2856837ef78f57382f06b2b8563a2f512f7185d732608fd9176cb3b8edf0e"
 
 [[package]]
 name = "version_check"
@@ -5277,9 +5236,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c1da10c01ae9f1ae40cbfac0bac3b1e724b320abfcf52229f80b547c0d250e2d"
+checksum = "da95793dfc411fbbd93f5be7715b0578ec61fe87cb1a42b12eb625caa5c5ea60"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -5289,24 +5248,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-bindgen-backend"
-version = "0.2.104"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "671c9a5a66f49d8a47345ab942e2cb93c7d1d0339065d4f8139c486121b43b19"
-dependencies = [
- "bumpalo",
- "log",
- "proc-macro2",
- "quote",
- "syn 2.0.107",
- "wasm-bindgen-shared",
-]
-
-[[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.54"
+version = "0.4.55"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e038d41e478cc73bae0ff9b36c60cff1c98b8f38f8d7e8061e79ee63608ac5c"
+checksum = "551f88106c6d5e7ccc7cd9a16f312dd3b5d36ea8b4954304657d5dfba115d4a0"
 dependencies = [
  "cfg-if 1.0.4",
  "js-sys",
@@ -5317,9 +5262,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca60477e4c59f5f2986c50191cd972e3a50d8a95603bc9434501cf156a9a119"
+checksum = "04264334509e04a7bf8690f2384ef5265f05143a4bff3889ab7a3269adab59c2"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5327,31 +5272,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f07d2f20d4da7b26400c9f4a0511e6e0345b040694e8a75bd41d578fa4421d7"
+checksum = "420bc339d9f322e562942d52e115d57e950d12d88983a14c79b86859ee6c7ebc"
 dependencies = [
+ "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.107",
- "wasm-bindgen-backend",
+ "syn 2.0.110",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.104"
+version = "0.2.105"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bad67dc8b2a1a6e5448428adec4c3e84c43e561d8c9ee8a9e5aabeb193ec41d1"
+checksum = "76f218a38c84bcb33c25ec7059b07847d465ce0e0a76b995e134a45adcb6af76"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.81"
+version = "0.3.82"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9367c417a924a74cae129e6a2ae3b47fabb1f8995595ab474029da749a8be120"
+checksum = "3a1f95c0d03a47f4ae1f7a64643a6bb97465d9b740f0fa8f90ea33915c99a9a1"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5373,14 +5318,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.3",
+ "webpki-root-certs 1.0.4",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.3"
+version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05d651ec480de84b762e7be71e6efa7461699c19d9e2c272c8d93455f567786e"
+checksum = "ee3e3b5f5e80bc89f30ce8d0343bf4e5f12341c51f3e26cbeecbc7c85443e85b"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5485,7 +5430,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5496,7 +5441,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5865,9 +5810,9 @@ checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"
 
 [[package]]
 name = "writeable"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
+checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
 
 [[package]]
 name = "ws2_32-sys"
@@ -5898,9 +5843,9 @@ dependencies = [
 
 [[package]]
 name = "xml-rs"
-version = "0.8.27"
+version = "0.8.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd8403733700263c6eb89f192880191f1b83e332f7a20371ddcf421c4a337c7"
+checksum = "3ae8337f8a065cfc972643663ea4279e04e7256de865aa66fe25cec5fb912d3f"
 
 [[package]]
 name = "xmltree"
@@ -5922,11 +5867,10 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f41bb01b8226ef4bfd589436a297c53d118f65921786300e427be8d487695cc"
+checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
 dependencies = [
- "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -5934,13 +5878,13 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38da3c9736e16c5d3c8c597a9aaa5d1fa565d0532ae05e27c24aa62fb32c0ab6"
+checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -5961,7 +5905,7 @@ checksum = "88d2b8d9c68ad2b9e4340d7832716a4d21a22a1154777ad56ea55c51a9cf3831"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]
@@ -5981,7 +5925,7 @@ checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
  "synstructure",
 ]
 
@@ -6003,9 +5947,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.2"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36f0bbd478583f79edad978b407914f61b2972f5af6fa089686016be8f9af595"
+checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6014,9 +5958,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.4"
+version = "0.11.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7aa2bd55086f1ab526693ecbe444205da57e25f4489879da80635a46d90e73b"
+checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6025,13 +5969,13 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.1"
+version = "0.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b96237efa0c878c64bd89c436f661be4e46b2f3eff1ebb976f7ef2321d2f58f"
+checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.107",
+ "syn 2.0.110",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1289,19 +1289,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52051878f80a721bb68ebfbc930e07b65ba72f2da88968ea5c06fd6ca3d3a127"
 
 [[package]]
-name = "flexbuffers"
-version = "25.9.23"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e6701cb4a12d88a63f83ac41a11aa61286b5a678445a1a5ab9bc8e38654910a"
-dependencies = [
- "bitflags 1.3.2",
- "byteorder",
- "num_enum",
- "serde",
- "serde_derive",
-]
-
-[[package]]
 name = "flume"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2315,7 +2302,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fa4f5daed39f982a1bb9d15449a28347490ad42b212f8eaa2a2a344a0dce9e9"
 dependencies = [
  "heck",
- "proc-macro-crate 3.4.0",
+ "proc-macro-crate",
  "proc-macro2",
  "quote",
  "syn 2.0.110",
@@ -3140,7 +3127,6 @@ dependencies = [
  "capnp-rpc",
  "capnpc",
  "clap",
- "flexbuffers",
  "futures",
  "hex",
  "if-addrs 0.13.4",
@@ -3290,27 +3276,6 @@ checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
 dependencies = [
  "hermit-abi 0.5.2",
  "libc",
-]
-
-[[package]]
-name = "num_enum"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f646caf906c20226733ed5b1374287eb97e3c2a5c227ce668c1f2ce20ae57c9"
-dependencies = [
- "num_enum_derive",
-]
-
-[[package]]
-name = "num_enum_derive"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dcbff9bc912032c62bf65ef1d5aea88983b420f4f839db1e9b0c281a25c9c799"
-dependencies = [
- "proc-macro-crate 1.3.1",
- "proc-macro2",
- "quote",
- "syn 1.0.109",
 ]
 
 [[package]]
@@ -3534,16 +3499,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
-]
-
-[[package]]
-name = "proc-macro-crate"
-version = "1.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
-dependencies = [
- "once_cell",
- "toml_edit 0.19.15",
 ]
 
 [[package]]
@@ -4922,17 +4877,6 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.19.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
-dependencies = [
- "indexmap",
- "toml_datetime 0.6.11",
- "winnow 0.5.40",
-]
-
-[[package]]
-name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
@@ -4942,7 +4886,7 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.13",
+ "winnow",
 ]
 
 [[package]]
@@ -4954,7 +4898,7 @@ dependencies = [
  "indexmap",
  "toml_datetime 0.7.3",
  "toml_parser",
- "winnow 0.7.13",
+ "winnow",
 ]
 
 [[package]]
@@ -4963,7 +4907,7 @@ version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0cbe268d35bdb4bb5a56a2de88d0ad0eb70af5384a99d648cd4b3d04039800e"
 dependencies = [
- "winnow 0.7.13",
+ "winnow",
 ]
 
 [[package]]
@@ -5784,15 +5728,6 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
-name = "winnow"
-version = "0.5.40"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
-dependencies = [
- "memchr",
-]
 
 [[package]]
 name = "winnow"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2038,6 +2038,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.13.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
+dependencies = [
+ "libc",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "if-watch"
 version = "3.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,7 +2057,7 @@ dependencies = [
  "core-foundation 0.9.4",
  "fnv",
  "futures",
- "if-addrs",
+ "if-addrs 0.10.2",
  "ipnet",
  "log",
  "netlink-packet-core",
@@ -3133,6 +3143,7 @@ dependencies = [
  "flexbuffers",
  "futures",
  "hex",
+ "if-addrs 0.13.4",
  "jsonrpsee",
  "libp2p",
  "num",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,8 +28,6 @@ bitcoin_hashes = { version = "0.16" }
 bitcoincore-rpc = { version = "0.19.0"}
 bitcoincore-rpc-json = { version = "0.19.0"}
 bitcoincore-zmq = { version = "1.5.2", git = "https://github.com/antonilol/rust-bitcoincore-zmq.git", features = ["async"] }
-env_logger = "0.11"
-log = "0.4.16"
 shellexpand = "3.1.0"
 num = { version = "0.4.1", features = ["serde", "rand"] }
 rand = "0.8"
@@ -42,3 +40,4 @@ sqlx = {version="0.8.6",features=[ "sqlite",
   "macros",
   "chrono",
   "uuid","regexp","runtime-tokio","runtime-async-std","derive"]}
+strum = { version = "0.26", features = ["derive"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,3 +40,7 @@ sqlx = {version="0.8.6",features=[ "sqlite",
   "chrono",
   "uuid","regexp","runtime-tokio","runtime-async-std","derive"]}
 strum = { version = "0.26", features = ["derive"] }
+if-addrs = "0.13"
+anyhow = "1.0.100"
+
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ tracing = "0.1"
 tracing-subscriber = { version = "0.3.1", default-features = false, features = ["fmt", "ansi", "env-filter", "tracing-log"] }
 futures = { version = "0.3.28", features = ["thread-pool"]}
 bytes = "1.4.0"
-flexbuffers = { version = "25.2", features = ["deserialize_human_readable", "serialize_human_readable"] }
 serde_json = "1.0.140"
 clap = { version = "4.4.2", features = ["derive", "string"] }
 bitcoin = { git = "https://github.com/braidpool/rust-bitcoin.git", branch = "cpunet",features=["serde"]}

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -24,8 +24,6 @@ bitcoin_hashes = { workspace = true }
 bitcoincore-rpc = { workspace = true }
 bitcoincore-rpc-json = { workspace = true }
 bitcoincore-zmq = { workspace = true }
-env_logger = { workspace = true }
-log = { workspace = true }
 shellexpand = { workspace = true }
 num = { workspace = true }
 rand = { workspace = true }
@@ -35,6 +33,7 @@ toml = { workspace = true }
 jsonrpsee = { workspace = true }
 async-trait = { workspace = true }
 sqlx = { workspace = true}
+strum = { workspace = true }
 anyhow = "1.0.100"
 
 

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -35,6 +35,7 @@ async-trait = { workspace = true }
 sqlx = { workspace = true}
 strum = { workspace = true }
 anyhow = "1.0.100"
+if-addrs = "0.13"
 
 
 [build-dependencies]

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -16,7 +16,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 futures = { workspace = true }
 bytes = { workspace = true }
-flexbuffers = { workspace = true }
 serde_json = { workspace = true }
 clap = { workspace = true }
 bitcoin = { workspace = true }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -33,8 +33,8 @@ jsonrpsee = { workspace = true }
 async-trait = { workspace = true }
 sqlx = { workspace = true}
 strum = { workspace = true }
-anyhow = "1.0.100"
-if-addrs = "0.13"
+if-addrs = { workspace = true }
+anyhow = { workspace = true }
 
 
 [build-dependencies]

--- a/node/build.rs
+++ b/node/build.rs
@@ -21,7 +21,7 @@ fn main() {
                     Ok(entry) => {
                         let path = entry.path();
                         if path.extension().and_then(|ext| ext.to_str()) == Some("capnp") {
-                            println!("cargo:warning=Compiling schema file: {:?}", path);
+                            println!("cargo:info=Compiling schema file: {:?}", path);
                             //The output path for rust bindings is default `OUT_DIR` -
                             if let Err(e) = capnpc::CompilerCommand::new()
                                 .src_prefix("schema")

--- a/node/build.rs
+++ b/node/build.rs
@@ -21,7 +21,7 @@ fn main() {
                     Ok(entry) => {
                         let path = entry.path();
                         if path.extension().and_then(|ext| ext.to_str()) == Some("capnp") {
-                            println!("cargo:info=Compiling schema file: {:?}", path);
+                            println!("cargo:warn=Compiling schema file: {:?}", path);
                             //The output path for rust bindings is default `OUT_DIR` -
                             if let Err(e) = capnpc::CompilerCommand::new()
                                 .src_prefix("schema")

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -27,11 +27,11 @@ pub struct Bead {
 }
 impl Default for Bead {
     fn default() -> Self {
-        let empty_merkel_bytes: [u8; 32] = [0; 32];
+        let empty_merkle_bytes: [u8; 32] = [0; 32];
         Self {
             block_header: BlockHeader {
                 bits: CompactTarget::from_consensus(486604799),
-                merkle_root: TxMerkleNode::from_byte_array(empty_merkel_bytes),
+                merkle_root: TxMerkleNode::from_byte_array(empty_merkle_bytes),
                 nonce: 0,
                 prev_blockhash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
                 time: BlockTime::from_u32(23021),

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -37,7 +37,7 @@ pub struct BraidpoolConfig {
 #[derive(Serialize, Deserialize, Clone)]
 //Rpc server configuration
 pub struct BraidRpcConfig {
-    rpc_server_addr: String,
+    pub rpc_server_addr: String,
 }
 impl Default for BraidRpcConfig {
     fn default() -> Self {

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -91,7 +91,7 @@ impl DBHandler {
         _ancestor_mapping: &HashMap<usize, HashSet<usize>>,
         bead_id: &usize,
     ) -> Result<(), DBErrors> {
-        debug!("Sequential insertion query received");
+        trace!("Sequential insertion query received");
         let hex_converted_extranonce_1 =
             hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes());
         let hex_converted_extranonce_2 =
@@ -532,9 +532,9 @@ pub async fn fetch_bead_by_bead_hash(
     {
         Ok(_rows) => {
             if _rows.is_none() == false {
-                debug!("Bead with given bead hash fetched successfully");
+                trace!(bead_hash = %bead_hash, "Bead fetched successfully");
             } else {
-                debug!("No such bead exists");
+                trace!(bead_hash = %bead_hash, "No such bead exists");
             }
         }
         Err(error) => {

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -98,7 +98,7 @@ impl DBHandler {
             hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes());
         let block_header_bytes = bead.block_header.block_hash().to_byte_array().to_vec();
         let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
-        let merkel_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
+        let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
         let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
         let public_key_bytes = bead.committed_metadata.comm_pub_key.to_vec();
         let signature_bytes = bead.uncommitted_metadata.signature.to_vec();
@@ -109,7 +109,7 @@ impl DBHandler {
             .bind(block_header_bytes)
             .bind(bead.block_header.version.to_consensus())
             .bind(prev_block_hash_bytes)
-            .bind(merkel_root_bytes)
+            .bind(merkle_root_bytes)
             .bind(bead.block_header.time.to_u32())
             .bind(bead.block_header.bits.to_consensus())
             .bind(bead.block_header.nonce)
@@ -479,7 +479,7 @@ pub async fn fetch_bead_by_bead_hash(
                     });
                 }
             };
-            let merkel_hash = match row.get::<Vec<u8>, _>("hashMerkleRoot").try_into() {
+            let merkle_hash = match row.get::<Vec<u8>, _>("hashMerkleRoot").try_into() {
                 Ok(arr) => TxMerkleNode::from_byte_array(arr),
                 Err(_) => {
                     return Err(DBErrors::TupleAttributeParsingError {
@@ -515,7 +515,7 @@ pub async fn fetch_bead_by_bead_hash(
             fetched_bead.committed_metadata.payout_address = payout_address;
             fetched_bead.block_header.prev_blockhash = prev_block_hash;
             fetched_bead.block_header.nonce = nonce;
-            fetched_bead.block_header.merkle_root = merkel_hash;
+            fetched_bead.block_header.merkle_root = merkle_hash;
             fetched_bead.committed_metadata.comm_pub_key = pub_key;
             fetched_bead.committed_metadata.miner_ip = miner_ip;
             fetched_bead.committed_metadata.min_target = min_target;
@@ -766,7 +766,7 @@ pub mod test {
                 hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes());
             let block_header_bytes = bead.block_header.block_hash().to_byte_array().to_vec();
             let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
-            let merkel_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
+            let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
             let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
             let public_key_bytes = bead.committed_metadata.comm_pub_key.to_vec();
             let signature_bytes = bead.uncommitted_metadata.signature.to_vec();
@@ -776,7 +776,7 @@ pub mod test {
                 .bind(block_header_bytes)
                 .bind(bead.block_header.version.to_consensus())
                 .bind(prev_block_hash_bytes)
-                .bind(merkel_root_bytes)
+                .bind(merkle_root_bytes)
                 .bind(bead.block_header.time.to_u32())
                 .bind(bead.block_header.bits.to_consensus())
                 .bind(bead.block_header.nonce)

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -61,7 +61,7 @@ impl DBHandler {
     pub async fn new(
         local_braid_arc: Arc<RwLock<Braid>>,
     ) -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
-        info!("Initializing schema for persistent database");
+        debug!("Initializing schema for persistent database");
         let connection = match init_db().await {
             Ok(conn) => conn,
             Err(error) => {

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -304,7 +304,7 @@ pub async fn fetch_beads_in_batch(
         })?
         .get("row_cnt");
 
-    info!(
+    debug!(
         total_rows = total_rows,
         "Number of beads present locally in persistent DB"
     );

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -50,7 +50,11 @@ pub async fn init_db() -> Result<SqlitePool, DBErrors> {
         .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
     //Initializing connection to existing DB
     let conn = if db_exists {
-        info!("Database already exists at {:?}", db_path);
+        info!(
+            db_path = %db_path.display(),
+            exists = true,
+            "Using existing database"
+        );
         let pool = match SqlitePool::connect_with(sql_lite_connections).await {
             Ok(initialized_pool) => initialized_pool,
             Err(error) => {
@@ -72,7 +76,10 @@ pub async fn init_db() -> Result<SqlitePool, DBErrors> {
         };
         let _query_result = match pool.execute(SCHEMA_SQL).await {
             Ok(_res) => {
-                info!("Schema initialized successfully at {:?}", db_path);
+                info!(
+                    db_path = %db_path.display(),
+                    "Database schema initialized"
+                );
             }
             Err(error) => {
                 return Err(DBErrors::SchemaNotInitialized {

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -20,10 +20,13 @@ pub async fn init_db() -> Result<SqlitePool, DBErrors> {
     let db_dir = Path::new(&home_dir).join(".braidpool");
     //Final db directory path
     let db_path = db_dir.join("braidpool.db");
-    //Creating db directory
+    //Creating db directory if it doesn't exist
+    let dir_exists = db_dir.exists();
     match fs::create_dir_all(&db_dir) {
         Ok(_) => {
-            info!("DB directory created successfully");
+            if !dir_exists {
+                info!("DB directory created successfully");
+            }
         }
         Err(error) => {
             return Err(DBErrors::DBDirectoryNotCreated {
@@ -52,7 +55,6 @@ pub async fn init_db() -> Result<SqlitePool, DBErrors> {
     let conn = if db_exists {
         info!(
             db_path = %db_path.display(),
-            exists = true,
             "Using existing database"
         );
         let pool = match SqlitePool::connect_with(sql_lite_connections).await {

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -2,6 +2,7 @@
 use std::{fmt, path::PathBuf};
 
 use crate::stratum::{BlockTemplate, JobDetails};
+use crate::TemplateId;
 use bitcoin::address::ParseError as AddressParseError;
 use tokio::sync::oneshot;
 
@@ -156,7 +157,7 @@ pub enum StratumErrors {
     },
     MiningJobNotFound {
         job_id: Option<u64>,
-        template_id: Option<String>,
+        template_id: Option<TemplateId>,
     },
     MiningJobInsertError {
         mining_job: JobDetails,

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -36,8 +36,9 @@ pub async fn ipc_block_listener(
     >,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(
-        "Starting IPC block listener on: {} for network: {}",
-        ipc_socket_path, network
+        socket = %ipc_socket_path,
+        network = %network,
+        "IPC block listener started"
     );
     let local = tokio::task::LocalSet::new();
     local.run_until(async move {
@@ -81,7 +82,7 @@ pub async fn ipc_block_listener(
                                 continue;
                             }
                             ErrorKind::ConnectionBroken => {
-                                error!("Connection broken during sync check");
+                                error!(error = %e, context = "sync_check", "Connection broken during sync check");
                                 break Err(ErrorKind::ConnectionBroken);
                             }
                             ErrorKind::LogicError => {
@@ -252,7 +253,7 @@ pub async fn ipc_block_listener(
                             }
 
                             None => {
-                                error!("Failed to receive notifications - connection lost");
+                                error!(context = "notification_receiver", reason = "channel_closed", "Failed to receive notifications - connection lost");
                                 break true;
                             }
                         }

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -3,7 +3,7 @@ use crate::config::CoinbaseConfig;
 use crate::error::CoinbaseError;
 use crate::error::{classify_error, ErrorKind};
 use crate::template_creator::{create_block_template, FinalTemplate};
-use crate::{MAX_CACHED_TEMPLATES, TemplateId};
+use crate::{TemplateId, MAX_CACHED_TEMPLATES};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -437,10 +437,10 @@ async fn get_template_with_retry(
                             if hex.len() >= MIN_TEMPLATE_SIZE {
                                 if attempt > 1 {
                                     info!(
-                                        "{}: Got valid template {} bytes (attempt {})",
-                                        context,
-                                        hex.len(),
-                                        attempt
+                                        context = %context,
+                                        size_bytes = %hex.len(),
+                                        attempt = %attempt,
+                                        "Got valid template on retry"
                                     );
                                 }
                                 return Ok(processed_template);
@@ -505,8 +505,10 @@ async fn get_template_with_retry(
                 }
 
                 warn!(
-                    "{}: Attempt {} failed: {}, retrying...",
-                    context, attempt, e
+                    context = %context,
+                    attempt = %attempt,
+                    error = %e,
+                    "Template fetch failed - retrying"
                 );
             }
         }

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -12,7 +12,7 @@ pub mod client;
 use crate::template_creator::{create_block_template, FinalTemplate};
 use bitcoin::Network;
 pub use client::{
-    bytes_to_hex, BitcoinNotification, BlockTemplateComponents, CheckBlockResult, RequestPriority,
+    BitcoinNotification, BlockTemplateComponents, CheckBlockResult, RequestPriority,
     SharedBitcoinClient,
 };
 
@@ -124,11 +124,6 @@ pub async fn ipc_block_listener(
                     network,
                 ).await {
                     Ok(template) => {
-                        info!(
-                            size_bytes = template.components.block_hex.len(),
-                            height = tip_height,
-                            "Got initial block template"
-                        );
                         if let Err(e) = block_template_tx.send(Arc::new(template)).await {
                             error!(error = %e, "Failed to send initial template");
                             continue;
@@ -175,8 +170,8 @@ pub async fn ipc_block_listener(
                                 hash_reversed.reverse();
                                 info!(
                                     height = height,
-                                    hash = %bytes_to_hex(&hash_reversed),
-                                    "New block received"
+                                    hash = %hex::encode(&hash_reversed),
+                                    "New block"
                                 );
                                 match shared_client.is_initial_block_download(Some(RequestPriority::High)).await {
                                     Ok(in_ibd) => {
@@ -191,10 +186,6 @@ pub async fn ipc_block_listener(
                                                 network,
                                             ).await {
                                                 Ok(template) => {
-                                                    info!(
-                                                        size_bytes = template.processed_block_hex.as_ref().map(|v| v.len()).unwrap_or(0),
-                                                        "Got block template data"
-                                                    );
                                                     if let Err(e) = block_template_tx.send(Arc::new(template)).await {
                                                         error!(error = %e, height = height, "Failed to send template");
                                                         break true;
@@ -261,16 +252,21 @@ pub async fn ipc_block_listener(
 
                     submission = block_submission_rx.recv() => {
                     if let Some(submission) = submission {
-                        let template_opt = template_cache.lock().await.get(&submission.template_id).cloned();
+                        let crate::stratum::BlockSubmissionRequest {
+                            template_id,
+                            header,
+                            coinbase_transaction,
+                        } = submission;
+                        let block_hash = header.block_hash();
+                        let template_opt = template_cache.lock().await.get(&template_id).cloned();
 
                         if let Some(ipc_template) = template_opt {
                             match shared_client
                                 .submit_solution(
                                     ipc_template,
-                                    submission.version as u32,
-                                    submission.timestamp,
-                                    submission.nonce,
-                                    bitcoin::consensus::encode::serialize(&submission.coinbase_transaction),
+                                    header,
+                                    bitcoin::consensus::encode::serialize(&coinbase_transaction),
+                                    template_id.clone(),
                                     Some(RequestPriority::Critical),
                                 )
                                 .await
@@ -278,12 +274,14 @@ pub async fn ipc_block_listener(
                                 Ok(result) => {
                                     if result.success {
                                         info!(
-                                            template_id = %submission.template_id,
+                                            template_id = %template_id,
+                                            block_hash = %block_hash,
                                             "Block ACCEPTED by Bitcoin Core"
                                         );
                                     } else {
                                         error!(
-                                            template_id = %submission.template_id,
+                                            template_id = %template_id,
+                                            block_hash = %block_hash,
                                             reason = %result.reason,
                                             "Block REJECTED by Bitcoin Core"
                                         );
@@ -291,7 +289,8 @@ pub async fn ipc_block_listener(
                                 }
                                 Err(e) => {
                                     error!(
-                                        template_id = %submission.template_id,
+                                        template_id = %template_id,
+                                        block_hash = %block_hash,
                                         error = %e,
                                         "Failed to submit block"
                                     );
@@ -303,7 +302,8 @@ pub async fn ipc_block_listener(
                             // - Template expired (cache is full and old template was evicted)
                             // - Cache overflow (exceeded MAX_CACHED_TEMPLATES limit)
                             error!(
-                                template_id = %submission.template_id,
+                                template_id = %template_id,
+                                block_hash = %block_hash,
                                 cache_size = template_cache.lock().await.len(),
                                 max_cache_size = MAX_CACHED_TEMPLATES,
                                 "Block submission dropped - template not found in cache"

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -2,14 +2,14 @@
 use crate::config::CoinbaseConfig;
 use crate::error::CoinbaseError;
 use crate::error::{classify_error, ErrorKind};
-use crate::MAX_CACHED_TEMPLATES;
+use crate::template_creator::{create_block_template, FinalTemplate};
+use crate::{MAX_CACHED_TEMPLATES, TemplateId};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::mpsc::Sender;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 pub mod client;
-use crate::template_creator::{create_block_template, FinalTemplate};
 use bitcoin::Network;
 pub use client::{
     BitcoinNotification, BlockTemplateComponents, CheckBlockResult, RequestPriority,
@@ -30,7 +30,7 @@ pub async fn ipc_block_listener(
     ipc_socket_path: String,
     block_template_tx: Sender<Arc<client::BlockTemplate>>,
     network: Network,
-    template_cache: Arc<tokio::sync::Mutex<HashMap<String, Arc<client::BlockTemplate>>>>,
+    template_cache: Arc<tokio::sync::Mutex<HashMap<TemplateId, Arc<client::BlockTemplate>>>>,
     mut block_submission_rx: tokio::sync::mpsc::UnboundedReceiver<
         crate::stratum::BlockSubmissionRequest,
     >,
@@ -266,7 +266,7 @@ pub async fn ipc_block_listener(
                                     ipc_template,
                                     header,
                                     bitcoin::consensus::encode::serialize(&coinbase_transaction),
-                                    template_id.clone(),
+                                    template_id,
                                     Some(RequestPriority::Critical),
                                 )
                                 .await

--- a/node/src/ipc/client.rs
+++ b/node/src/ipc/client.rs
@@ -1029,14 +1029,28 @@ impl SharedBitcoinClient {
                 {
                     Ok(result) => {
                         if result.success {
-                            info!("Block submitted successfully!");
+                            info!(
+                                version = %version,
+                                timestamp = %timestamp,
+                                nonce = %nonce,
+                                "Block submitted successfully"
+                            );
                         } else {
-                            error!("Block submission failed: {}", result.reason);
+                            error!(
+                                reason = %result.reason,
+                                version = %version,
+                                timestamp = %timestamp,
+                                "Block submission rejected by Bitcoin Core"
+                            );
                         }
                         let _ = response.send(Ok(result));
                     }
                     Err(e) => {
-                        error!("Submit solution IPC error: {}", e);
+                        error!(
+                            error = %e,
+                            operation = "submit_solution",
+                            "Block submission IPC error"
+                        );
                         let _ = response.send(Err(e.to_string()));
                     }
                 }

--- a/node/src/ipc/client.rs
+++ b/node/src/ipc/client.rs
@@ -1,6 +1,7 @@
 use crate::error::BraidpoolError;
 use crate::init_capnp::init::Client as InitClient;
 use crate::proxy_capnp::thread::Client as ThreadClient;
+use crate::TemplateId;
 use bitcoin::BlockHeader;
 use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 use futures::FutureExt;
@@ -106,7 +107,7 @@ enum BitcoinRequest {
         template: Arc<BlockTemplate>,
         header: BlockHeader,
         coinbase_transaction: Vec<u8>,
-        template_id: String,
+        template_id: TemplateId,
         response: oneshot::Sender<Result<SubmitBlockResult, String>>,
         priority: RequestPriority,
     },
@@ -1208,7 +1209,7 @@ impl SharedBitcoinClient {
         template: Arc<BlockTemplate>,
         header: BlockHeader,
         coinbase_transaction: Vec<u8>,
-        template_id: String,
+        template_id: TemplateId,
         priority: Option<RequestPriority>,
     ) -> Result<SubmitBlockResult, Box<dyn std::error::Error>> {
         let (response_sender, response_receiver) = oneshot::channel();

--- a/node/src/ipc/client.rs
+++ b/node/src/ipc/client.rs
@@ -1,6 +1,7 @@
 use crate::error::BraidpoolError;
 use crate::init_capnp::init::Client as InitClient;
 use crate::proxy_capnp::thread::Client as ThreadClient;
+use bitcoin::BlockHeader;
 use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 use futures::FutureExt;
 use std::collections::VecDeque;
@@ -17,12 +18,6 @@ use tokio_util::compat::{TokioAsyncReadCompatExt, TokioAsyncWriteCompatExt};
 
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
-pub fn bytes_to_hex(bytes: &[u8]) -> String {
-    bytes
-        .iter()
-        .map(|b| format!("{:02x}", b))
-        .collect::<String>()
-}
 
 #[derive(Debug, Clone)]
 pub struct CheckBlockResult {
@@ -109,10 +104,9 @@ enum BitcoinRequest {
     },
     SubmitSolution {
         template: Arc<BlockTemplate>,
-        version: u32,
-        timestamp: u32,
-        nonce: u32,
+        header: BlockHeader,
         coinbase_transaction: Vec<u8>,
+        template_id: String,
         response: oneshot::Sender<Result<SubmitBlockResult, String>>,
         priority: RequestPriority,
     },
@@ -597,7 +591,7 @@ impl BitcoinRpcClient {
                             error!(
                                 error = %e,
                                 height = %height,
-                                hash = %bytes_to_hex(&hash),
+                                hash = %hex::encode(&hash),
                                 "Failed to send tip change notification"
                             );
                             if notification_sender.is_closed() {
@@ -1010,13 +1004,16 @@ impl SharedBitcoinClient {
             }
             BitcoinRequest::SubmitSolution {
                 template,
-                version,
-                timestamp,
-                nonce,
+                header,
                 coinbase_transaction,
+                template_id,
                 response,
                 ..
             } => {
+                let block_hash = header.block_hash();
+                let version = header.version.to_consensus() as u32;
+                let timestamp = header.time.to_u32();
+                let nonce = header.nonce;
                 match bitcoin_client
                     .submit_solution(
                         &template.template_interface,
@@ -1030,6 +1027,8 @@ impl SharedBitcoinClient {
                     Ok(result) => {
                         if result.success {
                             info!(
+                                template_id = %template_id,
+                                block_hash = %block_hash,
                                 version = %version,
                                 timestamp = %timestamp,
                                 nonce = %nonce,
@@ -1037,9 +1036,12 @@ impl SharedBitcoinClient {
                             );
                         } else {
                             error!(
-                                reason = %result.reason,
+                                template_id = %template_id,
+                                block_hash = %block_hash,
                                 version = %version,
                                 timestamp = %timestamp,
+                                nonce = %nonce,
+                                reason = %result.reason,
                                 "Block submission rejected by Bitcoin Core"
                             );
                         }
@@ -1047,6 +1049,11 @@ impl SharedBitcoinClient {
                     }
                     Err(e) => {
                         error!(
+                            template_id = %template_id,
+                            block_hash = %block_hash,
+                            version = %version,
+                            timestamp = %timestamp,
+                            nonce = %nonce,
                             error = %e,
                             operation = "submit_solution",
                             "Block submission IPC error"
@@ -1199,20 +1206,18 @@ impl SharedBitcoinClient {
     pub async fn submit_solution(
         &self,
         template: Arc<BlockTemplate>,
-        version: u32,
-        timestamp: u32,
-        nonce: u32,
+        header: BlockHeader,
         coinbase_transaction: Vec<u8>,
+        template_id: String,
         priority: Option<RequestPriority>,
     ) -> Result<SubmitBlockResult, Box<dyn std::error::Error>> {
         let (response_sender, response_receiver) = oneshot::channel();
 
         let request = BitcoinRequest::SubmitSolution {
             template,
-            version,
-            timestamp,
-            nonce,
+            header,
             coinbase_transaction,
+            template_id,
             response: response_sender,
             priority: priority.unwrap_or(RequestPriority::Critical),
         };

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -134,7 +134,7 @@ pub async fn ipc_template_consumer(
         let template_bytes = match &ipc_template.processed_block_hex {
             Some(processed_hex) if !processed_hex.is_empty() => processed_hex,
             _ => {
-                warn!("Skipping template: processed_block_hex is missing or empty");
+                warn!(field = "processed_block_hex", "Skipping invalid template - hex payload missing");
                 continue;
             }
         };
@@ -364,7 +364,7 @@ impl SwarmHandler {
         info!(
             status = ?status,
             hash = %weak_share.block_header.block_hash(),
-            "Bead extended successfully"
+            "Braid extended successfully"
         );
         let _db_insertion_command = match self
             .db_command_sender
@@ -376,9 +376,9 @@ impl SwarmHandler {
             .await
         {
             Ok(_) => {
-                info!(
+                debug!(
                     hash = %weak_share.block_header.block_hash(),
-                    "Bead insertion query sent"
+                    "InsertBeadSequentially sent to DB thread"
                 );
             }
             Err(error) => {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -26,7 +26,7 @@ pub const MAX_CACHED_TEMPLATES: usize = 90;
 
 use crate::{
     bead::Bead,
-    braid::{Braid,AddBeadStatus},
+    braid::{AddBeadStatus, Braid},
     committed_metadata::{CommittedMetadata, TimeVec, TxIdVec},
     db::BraidpoolDBTypes,
     error::{IPCtemplateError, StratumErrors},
@@ -301,7 +301,7 @@ impl SwarmHandler {
                 .0
                 .push(current_tip_bead.committed_metadata.start_timestamp);
         }
-        debug!(tip_indices = ?tips_index, tip_hashes = ?parent_hash_set, 
+        debug!(tip_indices = ?tips_index, tip_hashes = ?parent_hash_set,
             "Tips before extending the Braid");
         //TODO:This will be replaced via the allotted `WeakShareDifficulty` after Difficulty adjustment
         let weak_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -26,7 +26,7 @@ pub const MAX_CACHED_TEMPLATES: usize = 90;
 
 use crate::{
     bead::Bead,
-    braid::Braid,
+    braid::{Braid,AddBeadStatus},
     committed_metadata::{CommittedMetadata, TimeVec, TxIdVec},
     db::BraidpoolDBTypes,
     error::{IPCtemplateError, StratumErrors},
@@ -284,7 +284,7 @@ impl SwarmHandler {
             .map(|tx| tx.compute_txid())
             .collect();
         let transaction_ids: Vec<Txid> = Vec::from(ids);
-        info!("Broadcasting bead via floodsub");
+        debug!("Broadcasting bead via floodsub");
         //TODO:Currently temprorary placeholder will be replaced in upcoming PRs
         let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
             .parse::<bitcoin::PublicKey>()
@@ -301,10 +301,8 @@ impl SwarmHandler {
                 .0
                 .push(current_tip_bead.committed_metadata.start_timestamp);
         }
-        info!(
-            "Current tip indices before new insertion - {:?}",
-            tips_index
-        );
+        debug!(tip_indices = ?tips_index, tip_hashes = ?parent_hash_set, 
+            "Tips before extending the Braid");
         //TODO:This will be replaced via the allotted `WeakShareDifficulty` after Difficulty adjustment
         let weak_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();
         //Mindiff
@@ -358,11 +356,20 @@ impl SwarmHandler {
             uncommitted_metadata: candidate_block_bead_uncommitted_metadata,
         };
         let status = braid_data.extend(&weak_share);
-        info!(
-            status = ?status,
-            hash = %weak_share.block_header.block_hash(),
-            "Braid extended successfully"
-        );
+        match status {
+            AddBeadStatus::BeadAdded => {
+                let new_tips: Vec<_> = braid_data.tips.iter().map(|&idx| idx).collect();
+                info!(
+                    hash = %weak_share.block_header.block_hash(),
+                    new_tips = ?new_tips,
+                    "Braid extended successfully"
+                );
+            }
+            _ => {
+                warn!(status = ?status, hash = %weak_share.block_header.block_hash(),
+                    "Failed to extend Braid")
+            }
+        }
         let _db_insertion_command = match self
             .db_command_sender
             .send(BraidpoolDBTypes::InsertTupleTypes {
@@ -394,7 +401,7 @@ impl SwarmHandler {
             Ok(_) => {
                 info!(
                     hash = %weak_share.block_header.block_hash(),
-                    "Candidate block sent to swarm"
+                    "Bead sent to swarm"
                 );
             }
             Err(e) => {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -68,13 +68,15 @@ pub mod init_capnp {
     include!(concat!(env!("OUT_DIR"), "/init_capnp.rs"));
 }
 
+/// Unique identifier assigned to each block template.
+pub type TemplateId = u64;
+
 /// Global template ID counter that persists across the application lifetime
 static GLOBAL_TEMPLATE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Get the next unique template ID (increments on each call)
-pub fn get_next_template_id() -> String {
-    let id = GLOBAL_TEMPLATE_COUNTER.fetch_add(1, Ordering::SeqCst);
-    id.to_string()
+pub fn get_next_template_id() -> TemplateId {
+    GLOBAL_TEMPLATE_COUNTER.fetch_add(1, Ordering::SeqCst)
 }
 
 /// **Length of the extranonce prefix (in bytes).**
@@ -126,9 +128,9 @@ pub async fn ipc_template_consumer(
     latest_template_arc: &mut Arc<Mutex<BlockTemplate>>,
     latest_template_merkle_branch_arc: &mut Arc<Mutex<Vec<Vec<u8>>>>,
     template_cache: Arc<
-        tokio::sync::Mutex<HashMap<String, Arc<crate::ipc::client::BlockTemplate>>>,
+        tokio::sync::Mutex<HashMap<TemplateId, Arc<crate::ipc::client::BlockTemplate>>>,
     >,
-    latest_template_id: Arc<Mutex<String>>,
+    latest_template_id: Arc<Mutex<TemplateId>>,
 ) -> Result<(), IPCtemplateError> {
     while let Some(ipc_template) = template_rx.recv().await {
         let template_bytes = match &ipc_template.processed_block_hex {
@@ -147,23 +149,22 @@ pub async fn ipc_template_consumer(
             let template_id = get_next_template_id();
             {
                 let mut latest_id = latest_template_id.lock().await;
-                *latest_id = template_id.clone();
+                *latest_id = template_id;
             }
 
             // Cache the IPC template with this new ID
             {
                 let mut cache = template_cache.lock().await;
-                cache.insert(template_id.clone(), ipc_template.clone());
+                cache.insert(template_id, ipc_template.clone());
 
                 // Cleanup old templates
                 if cache.len() > MAX_CACHED_TEMPLATES {
-                    let mut ids: Vec<u64> =
-                        cache.keys().filter_map(|k| k.parse::<u64>().ok()).collect();
-                    ids.sort();
+                    let mut ids: Vec<TemplateId> = cache.keys().copied().collect();
+                    ids.sort_unstable();
 
                     let remove_count = cache.len() - MAX_CACHED_TEMPLATES;
                     for id in ids.iter().take(remove_count) {
-                        cache.remove(&id.to_string());
+                        cache.remove(id);
                         debug!(template_id = %id, "Removed old template from cache");
                     }
                 }
@@ -178,11 +179,7 @@ pub async fn ipc_template_consumer(
             let (template_header, template_transactions) = candidate_block.unwrap().into_parts();
             let _coinbase_transaction = template_transactions.get(0);
 
-            debug!(
-                template_id = ?template_id,
-                template_header = ?template_header,
-                "New block template"
-            );
+            debug!(template_id = %template_id, template_header = ?template_header, "New block template");
             let template: BlockTemplate = BlockTemplate {
                 version: template_header.version,
                 previousblockhash: template_header.prev_blockhash,
@@ -229,7 +226,7 @@ pub async fn ipc_template_consumer(
                 .send(NotifyCmd::SendToAll {
                     template: template,
                     merkle_branch_coinbase,
-                    template_id: template_id.clone(),
+                    template_id,
                 })
                 .await;
             match notification_sent_or_not {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -134,7 +134,10 @@ pub async fn ipc_template_consumer(
         let template_bytes = match &ipc_template.processed_block_hex {
             Some(processed_hex) if !processed_hex.is_empty() => processed_hex,
             _ => {
-                warn!(field = "processed_block_hex", "Skipping invalid template - hex payload missing");
+                warn!(
+                    field = "processed_block_hex",
+                    "Skipping invalid template - hex payload missing"
+                );
                 continue;
             }
         };
@@ -176,12 +179,9 @@ pub async fn ipc_template_consumer(
             let _coinbase_transaction = template_transactions.get(0);
 
             debug!(
+                template_id = ?template_id,
                 template_header = ?template_header,
-                "The block header for the given template is"
-            );
-            debug!(
-                tx_count = template_transactions.len(),
-                "Transactions count is"
+                "New block template"
             );
             let template: BlockTemplate = BlockTemplate {
                 version: template_header.version,
@@ -222,7 +222,7 @@ pub async fn ipc_template_consumer(
             info!(
                 template_id = %template_id,
                 tx_count = %template_transactions.len(),
-                "Updated latest template from IPC"
+                "New block template"
             );
 
             let notification_sent_or_not = notifier_tx
@@ -234,7 +234,7 @@ pub async fn ipc_template_consumer(
                 .await;
             match notification_sent_or_not {
                 Ok(_) => {
-                    info!(template_id = %template_id, "Template sent to notifier");
+                    debug!(template_id = %template_id, "Template sent to notifier");
                 }
                 Err(error) => {
                     error!(error = ?error, "Failed to send template notification");

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -449,7 +449,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                              ),
                                          );
                                      } else {
-                                         warn!("No peers available to request parent beads");
+                                         warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
                                      }
                                  } else if let braid::AddBeadStatus::InvalidBead = status {
                                      // update the peer manager about the invalid bead

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -202,15 +202,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     };
     //spawning the rpc server
+    let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
     if let Some(rpc_command) = args.command {
-        let server_address = tokio::spawn(run_rpc_server(Arc::clone(&braid)));
+        let server_address = tokio::spawn(run_rpc_server(Arc::clone(&braid), rpc_addr));
         let socket_address = server_address.await.unwrap().unwrap();
         let _parsing_handle =
             tokio::spawn(parse_arguments(rpc_command, socket_address.clone())).await;
     } else {
         //running the rpc server and updating the reference counter
         //for shared ownership
-        let _server_handler = tokio::spawn(run_rpc_server(Arc::clone(&braid))).await;
+        let _server_handler = tokio::spawn(run_rpc_server(Arc::clone(&braid), rpc_addr)).await;
     }
     // load beads from db (if present) and insert in braid here
     // Initializing the peer manager

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -234,7 +234,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .with_behaviour(|local_key| BraidPoolBehaviour::new(local_key).unwrap())?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
         .build();
-    info!(peer_id = %swarm.local_peer_id(), "Local peer ID");
     let socket_addr: std::net::SocketAddr = match args.bind.parse() {
         Ok(addr) => addr,
         Err(_) => format!("{}:6680", args.bind)

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -66,19 +66,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //Reconstructing local braid upon startup
     let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
     let braid_ref = braid.clone();
+    // FIXME instead we should look 144 blocks back from the bitcoin tip (1 day) and load beads
+    // starting from that block as genesis
     let initial_bead_fetch_handle = tokio::spawn(async move {
         let mut guard = braid_ref.write().await;
-        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 4)
+        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000)
             .await
             .unwrap();
-        for bead in fetched_beads {
+        for bead in &fetched_beads {
             let curr_bead_status = guard.extend(&bead);
-            info!(
+            debug!(
                 hash = ?bead.block_header.block_hash(),
                 status = ?curr_bead_status,
                 "Bead inserted"
             );
         }
+        info!(beads = fetched_beads.len(), "Beads loaded from DB");
     });
     let _yield_result = initial_bead_fetch_handle.await.unwrap();
     let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -167,8 +167,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             let perms = fs::metadata(&keystore_path)?.permissions();
             if perms.mode() & 0o777 != 0o400 {
                 warn!(
-                    "Keystore permissions are not secure: {:o}, setting to 0o400",
-                    perms.mode() & 0o777
+                    permissions = perms.mode() & 0o777,
+                    "Keystore permissions are not secure, setting to 0o400"
                 );
                 let mut new_perms = perms.clone();
                 new_perms.set_mode(0o400);
@@ -517,7 +517,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         QueryResult::Bootstrap(Ok(BootstrapOk {
                             peer, ..
                         }))=>{
-                            info!(peer = ?peer, "Peer received during bootstrap");
+                            info!(peer = ?peer, "New peer");
                         }
                          _ => info!(result = ?result, "Other DHT query result"),
                      },
@@ -575,9 +575,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                          });
                          peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
                          info!(
-                             "Connection established to peer: {} via {}",
-                             peer_id,
-                             remote_addr
+                             peer_id = ?peer_id,
+                             remote_addr = ?remote_addr,
+                             "Connection established to peer"
                          );
                      }
                      SwarmEvent::ConnectionClosed {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -26,7 +26,7 @@ use node::{
     rpc_server::{parse_arguments, run_rpc_server},
     setup_tracing,
     stratum::{BlockTemplate, ConnectionMapping, Notifier, NotifyCmd, Server, StratumServerConfig},
-    SwarmCommand,
+    SwarmCommand, TemplateId,
 };
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
@@ -81,7 +81,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     });
     let _yield_result = initial_bead_fetch_handle.await.unwrap();
-    let latest_template_id = Arc::new(Mutex::new(String::from("genesis")));
+    let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
     let latest_template_id_for_notifier = latest_template_id.clone();
     let latest_template_id_for_consumer = latest_template_id.clone();
     //Starting the `query_handler` task
@@ -306,7 +306,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             local_set
                 .run_until(async {
                     let template_cache: Arc<
-                        tokio::sync::Mutex<HashMap<String, Arc<node::ipc::client::BlockTemplate>>>,
+                        tokio::sync::Mutex<
+                            HashMap<TemplateId, Arc<node::ipc::client::BlockTemplate>>,
+                        >,
                     > = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
                     let template_cache_for_consumer = template_cache.clone();
                     let template_cache_for_listener = template_cache.clone();
@@ -538,7 +540,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                  info!(
                                      peer = %peer,
                                      latency_ms = %latency.as_millis(),
-                                     "Ping successful"
+                                     "Ping"
                                  );
                              }
                              Err(err) => {

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -297,7 +297,18 @@ pub async fn run_rpc_server(
 
     // Parse host from bind_address
     let (bind_host, _port) = bind_address.rsplit_once(':').unwrap_or((bind_address, ""));
-    crate::utils::log_server_listening(bind_host, addr.port(), "http");
+    let endpoints = crate::utils::server_endpoints(bind_host, addr.port(), "http");
+    if endpoints.is_empty() {
+        warn!(
+            host = %bind_host,
+            port = %_port,
+            "RPC server listening but no interfaces discovered"
+        );
+    } else {
+        for endpoint in endpoints {
+            info!(endpoint = %endpoint, "RPC server is listening");
+        }
+    }
 
     tokio::spawn(
         //handling the stopping of the server
@@ -314,7 +325,9 @@ pub async fn test_extend_rpc() {
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
 
     let server_addr = "127.0.0.1:6682";
-    let _ = run_rpc_server(Arc::clone(&braid), server_addr).await.unwrap();
+    let _ = run_rpc_server(Arc::clone(&braid), server_addr)
+        .await
+        .unwrap();
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -276,14 +276,17 @@ where
 }
 //server building
 //running a server in seperate spawn event
-pub async fn run_rpc_server(braid_shared_pointer: Arc<RwLock<Braid>>) -> Result<SocketAddr, ()> {
+pub async fn run_rpc_server(
+    braid_shared_pointer: Arc<RwLock<Braid>>,
+    bind_address: &str,
+) -> Result<SocketAddr, ()> {
     //Initializing the middleware
     let rpc_middleware =
         jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
     //building the context/server supporting the http transport and ws
     let server = jsonrpsee::server::Server::builder()
         .set_rpc_middleware(rpc_middleware)
-        .build("127.0.0.1:6682")
+        .build(bind_address)
         .await
         .unwrap();
     //listening address for incoming requests/connection
@@ -291,7 +294,11 @@ pub async fn run_rpc_server(braid_shared_pointer: Arc<RwLock<Braid>>) -> Result<
     //context for the served server
     let rpc_impl = RpcServerImpl::new(braid_shared_pointer);
     let handle = server.start(rpc_impl.into_rpc());
-    info!(address = %addr, "RPC server listening");
+
+    // Parse host from bind_address
+    let (bind_host, _port) = bind_address.rsplit_once(':').unwrap_or((bind_address, ""));
+    crate::utils::log_server_listening(bind_host, addr.port(), "http");
+
     tokio::spawn(
         //handling the stopping of the server
         handle.stopped(),
@@ -306,9 +313,8 @@ pub async fn test_extend_rpc() {
 
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
 
-    let _ = run_rpc_server(Arc::clone(&braid)).await.unwrap();
-
     let server_addr = "127.0.0.1:6682";
+    let _ = run_rpc_server(Arc::clone(&braid), server_addr).await.unwrap();
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -607,12 +607,12 @@ impl DownstreamClient {
         };
         let compact_target = submitted_job.blocktemplate.bits;
         let target = bitcoin::Target::from_compact(compact_target);
-        info!(
+        debug!(
             connection_id = %connection_id_hex,
             target = %target.to_hex(),
             "Mining target"
         );
-        info!(
+        debug!(
             connection_id = %connection_id_hex,
             block_hash = %header.block_hash(),
             "Block hash computed"
@@ -687,7 +687,7 @@ impl DownstreamClient {
 
                     match submission_tx.send(submission) {
                         Ok(_) => {
-                            info!(
+                            debug!(
                                 connection_id = %connection_id_hex,
                                 template_id = %template_id,
                                 "Block sent to submission handler"

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1310,6 +1310,7 @@ impl Notifier {
         };
         let deserialized_coinbase = serialize::<Transaction>(&coinbase_transaction);
         debug!(
+            template_id = ?template_id,
             coinbase = ?coinbase_transaction,
             "Deserialized coinbase"
         );
@@ -1341,8 +1342,8 @@ impl Notifier {
             }
         }
         debug!(
-            merkle_branches = ?merkle_branches,
             template_id = ?template_id,
+            merkle_branches = ?merkle_branches,
             "Merkle branches are"
         );
         //Stratum accepts the prev block hash to be in little endian instead of big endian
@@ -1412,16 +1413,31 @@ impl Notifier {
                         template_id = %template_id,
                         "Received new block template"
                     );
+                    let connection_snapshot = downstream_connection_map
+                        .lock()
+                        .await
+                        .downstream_channel_mapping
+                        .clone();
                     //We will receive the template from the IPC channel and construct a valid job
                     //from the provided template and pass onto the message_reciver in the handle connection for
                     // downstream communication to take place.
                     for (peer_adr, mining_job_arc) in self.job_map_arc.lock().await.iter() {
+                        let connection_info = match connection_snapshot.get(peer_adr) {
+                            Some(info) => info,
+                            None => {
+                                warn!(
+                                    template_id = %template_id,
+                                    peer = %peer_adr,
+                                    "Peer not found in connection mapping during job notification - skipping notification"
+                                );
+                                continue;
+                            }
+                        };
+                        let connection_id_hex = format!("{:x}", connection_info.connection_id);
                         let mut template_for_job = template.clone();
                         template_for_job.transactions.remove(0);
 
                         let mut curr_peer_mining_job_map = mining_job_arc.lock().await;
-                        //The new job id to be provided while constructing the new job .
-                        // let next_job_id = curr_peer_mining_job_map.get_next_job_id();
                         // Clean Jobs. If true, miners should abort their current work and immediately use the new job,
                         // even if it degrades hashrate in the short term. If false, they can still use the current job,
                         // but should move to the new one as soon as possible without impacting hashrate.
@@ -1436,7 +1452,14 @@ impl Notifier {
                         {
                             Ok(job) => job,
                             Err(e) => {
-                                error!(peer = %peer_adr, error = %e, template_id = %template_id, reason = "job_construction_failed", "Failed to construct job for peer");
+                                error!(
+                                    connection_id = %connection_id_hex,
+                                    template_id = %template_id,
+                                    peer = %peer_adr,
+                                    error = %e,
+                                    reason = "job_construction_failed",
+                                    "Failed to construct job for peer"
+                                );
                                 continue; // Skip this peer but continue with others
                             }
                         };
@@ -1482,19 +1505,24 @@ impl Notifier {
                             ]),
                         };
 
-                        let downstream_channel_mapping = downstream_connection_map
-                            .lock()
+                        if let Err(e) = connection_info
+                            .sender
+                            .send(serde_json::to_string(&job_notification_response).unwrap())
                             .await
-                            .downstream_channel_mapping
-                            .clone();
-
-                        if let Some(downstream_channel) = downstream_channel_mapping.get(peer_adr) {
-                            if let Err(e) = downstream_channel
-                                .send(serde_json::to_string(&job_notification_response).unwrap())
-                                .await
-                            {
-                                error!(peer = %peer_adr, error = %e, "Failed to send job to peer");
-                            }
+                        {
+                            error!(
+                                connection_id = %connection_id_hex,
+                                peer = %peer_adr,
+                                error = %e,
+                                "Failed to send job to peer"
+                            );
+                        } else {
+                            trace!(
+                                connection_id = %connection_id_hex,
+                                peer = %peer_adr,
+                                job_id = %numeric_job_id,
+                                "Dispatched job to peer"
+                            );
                         }
                     }
                 }
@@ -1506,43 +1534,47 @@ impl Notifier {
                         let id = latest_template_id.lock().await;
                         id.clone()
                     };
+                    let connection_entry = {
+                        let current_downstream_mapping = downstream_connection_map.lock().await;
+                        current_downstream_mapping
+                            .downstream_channel_mapping
+                            .get(&new_downstream_addr)
+                            .cloned()
+                    };
+                    let connection_entry = match connection_entry {
+                        Some(entry) => entry,
+                        None => {
+                            error!(peer = %new_downstream_addr, "Mining peer not found in connection mapping");
+                            return Err(StratumErrors::PeerNotFoundInConnectionMapping {
+                                peer_addr: new_downstream_addr,
+                            });
+                        }
+                    };
+                    let connection_id_hex = format!("{:x}", connection_entry.connection_id);
 
                     if current_template_id == "genesis" {
                         warn!(
+                            connection_id = %connection_id_hex,
                             miner = %new_downstream_addr,
                             "No templates generated yet for new miner"
                         );
                         continue; // Skip but keep notifier running
                     }
 
+                    let latest_template = latest_template_arc.lock().await.to_owned();
+                    let latest_template_merkle_branch =
+                        latest_template_merkle_branch_arc.lock().await.to_owned();
                     info!(
+                        connection_id = %connection_id_hex,
                         template_id = %current_template_id,
                         miner = %new_downstream_addr,
                         "Sending template to new miner"
                     );
-
-                    let latest_template = latest_template_arc.lock().await.to_owned();
-                    let latest_template_merkle_branch =
-                        latest_template_merkle_branch_arc.lock().await.to_owned();
-                    let current_downstream_mapping = downstream_connection_map.lock().await;
-                    let current_downstream_message_sender_res = current_downstream_mapping
-                        .downstream_channel_mapping
-                        .get(&new_downstream_addr);
                     let global_peer_mining_job_map_arc = self.job_map_arc.lock().await;
                     let current_peer_mining_job_map_arc = global_peer_mining_job_map_arc
                         .get(&new_downstream_addr)
                         .unwrap();
                     let mut curr_peer_mining_job_map = current_peer_mining_job_map_arc.lock().await;
-                    let current_downstream_message_sender =
-                        match current_downstream_message_sender_res {
-                            Some(downstream_sender) => downstream_sender,
-                            None => {
-                                error!(peer = %new_downstream_addr, "Mining peer not found in connection mapping");
-                                return Err(StratumErrors::PeerNotFoundInConnectionMapping {
-                                    peer_addr: new_downstream_addr,
-                                });
-                            }
-                        };
 
                     // Clean Jobs. If true, miners should abort their current work and immediately use the new job, even if it degrades hashrate in the short term.
                     // If false, they can still use the current job, but should move to the new one as soon as possible without impacting hashrate.
@@ -1613,10 +1645,7 @@ impl Notifier {
                             return Err(error);
                         }
                     };
-                    match current_downstream_message_sender
-                        .send(job_notification)
-                        .await
-                    {
+                    match connection_entry.sender.send(job_notification).await {
                         Ok(_) => {}
                         Err(error) => {
                             return Err(StratumErrors::NotifyMessageNotSent {
@@ -1634,8 +1663,14 @@ impl Notifier {
 }
 ///Connection information associated with each downstream peer associated along with the mapped `Sender_channel` for sending downstream responses and communication.
 #[derive(Debug, Clone)]
+pub struct ConnectionInfo {
+    pub connection_id: u32,
+    pub sender: mpsc::Sender<String>,
+}
+
+#[derive(Debug, Clone)]
 pub struct ConnectionMapping {
-    downstream_channel_mapping: HashMap<String, mpsc::Sender<String>>,
+    downstream_channel_mapping: HashMap<String, ConnectionInfo>,
 }
 impl ConnectionMapping {
     pub fn new() -> Self {
@@ -1643,14 +1678,20 @@ impl ConnectionMapping {
             downstream_channel_mapping: HashMap::new(),
         }
     }
-    ///Inserting new connction along with its `peer_socket_address` and `Sender_channel` associated with the client.
+    ///Inserting new connction along with its `peer_socket_address`, `connection_id`, and `Sender_channel`.
     pub fn new_connection(
         &mut self,
         peer_addr: String,
+        connection_id: u32,
         peer_msg_sender: mpsc::Sender<String>,
-    ) -> () {
-        self.downstream_channel_mapping
-            .insert(peer_addr, peer_msg_sender);
+    ) {
+        self.downstream_channel_mapping.insert(
+            peer_addr,
+            ConnectionInfo {
+                connection_id,
+                sender: peer_msg_sender,
+            },
+        );
     }
 }
 //Containing all the functionality for a stratum service
@@ -1697,23 +1738,34 @@ impl Server {
             }
         };
 
-        let actual_addr = listener.local_addr().unwrap();
-        crate::utils::log_server_listening(
+        let endpoints = crate::utils::server_endpoints(
             &self.stratum_config.hostname,
-            actual_addr.port(),
+            self.stratum_config.port,
             "stratum+tcp",
         );
+        if endpoints.is_empty() {
+            warn!(
+                host = %self.stratum_config.hostname,
+                port = %self.stratum_config.port,
+                "Server listening but no interfaces were discovered"
+            );
+        } else {
+            for endpoint in endpoints {
+                info!(endpoint = %endpoint, "Stratum server is listening");
+            }
+        }
         loop {
             tokio::select! {
                 event = listener.accept()=>{
                     //shared ownership across all tasks and spawning a seperate downstream for each new connection
                     let self_ = Arc::new(Mutex::new(DownstreamClient::default()));
-                    let connection_id_hex = {
+                    let (connection_id, connection_id_hex) = {
                         let mut client = self_.lock().await;
                         if let Some(ref submission_tx) = self.block_submission_tx {
                             client.block_submission_tx = Some(submission_tx.clone());
                         }
-                        format!("{:x}", client.connection_id)
+                        let id = client.connection_id;
+                        (id, format!("{:x}", id))
                     };
                     //downstream miner mapping for associated jobs for a specific channel for downstream
                     let self_mining_map = Arc::new(Mutex::new(MiningJobMap::new()));
@@ -1729,7 +1781,10 @@ impl Server {
                             //downstream channel for server2client communication to take place
                             let (downstream_tx,mut downstream_rx) = mpsc::channel(1024);
                             //adding the new connection to the connection map
-                            self.downstream_connection_mapping.lock().await.new_connection(peer_addr.to_string(), downstream_tx.clone());
+                            self.downstream_connection_mapping
+                                .lock()
+                                .await
+                                .new_connection(peer_addr.to_string(), connection_id, downstream_tx.clone());
                             info!(
                                 connection_id = %connection_id_hex,
                                 peer = %peer_addr,

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1161,7 +1161,11 @@ impl MiningJobMap {
         }
     }
     ///Inserting a suitable mining job which has been passed to the downstream being constructed from a suitable block template .
-    pub async fn insert_mining_job(&mut self, template_id: TemplateId, job_details: JobDetails) -> u64 {
+    pub async fn insert_mining_job(
+        &mut self,
+        template_id: TemplateId,
+        job_details: JobDetails,
+    ) -> u64 {
         let numeric_job_id = self.next_job_id;
 
         debug!(job_id = %numeric_job_id, template_id = %template_id, "Inserting mining job into MiningJobMap");
@@ -1479,8 +1483,9 @@ impl Notifier {
                             job_sent_time: unix_timestamp,
                         };
 
-                        let numeric_job_id =
-                            curr_peer_mining_job_map.insert_mining_job(template_id, job_details).await;
+                        let numeric_job_id = curr_peer_mining_job_map
+                            .insert_mining_job(template_id, job_details)
+                            .await;
 
                         let job_notification_response = JobNotificationResponse {
                             method: "mining.notify".to_string(),

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -30,12 +30,8 @@ use tracing::{debug, error, info, trace, warn};
 pub struct BlockSubmissionRequest {
     /// The template ID that this submission is for
     pub template_id: String,
-    /// Block version
-    pub version: i32,
-    /// Block timestamp
-    pub timestamp: u32,
-    /// Block nonce
-    pub nonce: u32,
+    /// Fully constructed block header (includes version, prevhash, merkle root, time, bits, nonce)
+    pub header: BlockHeader,
     /// Complete coinbase transaction
     pub coinbase_transaction: bitcoin::Transaction,
 }
@@ -686,9 +682,7 @@ impl DownstreamClient {
                 if let Some(ref submission_tx) = self.block_submission_tx {
                     let submission = BlockSubmissionRequest {
                         template_id: template_id.clone(),
-                        version: final_masked_version,
-                        timestamp: header.time.to_u32(),
-                        nonce: header.nonce,
+                        header: header.clone(),
                         coinbase_transaction: coinbase_tx_for_submission.clone(),
                     };
 

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1,6 +1,6 @@
 use crate::error::StratumErrors;
 use crate::template_creator::calculate_merkle_root;
-use crate::{SwarmHandler, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
+use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
 use bitcoin::block::HeaderExt;
 use bitcoin::consensus::serialize;
 use bitcoin::io::Cursor;
@@ -29,7 +29,7 @@ use tracing::{debug, error, info, trace, warn};
 #[derive(Debug, Clone)]
 pub struct BlockSubmissionRequest {
     /// The template ID that this submission is for
-    pub template_id: String,
+    pub template_id: TemplateId,
     /// Fully constructed block header (includes version, prevhash, merkle root, time, bits, nonce)
     pub header: BlockHeader,
     /// Complete coinbase transaction
@@ -477,8 +477,7 @@ impl DownstreamClient {
             .ok_or_else(|| StratumErrors::MiningJobNotFound {
                 job_id: Some(numeric_job_id),
                 template_id: None,
-            })?
-            .clone();
+            })?;
         //Building the coinbase and then eventually the block and testing for the validation against the
         //mainnet/regtest/cpunet/testnet difficulty or the weakshare local difficulty .
         let extranonce_1_hex = hex::encode(self.extranonce1.clone());
@@ -681,7 +680,7 @@ impl DownstreamClient {
                 // If valid block found, send to submission channel
                 if let Some(ref submission_tx) = self.block_submission_tx {
                     let submission = BlockSubmissionRequest {
-                        template_id: template_id.clone(),
+                        template_id,
                         header: header.clone(),
                         coinbase_transaction: coinbase_tx_for_submission.clone(),
                     };
@@ -1092,7 +1091,7 @@ pub enum NotifyCmd {
     SendToAll {
         template: BlockTemplate,
         merkle_branch_coinbase: Vec<Vec<u8>>,
-        template_id: String,
+        template_id: TemplateId,
     },
     SendLatestTemplateToNewDownstream {
         new_downstream_addr: String,
@@ -1147,9 +1146,9 @@ pub struct JobDetails {
 /// multiple threads serving requests according to the new process of serving requests .
 pub struct MiningJobMap {
     // template_id to job details
-    mining_jobs: HashMap<String, JobDetails>,
+    mining_jobs: HashMap<TemplateId, JobDetails>,
     // numeric job_id to template_id
-    job_id_to_template: HashMap<u64, String>,
+    job_id_to_template: HashMap<u64, TemplateId>,
     // Generate sequential numeric job IDs for miners
     next_job_id: u64,
 }
@@ -1162,13 +1161,13 @@ impl MiningJobMap {
         }
     }
     ///Inserting a suitable mining job which has been passed to the downstream being constructed from a suitable block template .
-    pub async fn insert_mining_job(&mut self, template_id: String, job_details: JobDetails) -> u64 {
+    pub async fn insert_mining_job(&mut self, template_id: TemplateId, job_details: JobDetails) -> u64 {
         let numeric_job_id = self.next_job_id;
 
         debug!(job_id = %numeric_job_id, template_id = %template_id, "Inserting mining job into MiningJobMap");
 
         // Store job by template_id
-        self.mining_jobs.insert(template_id.clone(), job_details);
+        self.mining_jobs.insert(template_id, job_details);
 
         // Map numeric job_id to template_id for reverse lookup
         self.job_id_to_template.insert(numeric_job_id, template_id);
@@ -1179,13 +1178,13 @@ impl MiningJobMap {
     /// Get job by template_id which is used internally by server
     pub async fn get_by_template_id(
         &self,
-        template_id: &str,
+        template_id: TemplateId,
     ) -> Result<&JobDetails, StratumErrors> {
         self.mining_jobs
-            .get(template_id)
+            .get(&template_id)
             .ok_or_else(|| StratumErrors::MiningJobNotFound {
                 job_id: None,
-                template_id: Some(template_id.to_string()),
+                template_id: Some(template_id),
             })
     }
 
@@ -1198,12 +1197,12 @@ impl MiningJobMap {
             }
         })?;
 
-        self.get_by_template_id(template_id).await
+        self.get_by_template_id(*template_id).await
     }
 
     /// Get template_id from numeric job_id for mining.submit validation
-    pub fn template_id_from_job_id(&self, job_id: u64) -> Option<&String> {
-        self.job_id_to_template.get(&job_id)
+    pub fn template_id_from_job_id(&self, job_id: u64) -> Option<TemplateId> {
+        self.job_id_to_template.get(&job_id).copied()
     }
 }
 ///`Notifier` that will serve the purpose of notifying the downstream nodes with the lates available jobs
@@ -1275,7 +1274,7 @@ impl Notifier {
     pub async fn construct_job_notification(
         clean_job: bool,
         mut notified_template: BlockTemplate,
-        template_id: &str,
+        template_id: TemplateId,
         merkle_coinbase_branch: Vec<Vec<u8>>,
     ) -> Result<JobNotification, StratumErrors> {
         debug!(
@@ -1304,7 +1303,7 @@ impl Notifier {
         };
         let deserialized_coinbase = serialize::<Transaction>(&coinbase_transaction);
         debug!(
-            template_id = ?template_id,
+            template_id = %template_id,
             coinbase = ?coinbase_transaction,
             "Deserialized coinbase"
         );
@@ -1336,7 +1335,7 @@ impl Notifier {
             }
         }
         debug!(
-            template_id = ?template_id,
+            template_id = %template_id,
             merkle_branches = ?merkle_branches,
             "Merkle branches are"
         );
@@ -1392,7 +1391,7 @@ impl Notifier {
         downstream_connection_map: Arc<Mutex<ConnectionMapping>>,
         latest_template_arc: &mut Arc<Mutex<BlockTemplate>>,
         latest_template_merkle_branch_arc: &mut Arc<Mutex<Vec<Vec<u8>>>>,
-        latest_template_id: Arc<Mutex<String>>,
+        latest_template_id: Arc<Mutex<TemplateId>>,
     ) -> Result<(), StratumErrors> {
         debug!("Stratum notifier task started");
         while let Some(notification_command) = self.notification_receiver.recv().await {
@@ -1439,7 +1438,7 @@ impl Notifier {
                         let job_notification = match Self::construct_job_notification(
                             clean_job,
                             template.clone(),
-                            &template_id,
+                            template_id,
                             merkle_branch_coinbase.clone(),
                         )
                         .await
@@ -1480,9 +1479,8 @@ impl Notifier {
                             job_sent_time: unix_timestamp,
                         };
 
-                        let numeric_job_id = curr_peer_mining_job_map
-                            .insert_mining_job(template_id.clone(), job_details)
-                            .await;
+                        let numeric_job_id =
+                            curr_peer_mining_job_map.insert_mining_job(template_id, job_details).await;
 
                         let job_notification_response = JobNotificationResponse {
                             method: "mining.notify".to_string(),
@@ -1524,10 +1522,7 @@ impl Notifier {
                 NotifyCmd::SendLatestTemplateToNewDownstream {
                     new_downstream_addr,
                 } => {
-                    let current_template_id = {
-                        let id = latest_template_id.lock().await;
-                        id.clone()
-                    };
+                    let current_template_id = *latest_template_id.lock().await;
                     let connection_entry = {
                         let current_downstream_mapping = downstream_connection_map.lock().await;
                         current_downstream_mapping
@@ -1546,10 +1541,9 @@ impl Notifier {
                     };
                     let connection_id_hex = format!("{:x}", connection_entry.connection_id);
 
-                    if current_template_id == "genesis" {
+                    if current_template_id == 0 {
                         warn!(
                             connection_id = %connection_id_hex,
-                            miner = %new_downstream_addr,
                             "No templates generated yet for new miner"
                         );
                         continue; // Skip but keep notifier running
@@ -1561,8 +1555,7 @@ impl Notifier {
                     info!(
                         connection_id = %connection_id_hex,
                         template_id = %current_template_id,
-                        miner = %new_downstream_addr,
-                        "Sending template to new miner"
+                        "Sending existing latest template to new miner"
                     );
                     let global_peer_mining_job_map_arc = self.job_map_arc.lock().await;
                     let current_peer_mining_job_map_arc = global_peer_mining_job_map_arc
@@ -1576,7 +1569,7 @@ impl Notifier {
                     let job_notification = Self::construct_job_notification(
                         clean_job,
                         latest_template.clone(),
-                        &current_template_id,
+                        current_template_id,
                         latest_template_merkle_branch,
                     )
                     .await;
@@ -1609,7 +1602,7 @@ impl Notifier {
                                     job_sent_time: unix_timestamp,
                                 };
                                 let numeric_job_id = curr_peer_mining_job_map
-                                    .insert_mining_job(current_template_id.clone(), job_details)
+                                    .insert_mining_job(current_template_id, job_details)
                                     .await;
                                 let job_notification_response = JobNotificationResponse {
                                     method: "mining.notify".to_string(),
@@ -2314,7 +2307,7 @@ mod test {
             ..Default::default()
         };
         let mut constructed_test_notification =
-            Notifier::construct_job_notification(false, test_template.clone(), "1", vec![])
+            Notifier::construct_job_notification(false, test_template.clone(), 1, vec![])
                 .await
                 .unwrap();
         println!(
@@ -2340,7 +2333,7 @@ mod test {
         let numeric_job_id = mock_mining_job_map
             .lock()
             .await
-            .insert_mining_job("1".to_string(), job_details.clone())
+            .insert_mining_job(1, job_details.clone())
             .await;
         let test_submit_request_params = json!([
             "bitaxe",

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -212,8 +212,7 @@ pub struct DownstreamClient {
     ///Configuration done so that all the phases are tracked and thus template can be supplied to downstream
     pub channel_configured: bool,
     /// The unique identifier assigned to this downstream connection/channel.
-    #[allow(unused)]
-    pub(super) connection_id: u32,
+    connection_id: u32,
     /// The extranonce1 value assigned to this downstream miner.
     extranonce1: Vec<u8>,
     /// `extranonce1` to be sent to the Downstream in the SV1 `mining.subscribe` message response.
@@ -232,6 +231,10 @@ pub struct DownstreamClient {
     pub block_submission_tx: Option<mpsc::UnboundedSender<BlockSubmissionRequest>>,
 }
 impl DownstreamClient {
+    /// A helper function to keep connection_id immutable after assignment
+    pub fn connection_id(&self) -> u32 {
+        self.connection_id
+    }
     /// Handles an incoming Stratum `Client2Server` request from a downstream miner.
     ///
     /// Routes the request to the appropriate handler based on its `method`:
@@ -259,6 +262,7 @@ impl DownstreamClient {
         let req_params = client_request.params;
         let method = client_request.method.clone();
         let client_request_id = client_request.id;
+        let connection_id_hex = format!("{:x}", self.connection_id());
         let response_or_error = match method.as_ref() {
             "mining.configure" => self.handle_configure(&req_params, client_request_id).await,
             "mining.subscribe" => {
@@ -291,16 +295,24 @@ impl DownstreamClient {
                     } => serde_json::to_string(&suggest_difficulty_resp).unwrap(),
                 };
                 debug!(
+                    connection_id = %connection_id_hex,
                     method = %client_request.method,
                     response = %response_json_string,
                     "Sending response to downstream"
                 );
                 match response_message_sender.send(response_json_string).await {
                     Ok(_) => {
-                        debug!("Response sent to writer task");
+                        debug!(
+                            connection_id = %connection_id_hex,
+                            "Response sent to writer task"
+                        );
                     }
                     Err(error) => {
-                        error!(error = %error, "Failed to send response to writer task");
+                        error!(
+                            connection_id = %connection_id_hex,
+                            error = %error,
+                            "Failed to send response to writer task"
+                        );
                     }
                 };
                 //Sending the initial latest avaialble template to the recently subscribed and authorized
@@ -319,10 +331,15 @@ impl DownstreamClient {
                         .await;
                     match notification_sent_res {
                         Ok(_) => {
-                            debug!(peer_addr = %peer_addr, "Requested latest template for new peer");
+                            debug!(
+                                connection_id = %connection_id_hex,
+                                peer_addr = %peer_addr,
+                                "Requested latest template for new peer"
+                            );
                         }
                         Err(error) => {
                             error!(
+                                connection_id = %connection_id_hex,
                                 error = %error,
                                 peer_addr = %peer_addr,
                                 "Failed to request latest template for new downstream"
@@ -334,6 +351,7 @@ impl DownstreamClient {
             }
             Err(error) => {
                 error!(
+                    connection_id = %connection_id_hex,
                     error = %error,
                     method = "handle_client_to_server_request",
                     "Failed to process client request"
@@ -373,6 +391,7 @@ impl DownstreamClient {
         client_request_id: u64,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
     ) -> Result<StratumResponses, StratumErrors> {
+        let connection_id_hex = format!("{:x}", self.connection_id());
         let param_array = match submit_work_params.as_array() {
             Some(param_array) => param_array,
             None => {
@@ -397,7 +416,11 @@ impl DownstreamClient {
             Ok(name) => name,
             Err(error) => return Err(error),
         };
-        info!(worker = %worker_name, "Mining worker connected");
+        info!(
+            connection_id = %connection_id_hex,
+            worker = %worker_name,
+            "Mining worker connected"
+        );
 
         // Parse hex job_id (sent by miner)
         let job_id_str = match param_array.get(1).and_then(|v| v.as_str()) {
@@ -475,6 +498,7 @@ impl DownstreamClient {
 
         // Log the coinbase transaction in hex
         debug!(
+            connection_id = %connection_id_hex,
             coinbase_hex = %hex::encode(&coinbase_bytes),
             "Reconstructed coinbase transaction"
         );
@@ -518,7 +542,12 @@ impl DownstreamClient {
             match hex::decode_to_slice(rolled_version_bits, &mut rolled_version) {
                 Ok(_) => (),
                 Err(e) => {
-                    error!(error = ?e, param = "rolled_version_bits", "Failed to decode version rolling bits");
+                    error!(
+                        connection_id = %connection_id_hex,
+                        error = ?e,
+                        param = "rolled_version_bits",
+                        "Failed to decode version rolling bits"
+                    );
                     return Err(StratumErrors::VersionRollingHexParseError {
                         error: e.to_string(),
                     });
@@ -541,12 +570,21 @@ impl DownstreamClient {
             let version_rolling_mask_bytes = version_rolling_mask.to_be_bytes();
             let version_rolling_mask_hex = hex::encode(version_rolling_mask_bytes);
 
-            info!(version_mask = ?version_rolling_mask_hex, "Converted version mask");
+            info!(
+                connection_id = %connection_id_hex,
+                version_mask = ?version_rolling_mask_hex,
+                "Converted version mask"
+            );
 
             match hex::decode_to_slice(version_rolling_mask_hex, &mut mask_bytes) {
                 Ok(_) => (),
                 Err(e) => {
-                    error!(error = ?e, param = "version_rolling_mask_hex", "Failed to decode version mask hex");
+                    error!(
+                        connection_id = %connection_id_hex,
+                        error = ?e,
+                        param = "version_rolling_mask_hex",
+                        "Failed to decode version mask hex"
+                    );
                     return Err(StratumErrors::VersionRollingHexParseError {
                         error: e.to_string(),
                     });
@@ -574,8 +612,16 @@ impl DownstreamClient {
         };
         let compact_target = submitted_job.blocktemplate.bits;
         let target = bitcoin::Target::from_compact(compact_target);
-        info!(target = %target.to_hex(), "Mining target");
-        info!(block_hash = %header.block_hash(), "Block hash computed");
+        info!(
+            connection_id = %connection_id_hex,
+            target = %target.to_hex(),
+            "Mining target"
+        );
+        info!(
+            connection_id = %connection_id_hex,
+            block_hash = %header.block_hash(),
+            "Block hash computed"
+        );
 
         // Print each header field in big-endian hex just before PoW validation
         let coinbase_txid_be_hex = hex::encode(coinbase_tx.compute_txid().to_byte_array());
@@ -590,6 +636,7 @@ impl DownstreamClient {
         let nonce_be_hex = hex::encode(header.nonce.to_be_bytes());
 
         debug!(
+            connection_id = %connection_id_hex,
             coinbase_txid = %coinbase_txid_be_hex,
             version = %version_be_hex,
             prev_blockhash = %prevhash_be_hex,
@@ -603,7 +650,11 @@ impl DownstreamClient {
         let witness = match &submitted_job.coinbase_witness_commitment {
             Some(w) => w.to_vec(),
             None => {
-                error!(job_id = %numeric_job_id, "Job missing witness commitment");
+                error!(
+                    connection_id = %connection_id_hex,
+                    job_id = %numeric_job_id,
+                    "Job missing witness commitment"
+                );
                 return Err(StratumErrors::InvalidCoinbase);
             }
         };
@@ -624,7 +675,12 @@ impl DownstreamClient {
         //Checking with PoW of the target whether the block sent by downstream is below that or not
         match header.validate_pow(target) {
             Ok(_) => {
-                debug!(target = %target.to_hex(), hash = %header.block_hash(), "Header meets target");
+                debug!(
+                    connection_id = %connection_id_hex,
+                    target = %target.to_hex(),
+                    hash = %header.block_hash(),
+                    "Header meets target"
+                );
 
                 // If valid block found, send to submission channel
                 if let Some(ref submission_tx) = self.block_submission_tx {
@@ -638,18 +694,37 @@ impl DownstreamClient {
 
                     match submission_tx.send(submission) {
                         Ok(_) => {
-                            info!(template_id = %template_id, "Block sent to submission handler");
+                            info!(
+                                connection_id = %connection_id_hex,
+                                template_id = %template_id,
+                                "Block sent to submission handler"
+                            );
                         }
                         Err(e) => {
-                            error!(error = %e, template_id = %template_id, "Failed to send block submission");
+                            error!(
+                                connection_id = %connection_id_hex,
+                                error = %e,
+                                template_id = %template_id,
+                                "Failed to send block submission"
+                            );
                         }
                     }
                 } else {
-                    warn!(context = "block_submission", template_id = %template_id, "Channel unavailable - cannot forward valid block");
+                    warn!(
+                        connection_id = %connection_id_hex,
+                        context = "block_submission",
+                        template_id = %template_id,
+                        "Channel unavailable - cannot forward valid block"
+                    );
                 }
             }
             Err(e) => {
-                debug!(error = %e, target = %target.to_hex(), "Header does not meet target");
+                debug!(
+                    connection_id = %connection_id_hex,
+                    error = %e,
+                    target = %target.to_hex(),
+                    "Header does not meet target"
+                );
                 return Ok(StratumResponses::StandardResponse {
                     std_response: StandardResponse::new_ok(Some(client_request_id), json!(false)),
                 });
@@ -673,7 +748,13 @@ impl DownstreamClient {
             .await
         {
             Ok(_) => {
-                info!(job_id = %numeric_job_id, template_id = %template_id, peer = %self.downstream_ip, "Candidate block submitted");
+                info!(
+                    connection_id = %connection_id_hex,
+                    job_id = %numeric_job_id,
+                    template_id = %template_id,
+                    peer = %self.downstream_ip,
+                    "Candidate block submitted"
+                );
                 Ok(StratumResponses::StandardResponse {
                     std_response: StandardResponse::new_ok(Some(client_request_id), json!(true)),
                 })
@@ -700,6 +781,7 @@ impl DownstreamClient {
     ) -> Result<StratumResponses, StratumErrors> {
         if let Some(difficulty) = suggest_difficulty_params.get(0) {
             info!(
+                connection_id = %format!("{:x}", self.connection_id()),
                 params = ?suggest_difficulty_params,
                 "Handling suggested difficulty"
             );
@@ -730,9 +812,11 @@ impl DownstreamClient {
         authorize_request_params: &Value,
         client_request_id: u64,
     ) -> Result<StratumResponses, StratumErrors> {
-        info!(
-            "Authorization is taking place -- {:?}",
-            authorize_request_params
+        let connection_id_hex = format!("{:x}", self.connection_id());
+        debug!(
+            connection_id = %connection_id_hex,
+            params = ?authorize_request_params,
+            "Authorization request"
         );
         let param_array = match authorize_request_params.as_array() {
             Some(param_array) => param_array,
@@ -766,7 +850,11 @@ impl DownstreamClient {
         }
 
         self.authorized = true;
-        info!(username = %username, "Miner authorized");
+        info!(
+            connection_id = %connection_id_hex,
+            username = %username,
+            "Miner authorized"
+        );
         Ok(StratumResponses::StandardResponse {
             std_response: (StandardResponse {
                 id: Some(client_request_id),
@@ -786,9 +874,11 @@ impl DownstreamClient {
         config_req_params: &Value,
         client_request_id: u64,
     ) -> Result<StratumResponses, StratumErrors> {
+        let connection_id_hex = format!("{:x}", self.connection_id());
         info!(
-            "{:?} configuration handling is taking place",
-            config_req_params
+            connection_id = %connection_id_hex,
+            params = ?config_req_params,
+            "Configuration handling is taking place"
         );
         let params = match config_req_params.as_array() {
             Some(param_array) => param_array,
@@ -822,7 +912,11 @@ impl DownstreamClient {
                     return Err(StratumErrors::ConfigureFeatureStringConversion { error: "Json value could not be converted to string in while handling mining.configure ".to_string() })
                 }
             };
-        info!(features = ?feature_names, "Mining features requested");
+        info!(
+            connection_id = %connection_id_hex,
+            features = ?feature_names,
+            "Mining features requested"
+        );
         let config_map = match params[1].as_object() {
             Some(con_map) => con_map,
             None => {
@@ -832,7 +926,11 @@ impl DownstreamClient {
                 });
             }
         };
-        info!(config = ?config_map, "Configuration map processed");
+        info!(
+            connection_id = %connection_id_hex,
+            config = ?config_map,
+            "Configuration map processed"
+        );
         //Possible `req_params` under the request sent to server via client
         #[allow(unused)]
         let minimum_difficulty = config_map.get("minimum-difficulty.value").or(None);
@@ -924,7 +1022,11 @@ impl DownstreamClient {
         subscribe_req_params: &Value,
         client_request_id: u64,
     ) -> Result<StratumResponses, StratumErrors> {
-        info!(params = ?subscribe_req_params, "Miner subscribing");
+        info!(
+            connection_id = %format!("{:x}", self.connection_id()),
+            params = ?subscribe_req_params,
+            "Miner subscribing"
+        );
         //TODO: dummy testing subscription IDs must be unique though can be changed accordingly these are just dummy values
         let subscriptions: Vec<(String, String)> = vec![
             (String::from("mining.set_difficulty"), String::from("34")),
@@ -949,9 +1051,13 @@ impl Default for DownstreamClient {
         //4 bytes
         let mut extranonce1_bytes = [0; 4];
         rand::thread_rng().fill_bytes(&mut extranonce1_bytes);
-        info!(
-            "Extranonce1 generated for a new downstream connection is following {:?}",
-            hex::encode(&extranonce1_bytes)
+        let connection_id = rand::thread_rng().next_u32(); // FIXME use a counter here, not an RNG
+                                                           // (will collide with 65k mining devices)
+        let extranonce1_hex = hex::encode(&extranonce1_bytes); // FIXME should be connection_id
+        debug!(
+            connection_id = %format!("{:x}", connection_id),
+            extranonce1 = %extranonce1_hex,
+            "Generated extranonce1 for new downstream connection"
         );
         DownstreamClient {
             authorized: false,
@@ -960,7 +1066,7 @@ impl Default for DownstreamClient {
             suggest_difficulty_done: false,
             channel_configured: false,
             //generating a random u32 client connection id
-            connection_id: rand::thread_rng().next_u32(),
+            connection_id,
             extranonce1: Vec::from(extranonce1_bytes),
             version_rolling_mask: None,
             version_rolling_min_bit: None,
@@ -1065,7 +1171,7 @@ impl MiningJobMap {
     pub async fn insert_mining_job(&mut self, template_id: String, job_details: JobDetails) -> u64 {
         let numeric_job_id = self.next_job_id;
 
-        info!(job_id = %numeric_job_id, template_id = %template_id, "Inserting mining job");
+        debug!(job_id = %numeric_job_id, template_id = %template_id, "Inserting mining job into MiningJobMap");
 
         // Store job by template_id
         self.mining_jobs.insert(template_id.clone(), job_details);
@@ -1178,7 +1284,7 @@ impl Notifier {
         template_id: &str,
         merkle_coinbase_branch: Vec<Vec<u8>>,
     ) -> Result<JobNotification, StratumErrors> {
-        info!(
+        debug!(
             template_id = %template_id,
             clean_job = %clean_job,
             "Constructing JobNotification"
@@ -1204,9 +1310,8 @@ impl Notifier {
         };
         let deserialized_coinbase = serialize::<Transaction>(&coinbase_transaction);
         debug!(
-            "Deserialized coinbase length is - {:?} \n and the coinbase tx is - {:?}",
-            deserialized_coinbase.len(),
-            coinbase_transaction
+            coinbase = ?coinbase_transaction,
+            "Deserialized coinbase"
         );
         //For splitting of the coinbase we check for the extranonce_seperator we had inserted while reconstructing the coinbase during the
         //fetching of the template via IPC .
@@ -1229,17 +1334,16 @@ impl Notifier {
         for tx in notified_template.transactions {
             txids_hashes.push(tx.compute_txid());
         }
-        if merkle_coinbase_branch.len() == 0 {
-            info!(template_id = %template_id, "Using previous template - empty merkle branch");
-        } else {
+        if merkle_coinbase_branch.len() != 0 {
             for sibling_node in merkle_coinbase_branch.iter() {
                 let sibling_hex = hex::encode(sibling_node);
                 merkle_branches.push(sibling_hex);
             }
         }
-        info!(
+        debug!(
             merkle_branches = ?merkle_branches,
-            "Merkle branches for the given template's coinbase are"
+            template_id = ?template_id,
+            "Merkle branches are"
         );
         //Stratum accepts the prev block hash to be in little endian instead of big endian
         //therefore byte by byte reversal is required here .
@@ -1304,9 +1408,9 @@ impl Notifier {
                     merkle_branch_coinbase,
                     template_id,
                 } => {
-                    info!(
+                    debug!(
                         template_id = %template_id,
-                        "Received new template to broadcast to all clients"
+                        "Received new block template"
                     );
                     //We will receive the template from the IPC channel and construct a valid job
                     //from the provided template and pass onto the message_reciver in the handle connection for
@@ -1398,7 +1502,6 @@ impl Notifier {
                 NotifyCmd::SendLatestTemplateToNewDownstream {
                     new_downstream_addr,
                 } => {
-                    info!(peer = %new_downstream_addr, "New miner connected");
                     let current_template_id = {
                         let id = latest_template_id.lock().await;
                         id.clone()
@@ -1434,7 +1537,7 @@ impl Notifier {
                         match current_downstream_message_sender_res {
                             Some(downstream_sender) => downstream_sender,
                             None => {
-                                error!(peer = %new_downstream_addr, "Peer not found in connection mapping");
+                                error!(peer = %new_downstream_addr, "Mining peer not found in connection mapping");
                                 return Err(StratumErrors::PeerNotFoundInConnectionMapping {
                                     peer_addr: new_downstream_addr,
                                 });
@@ -1598,16 +1701,20 @@ impl Server {
         crate::utils::log_server_listening(
             &self.stratum_config.hostname,
             actual_addr.port(),
-            "stratum+tcp"
+            "stratum+tcp",
         );
         loop {
             tokio::select! {
                 event = listener.accept()=>{
                     //shared ownership across all tasks and spawning a seperate downstream for each new connection
                     let self_ = Arc::new(Mutex::new(DownstreamClient::default()));
-                     if let Some(ref submission_tx) = self.block_submission_tx {
-                        self_.lock().await.block_submission_tx = Some(submission_tx.clone());
-                    }
+                    let connection_id_hex = {
+                        let mut client = self_.lock().await;
+                        if let Some(ref submission_tx) = self.block_submission_tx {
+                            client.block_submission_tx = Some(submission_tx.clone());
+                        }
+                        format!("{:x}", client.connection_id)
+                    };
                     //downstream miner mapping for associated jobs for a specific channel for downstream
                     let self_mining_map = Arc::new(Mutex::new(MiningJobMap::new()));
                     match event{
@@ -1623,7 +1730,11 @@ impl Server {
                             let (downstream_tx,mut downstream_rx) = mpsc::channel(1024);
                             //adding the new connection to the connection map
                             self.downstream_connection_mapping.lock().await.new_connection(peer_addr.to_string(), downstream_tx.clone());
-                            info!(peer = %peer_addr, "Miner connected");
+                            info!(
+                                connection_id = %connection_id_hex,
+                                peer = %peer_addr,
+                                "Miner connected"
+                            );
                             self_.lock().await.downstream_ip = peer_addr.to_string();
 
                             let connection_mapping_clone = Arc::clone(&self.downstream_connection_mapping);
@@ -1633,7 +1744,11 @@ impl Server {
                             // catering each new connection as seperate process
                             tokio::spawn(async move{
                                 let _=  Self::handle_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref).await;
-                                debug!(peer = %peer_addr_string, "Cleaning up disconnected miner");
+                                debug!(
+                                    connection_id = %connection_id_hex,
+                                    peer = %peer_addr_string,
+                                    "Cleaning up disconnected miner"
+                                );
 
                                 // cleanup after connection closes, remove from connection mapping
                                 connection_mapping_clone
@@ -1648,12 +1763,20 @@ impl Server {
                                         .await
                                         .remove(&peer_addr_string);
 
-                                debug!(peer = %peer_addr_string, "Miner cleanup complete");
+                                debug!(
+                                    connection_id = %connection_id_hex,
+                                    peer = %peer_addr_string,
+                                    "Miner cleanup complete"
+                                );
 
                             });
                         }
                         Err(error)=>{
-                            info!(error = ?error, "Connection failed");
+                            info!(
+                                connection_id = %connection_id_hex,
+                                error = ?error,
+                                "Connection failed"
+                            );
                         }
                     }
                 }
@@ -1694,21 +1817,43 @@ impl Server {
         let reader = BufReader::new(stream_reader);
         //reading incoming stream frame by frame
         let mut framed = FramedRead::new(reader, LinesCodec::new_with_max_length(MAX_LINE_LENGTH));
-        info!(peer = %peer_addr, "Handling new connection");
+        let connection_id_hex = {
+            let client = downstream_client.lock().await;
+            format!("{:x}", client.connection_id)
+        };
+        debug!(
+            connection_id = %connection_id_hex,
+            peer = %peer_addr,
+            "Handling new connection"
+        );
 
         loop {
             tokio::select! {
                 Some(message) = downstream_receiver.recv()=>{
-                    trace!(message = ?message, peer = %peer_addr, "Sending message to miner");
+                    trace!(
+                        connection_id = %connection_id_hex,
+                        message = ?message,
+                        peer = %peer_addr,
+                        "Sending message to miner"
+                    );
                     //Sending the notifications of new job to the downstream
                     let write_or_not = stream_writer.write_all(format!("{}\n",message).as_bytes()).await;
                     match write_or_not{
                         Ok(_)=>{
-                            trace!(peer = %peer_addr, "Response written to stream");
+                            trace!(
+                                connection_id = %connection_id_hex,
+                                peer = %peer_addr,
+                                "Response written to stream"
+                            );
 
                         },
                         Err(error)=>{
-                            error!(error = %error, peer = %peer_addr, "Failed to write to stream");
+                            error!(
+                                connection_id = %connection_id_hex,
+                                error = %error,
+                                peer = %peer_addr,
+                                "Failed to write to stream"
+                            );
                         }
                     }
                 }
@@ -1718,7 +1863,12 @@ impl Server {
                             if line.is_empty() {
                                 continue;
                             }
-                            trace!(line = %line, peer = %peer_addr, "Read line from miner");
+                            trace!(
+                                connection_id = %connection_id_hex,
+                                line = %line,
+                                peer = %peer_addr,
+                                "Read line from miner"
+                            );
                         //Parsing the lines read from buffer to find out whether they are valid JSON request type to be server as per
                         //stratum or not .
                         match serde_json::from_str::<StandardRequest>(&line) {
@@ -1735,6 +1885,7 @@ impl Server {
                                 }
                                 Err(e) => {
                                     error!(
+                                        connection_id = %connection_id_hex,
                                         peer = %peer_addr,
                                         error = %e,
                                         line = %line,
@@ -1747,11 +1898,21 @@ impl Server {
 
                         }
                         Some(Err(e)) => {
-                            error!(error = %e, peer = %peer_addr, fatal = true, "Fatal error reading from stream");
+                            error!(
+                                connection_id = %connection_id_hex,
+                                error = %e,
+                                peer = %peer_addr,
+                                fatal = true,
+                                "Fatal error reading from stream"
+                            );
                             return Err(Box::new(StratumErrors::UnableToReadStream { error: e }));
                         }
                         None => {
-                            info!(peer = %peer_addr, "Connection closed by client");
+                            info!(
+                                connection_id = %connection_id_hex,
+                                peer = %peer_addr,
+                                "Connection closed by client"
+                            );
                             break;
 
                         }

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1694,7 +1694,7 @@ impl Server {
         connection_mapping_arc: Arc<Mutex<ConnectionMapping>>,
         block_submission_tx: Option<mpsc::UnboundedSender<BlockSubmissionRequest>>,
     ) -> Self {
-        info!(config = ?server_config, "Initializing stratum server");
+        debug!(config = ?server_config, "Initializing stratum server");
 
         Self {
             stratum_config: server_config,

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -700,8 +700,8 @@ impl DownstreamClient {
     ) -> Result<StratumResponses, StratumErrors> {
         if let Some(difficulty) = suggest_difficulty_params.get(0) {
             info!(
-                "Handling suggested difficulty - {}",
-                suggest_difficulty_params
+                params = ?suggest_difficulty_params,
+                "Handling suggested difficulty"
             );
             self.suggest_difficulty_done = true;
             Ok(StratumResponses::SuggestDifficultyResponse {
@@ -1179,8 +1179,9 @@ impl Notifier {
         merkle_coinbase_branch: Vec<Vec<u8>>,
     ) -> Result<JobNotification, StratumErrors> {
         info!(
-            "Constructing JobNotification for job_id: {} with clean_job: {}",
-            template_id, clean_job
+            template_id = %template_id,
+            clean_job = %clean_job,
+            "Constructing JobNotification"
         );
 
         let coinbase_transaction = match notified_template.transactions.get_mut(0) {
@@ -1304,8 +1305,8 @@ impl Notifier {
                     template_id,
                 } => {
                     info!(
-                        "Received new template {} to broadcast to all clients",
-                        template_id
+                        template_id = %template_id,
+                        "Received new template to broadcast to all clients"
                     );
                     //We will receive the template from the IPC channel and construct a valid job
                     //from the provided template and pass onto the message_reciver in the handle connection for
@@ -1405,15 +1406,16 @@ impl Notifier {
 
                     if current_template_id == "genesis" {
                         warn!(
-                            "No templates generated yet for new miner {}",
-                            new_downstream_addr
+                            miner = %new_downstream_addr,
+                            "No templates generated yet for new miner"
                         );
                         continue; // Skip but keep notifier running
                     }
 
                     info!(
-                        "Sending template {} to new miner {}",
-                        current_template_id, new_downstream_addr
+                        template_id = %current_template_id,
+                        miner = %new_downstream_addr,
+                        "Sending template to new miner"
                     );
 
                     let latest_template = latest_template_arc.lock().await.to_owned();
@@ -1502,8 +1504,8 @@ impl Notifier {
                         Ok(job) => job,
                         Err(error) => {
                             error!(
-                                "Error occurred while fetching the job notification - {}",
-                                error
+                                error = %error,
+                                "Error occurred while fetching the job notification"
                             );
                             return Err(error);
                         }
@@ -1584,10 +1586,6 @@ impl Server {
             "{}:{}",
             self.stratum_config.hostname, self.stratum_config.port
         );
-        info!(
-            "Stratum mining server is listening at stratum+tcp://{:?}",
-            bind_address
-        );
         let listener = match TcpListener::bind(&bind_address).await {
             Ok(listener) => listener,
             Err(e) => {
@@ -1595,6 +1593,13 @@ impl Server {
                 return Err(Box::new(e));
             }
         };
+
+        let actual_addr = listener.local_addr().unwrap();
+        crate::utils::log_server_listening(
+            &self.stratum_config.hostname,
+            actual_addr.port(),
+            "stratum+tcp"
+        );
         loop {
             tokio::select! {
                 event = listener.accept()=>{

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -202,18 +202,18 @@ fn find_transaction_end(tx_data: &[u8]) -> Result<usize, CoinbaseError> {
         Ok(tx) => {
             let end_pos = cursor.position() as usize;
             debug!(
-                "Transaction parsing: {} inputs, {} outputs, {} bytes",
-                tx.input.len(),
-                tx.output.len(),
-                end_pos
+                input_count = %tx.input.len(),
+                output_count = %tx.output.len(),
+                bytes = %end_pos,
+                "Transaction parsed"
             );
             Ok(end_pos)
         }
         Err(e) => {
             error!(
-                "Failed to parse transaction: {} (data length: {})",
-                e,
-                tx_data.len()
+                error = %e,
+                data_length = %tx_data.len(),
+                "Transaction parsing failed"
             );
             Err(CoinbaseError::ConsensusDecodeError)
         }
@@ -330,7 +330,7 @@ fn create_segwit_commitment_output(commitment_bytes: &[u8]) -> Result<TxOut, Coi
 
     // Verify it starts with the SegWit commitment pattern
     if commitment_bytes.len() >= 6 && commitment_bytes[2..6] != [0xaa, 0x21, 0xa9, 0xed] {
-        warn!("Invalid SegWit commitment pattern");
+        warn!(commitment_len = %commitment_bytes.len(), expected_pattern = "aa21a9ed", "Invalid SegWit commitment pattern");
         return Err(CoinbaseError::InvalidCommitmentLength);
     }
     let script_bytes = commitment_bytes.to_vec();
@@ -376,7 +376,7 @@ pub fn build_braidpool_coinbase_from_template(
             &components.coinbase_commitment,
         )?)
     } else {
-        warn!("No SegWit commitment found in block template components");
+        warn!(context = "block_template", "SegWit commitment missing (may be expected for non-SegWit blocks)");
         None
     };
 

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -391,7 +391,7 @@ pub fn build_braidpool_coinbase_from_template(
 
     let reward_payout = TxOut {
         value: Amount::from_sat(total_available).map_err(|e| {
-            error!("Amount conversion failed: {}", e);
+            error!(error = %e, "Amount conversion failed");
             CoinbaseError::InvalidBlockTemplateData
         })?,
         script_pubkey: payout_address.script_pubkey(),
@@ -719,7 +719,7 @@ mod tests {
                     assert_eq!(empty_result, coinbase_txid.to_byte_array());
                 }
                 Err(e) => {
-                    error!("Invalid coinbase bytes: {}", e);
+                    error!(error = %e, "Invalid coinbase bytes");
                 }
             }
         }

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -376,7 +376,10 @@ pub fn build_braidpool_coinbase_from_template(
             &components.coinbase_commitment,
         )?)
     } else {
-        warn!(context = "block_template", "SegWit commitment missing (may be expected for non-SegWit blocks)");
+        warn!(
+            context = "block_template",
+            "SegWit commitment missing (may be expected for non-SegWit blocks)"
+        );
         None
     };
 

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -23,7 +23,7 @@ pub type Bytes = Vec<Byte>;
 pub(crate) type Relatives = HashSet<BeadHash>;
 
 // Error Definitions
-use std::{collections::HashSet, str::FromStr};
+use std::{collections::HashSet, net::IpAddr, str::FromStr};
 
 pub(crate) fn hashset_to_vec_deterministic(hashset: &HashSet<BeadHash>) -> Vec<BeadHash> {
     let mut vec: Vec<BeadHash> = hashset.iter().cloned().collect();
@@ -39,6 +39,61 @@ pub(crate) fn retrieve_bead(_beadhash: BeadHash) -> Option<Bead> {
     // This function is a placeholder for the actual retrieval logic.
     // In a real implementation, this would fetch the bead from a database or other storage.
     None
+}
+
+/// Get list of actual local IPv4 addresses for servers binding to 0.0.0.0
+///
+/// Returns all IPv4 addresses found on network interfaces.
+/// Returns empty vector if no interfaces found or on error.
+pub fn get_local_ipv4_addresses() -> Vec<IpAddr> {
+    if_addrs::get_if_addrs()
+        .unwrap_or_default()
+        .into_iter()
+        .filter_map(|iface| {
+            if let if_addrs::IfAddr::V4(ref addr) = iface.addr {
+                Some(IpAddr::V4(addr.ip))
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+/// Log server listening endpoints with actual IP addresses
+///
+/// When binding to 0.0.0.0, this enumerates all non-loopback IPv4 interfaces
+/// and logs each available endpoint. Otherwise, logs the configured address.
+///
+/// # Arguments
+/// * `bind_host` - The configured hostname (e.g., "0.0.0.0", "127.0.0.1", or specific IP)
+/// * `port` - The port number the server is listening on
+/// * `protocol` - Protocol prefix for the URL (e.g., "stratum+tcp", "http")
+pub fn log_server_listening(bind_host: &str, port: u16, protocol: &str) {
+    use tracing::info;
+
+    if bind_host == "0.0.0.0" {
+        let local_ips = get_local_ipv4_addresses();
+        if local_ips.is_empty() {
+            info!(
+                port = %port,
+                "Server is listening on all interfaces"
+            );
+        } else {
+            for ip in local_ips {
+                let endpoint = format!("{}://{}:{}", protocol, ip, port);
+                info!(
+                    endpoint = %endpoint,
+                    "Server is listening"
+                );
+            }
+        }
+    } else {
+        let endpoint = format!("{}://{}:{}", protocol, bind_host, port);
+        info!(
+            endpoint = %endpoint,
+            "Server is listening"
+        );
+    }
 }
 
 // Helper function to create test beads

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -10,6 +10,8 @@ use bitcoin::{
     CompactTarget, EcdsaSighashType, TxMerkleNode,
 };
 // Standard Imports
+#[allow(unused_imports)]
+use tracing::{debug, error, info, trace, warn};
 
 pub mod test_utils;
 
@@ -62,37 +64,25 @@ pub fn get_local_ipv4_addresses() -> Vec<IpAddr> {
 /// Log server listening endpoints with actual IP addresses
 ///
 /// When binding to 0.0.0.0, this enumerates all non-loopback IPv4 interfaces
-/// and logs each available endpoint. Otherwise, logs the configured address.
+/// and return each available endpoint. Otherwise, logs the configured address.
 ///
 /// # Arguments
 /// * `bind_host` - The configured hostname (e.g., "0.0.0.0", "127.0.0.1", or specific IP)
 /// * `port` - The port number the server is listening on
 /// * `protocol` - Protocol prefix for the URL (e.g., "stratum+tcp", "http")
-pub fn log_server_listening(bind_host: &str, port: u16, protocol: &str) {
-    use tracing::info;
-
+pub fn server_endpoints(bind_host: &str, port: u16, protocol: &str) -> Vec<String> {
     if bind_host == "0.0.0.0" {
         let local_ips = get_local_ipv4_addresses();
         if local_ips.is_empty() {
-            info!(
-                port = %port,
-                "Server is listening on all interfaces"
-            );
+            Vec::new()
         } else {
-            for ip in local_ips {
-                let endpoint = format!("{}://{}:{}", protocol, ip, port);
-                info!(
-                    endpoint = %endpoint,
-                    "Server is listening"
-                );
-            }
+            local_ips
+                .into_iter()
+                .map(|ip| format!("{}://{}:{}", protocol, ip, port))
+                .collect()
         }
     } else {
-        let endpoint = format!("{}://{}:{}", protocol, bind_host, port);
-        info!(
-            endpoint = %endpoint,
-            "Server is listening"
-        );
+        vec![format!("{}://{}:{}", protocol, bind_host, port)]
     }
 }
 
@@ -147,5 +137,32 @@ pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
         block_header: test_block_header,
         committed_metadata: test_committed_metadata,
         uncommitted_metadata: test_uncommitted_metadata,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[test]
+    fn server_endpoints_returns_single_endpoint_for_specific_host() {
+        let result = server_endpoints("127.0.0.1", 8080, "http");
+        assert_eq!(result, vec!["http://127.0.0.1:8080"]);
+    }
+
+    #[test]
+    fn server_endpoints_expands_all_interfaces_when_ips_provided() {
+        let local_ips = get_local_ipv4_addresses();
+        if local_ips.is_empty() {
+            // Some CI sandboxes may report no interfaces; in that case ensure the function returns empty too.
+            let result = server_endpoints("0.0.0.0", 3333, "stratum+tcp");
+            assert!(result.is_empty());
+        } else {
+            let expected: Vec<String> = local_ips
+                .into_iter()
+                .map(|ip| format!("stratum+tcp://{}:3333", ip))
+                .collect();
+            let result = server_endpoints("0.0.0.0", 3333, "stratum+tcp");
+            assert_eq!(result, expected);
+        }
     }
 }


### PR DESCRIPTION
Switch to the `tracing` library instead of `log` for systematic logging:
1. libp2p already uses it
2. Logs crate/module emitting the message
3. Replace all `println!()` statements with equivalent `tracing::info/error/debug` statements
4. Remove `env_logger` dependency
5. Removed `log` dependency in favor of `tracing-log` to intercept calls to `log::debug!` (etc) and forward them to the tracing module, for dependencies that use `log`.
6. Systematically use structured logging instead of string interpolation
7. Add `strum` as a dependency for better logging of errors involving enums (for `BitcoinRequest`, mostly in `ipc/client.rs`).
8. Propagate `template_id` and `block_hash` through the stratum and ipc interfaces for logging
9. Systematically use `template_id` as an integer instead of mixed string/int usage
10. Remove flexbuffers dependency (we removed it long ago) Fixes #165 
11. More clearly log Braid::extend and log failure to extend

Here's a list of direct dependencies that use `log`:
1. `sqlx` - Database connectivity (via sqlx-core, sqlx-sqlite)
2. `bitcoincore-rpc` - Bitcoin Core RPC client
3. `libp2p` - Peer-to-peer networking (via many sub-crates)
4. `jsonrpsee` - JSON-RPC client/server (via jsonrpsee-http-client)
5. `bitcoincore-zmq` - Bitcoin Core ZMQ bindings (via async_zmq → mio)

Here's a list of indirect dependencies that use `log`:
  - `async-io` - Used by sqlx-core
  - `async-std` - Used by sqlx
  - `kv-log-macro` - Used by async-std
  - `hyper-rustls` - HTTPS support for jsonrpsee
  - `if-watch` - Network interface monitoring for libp2p
  - `mio` (v0.6) - Async I/O for bitcoincore-zmq
  - `multistream-select` - Protocol negotiation for libp2p
  - `netlink-proto` & `netlink-sys` - Linux netlink for if-watch
  - `polling` - Polling mechanisms for async-io
  - `rtnetlink` - Linux routing for if-watch
  - `rustls` - TLS implementation (multiple dependents)
  - `rustls-platform-verifier` - Platform certificate verification
  - `soketto` - WebSocket for jsonrpsee
  - `tokio` - Core async runtime
  - `tracing-log` - The bridge itself (used by tracing-subscriber)
  - `tracing-subscriber` - tracing infrastructure

This PR is targeting the `15-10-25-db-integration` (#265) to minimize the diff. I will merge #265 first and change the target of this PR after merging it.