### PR TITLE
Implement braidpool_protocol! for p2p messages

### DIFF
--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -4,29 +4,56 @@ use crate::utils::BeadHash;
 use async_trait::async_trait;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
-use bitcoin::consensus::Error;
-use bitcoin::io::{self, BufRead, Write};
 use bitcoin::{BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget, TxMerkleNode};
 use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;
 use libp2p::StreamProtocol;
 use serde::{Deserialize, Serialize};
+use std::io::{Error as IoError, ErrorKind, Result as IoResult};
+
+/// Collection of beads.
+///
+/// Newtype wrapper around `Vec<Bead>` that provides Bitcoin consensus encoding/decoding
+/// and convenient iteration methods. Used to work around Rust's orphan rule.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct Beads(pub Vec<Bead>);
+impl_vec_wrapper!(Beads, Bead);
+
+/// Collection of bead hashes.
+///
+/// Newtype wrapper around `Vec<BeadHash>` that provides Bitcoin consensus encoding/decoding
+/// and convenient iteration methods. Used for requesting and responding with bead identifiers.
+#[derive(Clone, Debug, PartialEq, serde::Serialize, serde::Deserialize)]
+pub struct BeadHashes(pub Vec<BeadHash>);
+impl_vec_wrapper!(BeadHashes, BeadHash);
+
+/// A bead in the Braidpool DAG structure.
+///
+/// A bead represents a weak share in the Braidpool mining protocol. It combines a Bitcoin
+/// block header with metadata about the mining process and network topology.
+///
+/// **Fields:**
+/// - `block_header`: Standard Bitcoin block header with proof-of-work
+/// - `committed_metadata`: Metadata committed to the block (parents, timestamps, transactions)
+/// - `uncommitted_metadata`: Metadata not part of the hash (signature, broadcast time)
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Bead {
     pub block_header: BlockHeader,
     pub committed_metadata: CommittedMetadata,
     pub uncommitted_metadata: UnCommittedMetadata,
 }
+impl_consensus_encoding!(Bead, block_header, committed_metadata, uncommitted_metadata);
+
 impl Default for Bead {
     fn default() -> Self {
         let empty_merkle_bytes: [u8; 32] = [0; 32];
         Self {
             block_header: BlockHeader {
-                bits: CompactTarget::from_consensus(486604799),
+                bits: CompactTarget::from_consensus(1),
                 merkle_root: TxMerkleNode::from_byte_array(empty_merkle_bytes),
                 nonce: 0,
                 prev_blockhash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
-                time: BlockTime::from_u32(23021),
+                time: BlockTime::from_u32(0),
                 version: BlockVersion::TWO,
             },
             committed_metadata: CommittedMetadata::default(),
@@ -34,304 +61,72 @@ impl Default for Bead {
         }
     }
 }
-impl Encodable for Bead {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        let mut len = 0;
-        len += self.block_header.consensus_encode(w)?;
-        len += self.committed_metadata.consensus_encode(w)?;
-        len += self.uncommitted_metadata.consensus_encode(w)?;
-        Ok(len)
+
+braidpool_protocol! {
+    /// Request types for bead synchronization protocol.
+    ///
+    /// Used in the request-response protocol to request beads from remote peers.
+    /// Each variant maps to a specific opcode for network encoding.
+    ///
+    /// **Variants:**
+    /// - `GetBeads(BeadHashes)`: Request specific beads by their hashes
+    /// - `GetTips`: Request the current DAG tips
+    /// - `GetGenesis`: Request the genesis bead(s)
+    /// - `GetAllBeads`: Request all beads (for IBD)
+    /// - `GetBeadsAfter(BeadHashes)`: Request all beads after specified hashes (for sync)
+    pub enum BeadRequest {
+        GetBeads(BeadHashes)        = 0,
+        GetTips                     = 1,
+        GetGenesis                  = 2,
+        GetAllBeads                 = 3,
+        GetBeadsAfter(BeadHashes)   = 4,
     }
 }
 
-impl Decodable for Bead {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
-        let block_header = BlockHeader::consensus_decode(r)?;
-        let committed_metadata = CommittedMetadata::consensus_decode(r)?;
-        let uncommitted_metadata = UnCommittedMetadata::consensus_decode(r)?;
-        Ok(Bead {
-            block_header,
-            committed_metadata,
-            uncommitted_metadata,
-        })
+braidpool_protocol! {
+    /// Response types for bead synchronization protocol.
+    ///
+    /// Responses to `BeadRequest` messages. Contains either the requested data
+    /// or an error explaining why the request couldn't be fulfilled.
+    ///
+    /// **Variants:**
+    /// - `Beads(Beads)`: Response containing requested beads
+    /// - `Tips(BeadHashes)`: Response containing current DAG tip hashes
+    /// - `Genesis(BeadHashes)`: Response containing genesis bead hash(es)
+    /// - `GetAllBeads(Beads)`: Response containing all beads (for IBD)
+    /// - `GetBeadsAfter(BeadHashes)`: Response containing beads after specified hashes
+    /// - `Error(BeadSyncError)`: Error response indicating why request failed
+    pub enum BeadResponse {
+        Beads(Beads)                = 0,
+        Tips(BeadHashes)            = 1,
+        Genesis(BeadHashes)         = 2,
+        GetAllBeads(Beads)          = 3,
+        GetBeadsAfter(BeadHashes)   = 4,
+        Error(BeadSyncError)        = 5,
     }
 }
 
-#[repr(u8)]
-#[derive(Debug, Clone, Copy)]
-pub enum BeadRequestType {
-    GetBeads = 0,
-    GetTips = 1,
-    GetGenesis = 2,
-    GetAllBeads = 3,
-    GetBeadsAfter = 4,
-    BeadResponseError = 5,
-}
-//Converting from u8 to `RequestType`/ `ResponseType`
-impl BeadRequestType {
-    pub fn from_u8(v: u8) -> Option<Self> {
-        match v {
-            0 => Some(Self::GetBeads),
-            1 => Some(Self::GetTips),
-            2 => Some(Self::GetGenesis),
-            3 => Some(Self::GetAllBeads),
-            4 => Some(Self::GetBeadsAfter),
-            5 => Some(Self::BeadResponseError),
-            _ => None,
-        }
+braidpool_protocol! {
+    /// Errors that can occur during bead synchronization.
+    ///
+    /// These errors are returned in `BeadResponse::Error` to indicate
+    /// why a bead request could not be fulfilled.
+    ///
+    /// **Variants:**
+    /// - `GenesisMismatch`: Genesis beads don't match between peers
+    /// - `BeadHashNotFound`: Requested bead hash not found in local store
+    /// - `PeerSyncing`: Peer is still syncing (in IBD) and cannot serve requests
+    pub enum BeadSyncError {
+        GenesisMismatch     = 0,
+        BeadHashNotFound    = 1,
+        PeerSyncing         = 2,
     }
 }
 
-// Request types for bead download
-#[derive(Debug, Clone, PartialEq)]
-pub enum BeadRequest {
-    // Request beads from a specific set of hashes
-    GetBeads(Vec<BeadHash>),
-    // Request the latest tips from a peer
-    GetTips,
-    GetGenesis,
-    GetAllBeads,
-    GetBeadsAfter(Vec<BeadHash>),
-}
-
-// Response types for bead download
-#[derive(Debug, Clone, PartialEq)]
-pub enum BeadResponse {
-    // Response containing requested beads
-    Beads(Vec<Bead>),
-    // Response containing tips
-    Tips(Vec<BeadHash>),
-    // Response containing genesis
-    Genesis(Vec<BeadHash>),
-    // Get all beads for IBD
-    GetAllBeads(Vec<Bead>),
-    // Get beads after a specific set of hashes
-    GetBeadsAfter(Vec<BeadHash>),
-    // Error response
-    Error(BeadSyncError),
-}
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum BeadSyncError {
-    GenesisMismatch,
-    Other(String),
-}
-
-impl Encodable for BeadSyncError {
-    fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
-        match self {
-            BeadSyncError::GenesisMismatch => 0u8.consensus_encode(w),
-            BeadSyncError::Other(message) => {
-                let mut written = 0;
-                written += 1u8.consensus_encode(w)?;
-                written += message.consensus_encode(w)?;
-                Ok(written)
-            }
-        }
-    }
-}
-
-impl Decodable for BeadSyncError {
-    fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let error_type = u8::consensus_decode(d)?;
-        match error_type {
-            0 => Ok(BeadSyncError::GenesisMismatch),
-            1 => {
-                let message = String::consensus_decode(d)?;
-                Ok(BeadSyncError::Other(message))
-            }
-            _ => Err(Error::from(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid BeadSyncError type",
-            ))),
-        }
-    }
-}
-
-impl Encodable for BeadRequest {
-    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        match self {
-            BeadRequest::GetBeads(hashes) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeads as u8).consensus_encode(writer)?;
-                written += (hashes.len() as u32).consensus_encode(writer)?;
-                for hash in hashes {
-                    written += hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadRequest::GetTips => (BeadRequestType::GetTips as u8).consensus_encode(writer),
-            BeadRequest::GetGenesis => (BeadRequestType::GetGenesis as u8).consensus_encode(writer),
-            BeadRequest::GetAllBeads => {
-                (BeadRequestType::GetAllBeads as u8).consensus_encode(writer)
-            }
-            BeadRequest::GetBeadsAfter(hashes) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeadsAfter as u8).consensus_encode(writer)?;
-                written += (hashes.len() as u32).consensus_encode(writer)?;
-                for hash in hashes {
-                    written += hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-        }
-    }
-}
-
-impl Decodable for BeadRequest {
-    fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let request_type_u8 = u8::consensus_decode(d)?;
-        let request_type = BeadRequestType::from_u8(request_type_u8).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "Invalid bead request type")
-        })?;
-        match request_type {
-            BeadRequestType::GetBeads => {
-                let count = u32::consensus_decode(d)?;
-                let mut hashes = Vec::new();
-                for _ in 0..count {
-                    let hash = BeadHash::consensus_decode(d)?;
-                    hashes.push(hash);
-                }
-                Ok(BeadRequest::GetBeads(hashes))
-            }
-            BeadRequestType::GetTips => Ok(BeadRequest::GetTips),
-            BeadRequestType::GetGenesis => Ok(BeadRequest::GetGenesis),
-            BeadRequestType::GetAllBeads => Ok(BeadRequest::GetAllBeads),
-            BeadRequestType::GetBeadsAfter => {
-                let count = u32::consensus_decode(d)?;
-                let mut hashes = Vec::new();
-                for _ in 0..count {
-                    let hash = BeadHash::consensus_decode(d)?;
-                    hashes.push(hash);
-                }
-                Ok(BeadRequest::GetBeadsAfter(hashes))
-            }
-            _ => Err(Error::from(io::Error::new(
-                io::ErrorKind::InvalidData,
-                "Invalid BeadRequest type",
-            ))),
-        }
-    }
-}
-
-impl Encodable for BeadResponse {
-    fn consensus_encode<W: Write + ?Sized>(&self, writer: &mut W) -> Result<usize, io::Error> {
-        match self {
-            BeadResponse::Beads(beads) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeads as u8).consensus_encode(writer)?;
-                written += (beads.len() as u32).consensus_encode(writer)?;
-                for bead in beads {
-                    written += bead.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::Tips(tips) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetTips as u8).consensus_encode(writer)?;
-                written += (tips.len() as u32).consensus_encode(writer)?;
-                for tip in tips {
-                    written += tip.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::Genesis(genesis) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetGenesis as u8).consensus_encode(writer)?;
-                written += (genesis.len() as u32).consensus_encode(writer)?;
-                for hash in genesis {
-                    written += hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::GetAllBeads(beads) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetAllBeads as u8).consensus_encode(writer)?;
-                written += (beads.len() as u32).consensus_encode(writer)?;
-                for bead in beads {
-                    written += bead.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-            BeadResponse::Error(error) => {
-                let mut written = 0;
-                written += (BeadRequestType::BeadResponseError as u8).consensus_encode(writer)?;
-                written += error.consensus_encode(writer)?;
-                Ok(written)
-            }
-            BeadResponse::GetBeadsAfter(beads) => {
-                let mut written = 0;
-                written += (BeadRequestType::GetBeadsAfter as u8).consensus_encode(writer)?;
-                written += (beads.len() as u32).consensus_encode(writer)?;
-                for bead_hash in beads {
-                    written += bead_hash.consensus_encode(writer)?;
-                }
-                Ok(written)
-            }
-        }
-    }
-}
-
-impl Decodable for BeadResponse {
-    fn consensus_decode<D: BufRead + ?Sized>(d: &mut D) -> Result<Self, Error> {
-        let response_type_u8 = u8::consensus_decode(d)?;
-        let response_type = BeadRequestType::from_u8(response_type_u8).ok_or_else(|| {
-            io::Error::new(io::ErrorKind::InvalidData, "Invalid bead response type")
-        })?;
-        match response_type {
-            BeadRequestType::GetBeads => {
-                let count = u32::consensus_decode(d)?;
-                let mut beads = Vec::new();
-                for _ in 0..count {
-                    let bead = Bead::consensus_decode(d)?;
-                    beads.push(bead);
-                }
-                Ok(BeadResponse::Beads(beads))
-            }
-            BeadRequestType::GetTips => {
-                let count = u32::consensus_decode(d)?;
-                let mut tips = Vec::new();
-                for _ in 0..count {
-                    let tip = BeadHash::consensus_decode(d)?;
-                    tips.push(tip);
-                }
-                Ok(BeadResponse::Tips(tips))
-            }
-            BeadRequestType::GetGenesis => {
-                let count = u32::consensus_decode(d)?;
-                let mut genesis = Vec::new();
-                for _ in 0..count {
-                    let hash = BeadHash::consensus_decode(d)?;
-                    genesis.push(hash);
-                }
-                Ok(BeadResponse::Genesis(genesis))
-            }
-            BeadRequestType::GetAllBeads => {
-                let count = u32::consensus_decode(d)?;
-                let mut beads = Vec::new();
-                for _ in 0..count {
-                    let bead = Bead::consensus_decode(d)?;
-                    beads.push(bead);
-                }
-                Ok(BeadResponse::GetAllBeads(beads))
-            }
-            BeadRequestType::BeadResponseError => {
-                let error = BeadSyncError::consensus_decode(d)?;
-                Ok(BeadResponse::Error(error))
-            }
-            BeadRequestType::GetBeadsAfter => {
-                let count = u32::consensus_decode(d)?;
-                let mut bead_hashes = Vec::new();
-                for _ in 0..count {
-                    let bead_hash = BeadHash::consensus_decode(d)?;
-                    bead_hashes.push(bead_hash);
-                }
-                Ok(BeadResponse::GetBeadsAfter(bead_hashes))
-            }
-        }
-    }
-}
-
+/// Codec for encoding/decoding bead sync messages over libp2p.
+///
+/// Implements the `libp2p::request_response::Codec` trait to handle serialization
+/// of `BeadRequest` and `BeadResponse` messages using Bitcoin consensus encoding.
 #[derive(Clone, Default)]
 pub struct BeadCodec;
 
@@ -341,32 +136,24 @@ impl Codec for BeadCodec {
     type Request = BeadRequest;
     type Response = BeadResponse;
 
-    async fn read_request<T>(
-        &mut self,
-        _: &Self::Protocol,
-        io: &mut T,
-    ) -> std::io::Result<Self::Request>
+    async fn read_request<T>(&mut self, _: &Self::Protocol, io: &mut T) -> IoResult<Self::Request>
     where
         T: AsyncRead + Unpin + Send,
     {
         let mut buf = Vec::new();
         io.read_to_end(&mut buf).await?;
         BeadRequest::consensus_decode(&mut buf.as_slice())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))
     }
 
-    async fn read_response<T>(
-        &mut self,
-        _: &Self::Protocol,
-        io: &mut T,
-    ) -> std::io::Result<Self::Response>
+    async fn read_response<T>(&mut self, _: &Self::Protocol, io: &mut T) -> IoResult<Self::Response>
     where
         T: AsyncRead + Unpin + Send,
     {
         let mut buf = Vec::new();
         io.read_to_end(&mut buf).await?;
         BeadResponse::consensus_decode(&mut buf.as_slice())
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))
     }
 
     async fn write_request<T>(
@@ -374,17 +161,17 @@ impl Codec for BeadCodec {
         _: &Self::Protocol,
         io: &mut T,
         request: Self::Request,
-    ) -> std::io::Result<()>
+    ) -> IoResult<()>
     where
         T: AsyncWrite + Unpin + Send,
     {
         let mut buf = Vec::new();
         request
             .consensus_encode(&mut buf)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))?;
         io.write_all(&buf)
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            .map_err(|e| IoError::new(ErrorKind::Other, e))
     }
 
     async fn write_response<T>(
@@ -392,17 +179,17 @@ impl Codec for BeadCodec {
         _: &Self::Protocol,
         io: &mut T,
         response: Self::Response,
-    ) -> std::io::Result<()>
+    ) -> IoResult<()>
     where
         T: AsyncWrite + Unpin + Send,
     {
         let mut buf = Vec::new();
         response
             .consensus_encode(&mut buf)
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e))?;
+            .map_err(|e| IoError::new(ErrorKind::InvalidData, e))?;
         io.write_all(&buf)
             .await
-            .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+            .map_err(|e| IoError::new(ErrorKind::Other, e))
     }
 }
 

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -1,9 +1,11 @@
 use super::Bead;
 use super::BeadCodec;
 use super::BeadHash;
+use super::BeadHashes;
 use super::BeadRequest;
 use super::BeadResponse;
 use super::BeadSyncError;
+use super::Beads;
 use super::CommittedMetadata;
 use super::UnCommittedMetadata;
 use crate::committed_metadata::TimeVec;
@@ -164,11 +166,7 @@ fn test_serialized_bead() {
 
 #[test]
 fn test_bead_request_serialization() {
-    let request = BeadRequest::GetBeads(
-        vec![BeadHash::from_byte_array([0u8; 32])]
-            .into_iter()
-            .collect(),
-    );
+    let request = BeadRequest::GetBeads(vec![BeadHash::from_byte_array([0u8; 32])].into());
     let mut buffer = Vec::new();
     request.consensus_encode(&mut buffer).unwrap();
 
@@ -224,7 +222,7 @@ fn test_bead_response_serialization() {
         .committed_metadata(test_committed_metadata)
         .uncommitted_metadata(test_uncommitted_metadata)
         .build();
-    let response = BeadResponse::Beads(vec![test_bead]);
+    let response = BeadResponse::Beads(Beads(vec![test_bead]));
     let mut buffer = Vec::new();
     response.consensus_encode(&mut buffer).unwrap();
     let decoded = BeadResponse::consensus_decode(&mut buffer.as_slice()).unwrap();
@@ -251,20 +249,16 @@ fn test_codec_request_roundtrip() {
 #[test]
 fn test_codec_response_roundtrip() {
     let mut codec = BeadCodec::default();
-    let response = BeadResponse::Tips(
-        vec![
-            BeadHash::from_byte_array([
-                3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 1, 24, 12, 14, 35, 35, 34, 3, 42, 32, 32,
-                32, 32, 4, 32, 24, 5, 12, 1,
-            ]),
-            BeadHash::from_byte_array([
-                1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1,
-                2, 3, 4, 5,
-            ]),
-        ]
-        .into_iter()
-        .collect(),
-    );
+    let response = BeadResponse::Tips(BeadHashes(vec![
+        BeadHash::from_byte_array([
+            3, 4, 5, 6, 7, 8, 9, 10, 1, 2, 3, 4, 5, 1, 24, 12, 14, 35, 35, 34, 3, 42, 32, 32, 32,
+            32, 4, 32, 24, 5, 12, 1,
+        ]),
+        BeadHash::from_byte_array([
+            1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2, 3, 4, 5, 6, 7, 8, 9, 1, 2,
+            3, 4, 5,
+        ]),
+    ]));
 
     // Serialize
     let mut buffer = Vec::new();
@@ -280,11 +274,8 @@ fn test_codec_response_roundtrip() {
 #[test]
 fn test_get_beads_after_serialization() {
     let mut codec = BeadCodec::default();
-    let request = BeadRequest::GetBeadsAfter(
-        vec![BeadHash::from_byte_array([0u8; 32])]
-            .into_iter()
-            .collect(),
-    );
+    let request =
+        BeadRequest::GetBeadsAfter(BeadHashes(vec![BeadHash::from_byte_array([0u8; 32])]));
 
     // Serialize
     let mut buffer = Vec::new();
@@ -305,10 +296,12 @@ fn test_bead_request_codec() {
 
     for request in vec![
         BeadRequest::GetTips,
-        BeadRequest::GetBeads(Vec::from([BeadHash::from_byte_array([0u8; 32])])),
+        BeadRequest::GetBeads(BeadHashes(Vec::from([BeadHash::from_byte_array(
+            [0u8; 32],
+        )]))),
         BeadRequest::GetGenesis,
         BeadRequest::GetAllBeads,
-        BeadRequest::GetBeadsAfter(vec![BeadHash::from_byte_array([0u8; 32])]),
+        BeadRequest::GetBeadsAfter(BeadHashes(vec![BeadHash::from_byte_array([0u8; 32])])),
     ] {
         // Serialize
         let mut buffer = Vec::new();
@@ -334,13 +327,13 @@ fn test_bead_response_codec() {
 
     // Test all BeadResponse variants
     let responses = vec![
-        BeadResponse::Beads(vec![test_bead.clone()]),
-        BeadResponse::Tips(vec![test_hash, test_hash2]),
-        BeadResponse::Genesis(vec![test_hash]),
-        BeadResponse::GetAllBeads(vec![test_bead.clone(), test_bead.clone()]),
-        BeadResponse::GetBeadsAfter(vec![test_bead.block_header.block_hash()]),
+        BeadResponse::Beads(Beads(vec![test_bead.clone()])),
+        BeadResponse::Tips(BeadHashes(vec![test_hash, test_hash2])),
+        BeadResponse::Genesis(BeadHashes(vec![test_hash])),
+        BeadResponse::GetAllBeads(Beads(vec![test_bead.clone(), test_bead.clone()])),
+        BeadResponse::GetBeadsAfter(BeadHashes(vec![test_bead.block_header.block_hash()])),
         BeadResponse::Error(BeadSyncError::GenesisMismatch),
-        BeadResponse::Error(BeadSyncError::Other("Test error message".to_string())),
+        BeadResponse::Error(BeadSyncError::BeadHashNotFound),
     ];
 
     for response in responses {
@@ -363,10 +356,8 @@ fn test_bead_sync_error_codec() {
     // Test BeadSyncError encoding/decoding directly (not through codec)
     let errors = vec![
         BeadSyncError::GenesisMismatch,
-        BeadSyncError::Other("Network timeout".to_string()),
-        BeadSyncError::Other("Invalid bead format".to_string()),
-        BeadSyncError::Other("".to_string()), // Empty string edge case
-        BeadSyncError::Other("Very long error message that tests the string encoding and decoding with special characters: !@#$%^&*()_+-=[]{}|;':,.<>?".to_string()),
+        BeadSyncError::BeadHashNotFound,
+        BeadSyncError::PeerSyncing,
     ];
 
     for error in errors {

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -1,4 +1,4 @@
-use crate::bead::{Bead, BeadCodec, BeadRequest, BeadResponse, BeadSyncError};
+use crate::bead::{Bead, BeadCodec, BeadHashes, BeadRequest, BeadResponse, BeadSyncError};
 use crate::utils::BeadHash;
 use libp2p::floodsub;
 use libp2p::{
@@ -90,7 +90,7 @@ impl BraidPoolBehaviour {
     // Request beads from a peer
     pub fn request_beads(&mut self, peer: PeerId, hashes: &Vec<BeadHash>) -> OutboundRequestId {
         self.bead_sync
-            .send_request(&peer, BeadRequest::GetBeads(hashes.clone()))
+            .send_request(&peer, BeadRequest::GetBeads(BeadHashes(hashes.clone())))
     }
 
     // Request tips from a peer
@@ -106,7 +106,7 @@ impl BraidPoolBehaviour {
     // Respond to a bead request
     pub fn respond_with_beads(&mut self, channel: ResponseChannel<BeadResponse>, beads: Vec<Bead>) {
         self.bead_sync
-            .send_response(channel, BeadResponse::Beads(beads))
+            .send_response(channel, BeadResponse::Beads(crate::bead::Beads(beads)))
             .expect("Failed to send response");
     }
     //Respond with `GetBeadsAfter` beadhashes request
@@ -116,7 +116,10 @@ impl BraidPoolBehaviour {
         bead_hashes: Vec<BeadHash>,
     ) {
         self.bead_sync
-            .send_response(channel, BeadResponse::GetBeadsAfter(bead_hashes))
+            .send_response(
+                channel,
+                BeadResponse::GetBeadsAfter(BeadHashes(bead_hashes)),
+            )
             .expect("Failed to send response");
     }
     // Respond to a tips request
@@ -126,7 +129,7 @@ impl BraidPoolBehaviour {
         tips: Vec<BeadHash>,
     ) {
         self.bead_sync
-            .send_response(channel, BeadResponse::Tips(tips))
+            .send_response(channel, BeadResponse::Tips(BeadHashes(tips)))
             .expect("Failed to send response");
     }
 
@@ -137,7 +140,7 @@ impl BraidPoolBehaviour {
         genesis: Vec<BeadHash>,
     ) {
         self.bead_sync
-            .send_response(channel, BeadResponse::Genesis(genesis))
+            .send_response(channel, BeadResponse::Genesis(BeadHashes(genesis)))
             .expect("Failed to send response");
     }
 

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -178,15 +178,13 @@ async fn test_bead_request_handling() {
                                     );
                                     assert_eq!(hashes.len(), 1);
                                     assert_eq!(hashes.iter().next().unwrap(), &bead_hash);
-                                    // Respond with an error for now
+                                    // Bead not found in local store - return appropriate error
                                     swarm
                                         .behaviour_mut()
                                         .bead_sync
                                         .send_response(
                                             channel,
-                                            BeadResponse::Error(BeadSyncError::Other(
-                                                "Bead retrieval not implemented yet".to_string(),
-                                            )),
+                                            BeadResponse::Error(BeadSyncError::BeadHashNotFound),
                                         )
                                         .unwrap();
                                 }
@@ -235,16 +233,15 @@ async fn test_bead_request_handling() {
                                 } => {
                                     if let BeadRequest::GetBeads(hashes) = request {
                                         println!("Swarm2: Received bead request from {} with hashes: {:?}", peer, hashes);
-                                        // Respond with an error for now
+                                        // Bead not found in local store - return appropriate error
                                         swarm
                                             .behaviour_mut()
                                             .bead_sync
                                             .send_response(
                                                 channel,
-                                                BeadResponse::Error(BeadSyncError::Other(
-                                                    "Bead retrieval not implemented yet"
-                                                        .to_string(),
-                                                )),
+                                                BeadResponse::Error(
+                                                    BeadSyncError::BeadHashNotFound,
+                                                ),
                                             )
                                             .unwrap();
                                     }
@@ -256,12 +253,7 @@ async fn test_bead_request_handling() {
                                 } => {
                                     if let BeadResponse::Error(error) = response {
                                         println!("Swarm2: Received error response: {:?}", error);
-                                        assert_eq!(
-                                            error,
-                                            BeadSyncError::Other(String::from(
-                                                "Bead retrieval not implemented yet"
-                                            ))
-                                        );
+                                        assert_eq!(error, BeadSyncError::BeadHashNotFound);
                                         break;
                                     }
                                 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -34,6 +34,8 @@ use crate::{
     uncommitted_metadata::UnCommittedMetadata,
 };
 use std::error::Error;
+#[macro_use]
+pub mod macros;
 pub mod bead;
 pub mod behaviour;
 pub mod braid;

--- a/node/src/macros.rs
+++ b/node/src/macros.rs
@@ -1,0 +1,483 @@
+//! Macros for generating protocol enums with data-carrying variants
+
+/// Generates protocol enums with automatic consensus encoding/decoding implementations.
+/// Supports both unit variants and data-carrying variants.
+///
+/// This is intended for P2P messages which will be sent over the wire and assists in
+/// creating an enum for a category of requests or responses.
+///
+/// Each generated enum has a `msg_id()` method that returns the discriminant value.
+///
+/// **Syntax:**
+/// ```text
+/// braidpool_protocol! {
+///     pub enum MyProtocol {
+///         FirstMessage            = 0,            // unit variant
+///         SecondMessage(String)   = 1             // data-carrying with type
+///     }
+/// }
+///
+/// // Usage:
+/// let msg = MyProtocol::FirstMessage;
+/// assert_eq!(msg.msg_id(), 0);
+/// ```
+macro_rules! braidpool_protocol {
+    // Entry point - generate full enum with all implementations
+    (
+        $(#[$meta:meta])*
+        pub enum $name:ident {
+            $($variants:tt)*
+        }
+    ) => {
+        braidpool_protocol!(@generate
+            [$(#[$meta])*]
+            $name
+            $($variants)*
+        );
+    };
+
+    // Generate the enum and all implementations
+    (@generate
+        [$($meta:tt)*]
+        $name:ident
+        $($variants:tt)*
+    ) => {
+        $($meta)*
+        #[derive(Clone, Debug, PartialEq)]
+        #[repr(u8)]
+        pub enum $name {
+            $($variants)*
+        }
+
+        impl $name {
+            pub fn msg_id(&self) -> u8 {
+                braidpool_protocol!(@msg_id self, $name, $($variants)*)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Encodable for $name {
+            fn consensus_encode<W: bitcoin::io::Write + ?Sized>(&self, w: &mut W) -> core::result::Result<usize, bitcoin::io::Error> {
+                let mut len = 0;
+                braidpool_protocol!(@encode self, w, len, $name, $($variants)*)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Decodable for $name {
+            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::Error> {
+                let discriminant = u8::consensus_decode(r)?;
+                braidpool_protocol!(@decode discriminant, r, $name, $($variants)*)
+            }
+        }
+    };
+
+    // Message ID matching
+    (@msg_id $self:ident, $name:ident,) => {
+        panic!("Unreachable: All variants should be covered")
+    };
+    // Fallback for last element without trailing comma
+    (@msg_id $self:ident, $name:ident, $variant:ident = $discrim:literal) => {
+        $discrim
+    };
+    (@msg_id $self:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal) => {
+        $discrim
+    };
+    // Standard case with rest
+    (@msg_id $self:ident, $name:ident, $variant:ident = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant = $self {
+            $discrim
+        } else {
+            braidpool_protocol!(@msg_id $self, $name, $($rest)*)
+        }
+    };
+    (@msg_id $self:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant(_) = $self {
+            $discrim
+        } else {
+            braidpool_protocol!(@msg_id $self, $name, $($rest)*)
+        }
+    };
+
+    // Encode implementation
+    (@encode $self:ident, $w:ident, $len:ident, $name:ident, $($rest:tt)*) => {
+        braidpool_protocol!(@encode_match $self, $w, $len, $name, $($rest)*)
+    };
+
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant = $self {
+            $len += ($discrim as u8).consensus_encode($w)?;
+            Ok($len)
+        } else {
+            braidpool_protocol!(@encode_match $self, $w, $len, $name, $($rest)*)
+        }
+    };
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal, $($rest:tt)*) => {
+        if let $name::$variant(data) = $self {
+            $len += ($discrim as u8).consensus_encode($w)?;
+            $len += data.consensus_encode($w)?;
+            Ok($len)
+        } else {
+            braidpool_protocol!(@encode_match $self, $w, $len, $name, $($rest)*)
+        }
+    };
+    // Fallback for last element without trailing comma
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident = $discrim:literal) => {
+        $len += ($discrim as u8).consensus_encode($w)?;
+        Ok($len)
+    };
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $variant:ident($type:ty) = $discrim:literal) => {
+        if let $name::$variant(data) = $self {
+            $len += ($discrim as u8).consensus_encode($w)?;
+            $len += data.consensus_encode($w)?;
+            Ok($len)
+        } else {
+            panic!("Unreachable: All variants should be covered")
+        }
+    };
+    (@encode_match $self:ident, $w:ident, $len:ident, $name:ident, $($rest:tt)*) => {
+        panic!("Unreachable: All variants should be covered")
+    };
+
+    // Decode implementation
+    (@decode $discrim:ident, $r:ident, $name:ident, $($rest:tt)*) => {
+        braidpool_protocol!(@decode_match $discrim, $r, $name, $($rest)*)
+    };
+
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident = $expected:literal, $($rest:tt)*) => {
+        if $discrim == $expected {
+            Ok($name::$variant)
+        } else {
+            braidpool_protocol!(@decode_match $discrim, $r, $name, $($rest)*)
+        }
+    };
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident($type:ty) = $expected:literal, $($rest:tt)*) => {
+        if $discrim == $expected {
+            Ok($name::$variant(<$type as bitcoin::consensus::encode::Decodable>::consensus_decode($r)?))
+        } else {
+            braidpool_protocol!(@decode_match $discrim, $r, $name, $($rest)*)
+        }
+    };
+    // Fallback for last element without trailing comma
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident = $expected:literal) => {
+        if $discrim == $expected {
+            Ok($name::$variant)
+        } else {
+            Err(bitcoin::consensus::Error::from(bitcoin::io::Error::new(
+                bitcoin::io::ErrorKind::InvalidData,
+                concat!("Invalid message id for ", stringify!($name)),
+            )))
+        }
+    };
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $variant:ident($type:ty) = $expected:literal) => {
+        if $discrim == $expected {
+            Ok($name::$variant(<$type as bitcoin::consensus::encode::Decodable>::consensus_decode($r)?))
+        } else {
+            Err(bitcoin::consensus::Error::from(bitcoin::io::Error::new(
+                bitcoin::io::ErrorKind::InvalidData,
+                concat!("Invalid message id for ", stringify!($name)),
+            )))
+        }
+    };
+    (@decode_match $discrim:ident, $r:ident, $name:ident, $($rest:tt)*) => {
+        Err(bitcoin::consensus::Error::from(bitcoin::io::Error::new(
+            bitcoin::io::ErrorKind::InvalidData,
+            concat!("Invalid message id for ", stringify!($name)),
+        )))
+    };
+}
+
+/// Implements Bitcoin consensus encoding for structs with named fields.
+///
+/// This macro generates `Encodable` and `Decodable` trait implementations that encode/decode
+/// struct fields sequentially in the order specified. Includes OOM protection via `MAX_VEC_SIZE`.
+///
+/// **Syntax:** `impl_consensus_encoding!(StructName, field1, field2, field3);`
+///
+/// **Example:**
+/// ```text
+/// pub struct Transaction {
+///     pub version: u32,
+///     pub inputs: Vec<TxIn>,
+///     pub outputs: Vec<TxOut>,
+/// }
+///
+/// impl_consensus_encoding!(Transaction, version, inputs, outputs);
+/// ```
+///
+/// Based on rust-bitcoin's implementation pattern:
+/// <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/p2p/src/consensus.rs>
+macro_rules! impl_consensus_encoding {
+    ($thing:ident, $($field:ident),+) => {
+        impl bitcoin::consensus::encode::Encodable for $thing {
+            #[inline]
+            fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, bitcoin::io::Error> {
+                let mut len = 0;
+                $(len += self.$field.consensus_encode(w)?;)+
+                Ok(len)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Decodable for $thing {
+            #[inline]
+            fn consensus_decode_from_finite_reader<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$thing, bitcoin::consensus::encode::Error> {
+                Ok($thing {
+                    $($field: bitcoin::consensus::encode::Decodable::consensus_decode_from_finite_reader(r)?),+
+                })
+            }
+
+            #[inline]
+            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$thing, bitcoin::consensus::encode::Error> {
+                use bitcoin::io::Read;
+                let mut r = Read::take(r, bitcoin::consensus::encode::MAX_VEC_SIZE as u64);
+                Ok($thing {
+                    $($field: bitcoin::consensus::encode::Decodable::consensus_decode(&mut r)?),+
+                })
+            }
+        }
+    };
+}
+
+/// Implements traits for newtype wrappers around `Vec<T>`.
+///
+/// This macro generates implementations for wrapper types around `Vec<T>` to work around
+/// Rust's orphan rule. It provides:
+/// - `Deref` to `Vec<T>` for automatic method access
+/// - `IntoIterator` for use in `for` loops
+/// - `From<Vec<T>>` and `From<Wrapper>` for conversions
+/// - `Encodable` and `Decodable` with OOM protection
+///
+/// **Syntax:** `impl_vec_wrapper!(WrapperName, ElementType);`
+///
+/// **Example:**
+/// ```text
+/// #[derive(Clone, Debug, PartialEq)]
+/// pub struct Transactions(pub Vec<Transaction>);
+///
+/// impl_vec_wrapper!(Transactions, Transaction);
+///
+/// // Now you can use:
+/// let txs: Transactions = vec![tx1, tx2].into();
+/// for tx in txs { ... }
+/// txs.len();  // Via Deref
+/// ```
+///
+/// Based on rust-bitcoin's orphan rule workaround pattern:
+/// <https://github.com/rust-bitcoin/rust-bitcoin/blob/master/p2p/src/consensus.rs>
+macro_rules! impl_vec_wrapper {
+    ($wrapper: ident, $type: ty) => {
+        impl std::ops::Deref for $wrapper {
+            type Target = Vec<$type>;
+
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl IntoIterator for $wrapper {
+            type Item = $type;
+            type IntoIter = std::vec::IntoIter<$type>;
+
+            fn into_iter(self) -> Self::IntoIter {
+                self.0.into_iter()
+            }
+        }
+
+        impl From<Vec<$type>> for $wrapper {
+            fn from(v: Vec<$type>) -> Self {
+                $wrapper(v)
+            }
+        }
+
+        impl From<$wrapper> for Vec<$type> {
+            fn from(w: $wrapper) -> Self {
+                w.0
+            }
+        }
+
+        impl bitcoin::consensus::encode::Encodable for $wrapper {
+            #[inline]
+            fn consensus_encode<W: bitcoin::io::Write + ?Sized>(
+                &self,
+                w: &mut W,
+            ) -> core::result::Result<usize, bitcoin::io::Error> {
+                use bitcoin::consensus::WriteExt;
+                let mut len = 0;
+                len += w.emit_compact_size(self.0.len())?;
+                for c in self.0.iter() {
+                    len += c.consensus_encode(w)?;
+                }
+                Ok(len)
+            }
+        }
+
+        impl bitcoin::consensus::encode::Decodable for $wrapper {
+            #[inline]
+            fn consensus_decode_from_finite_reader<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$wrapper, bitcoin::consensus::encode::Error> {
+                use bitcoin::consensus::ReadExt;
+                let len = r.read_compact_size()?;
+                // Limit the initial vec allocation to at most 8,000 bytes, which is
+                // sufficient for most use cases. We don't allocate more space upfront
+                // than this, since `len` is an untrusted allocation capacity. If the
+                // vector does overflow the initial capacity `push` will just reallocate.
+                // Note: OOM protection relies on reader eventually running out of
+                // data to feed us.
+                let max_init_capacity = 8000 / core::mem::size_of::<$type>();
+                let mut ret = Vec::with_capacity(core::cmp::min(len as usize, max_init_capacity));
+                for _ in 0..len {
+                    ret.push(<$type as bitcoin::consensus::encode::Decodable>::consensus_decode_from_finite_reader(r)?);
+                }
+                Ok($wrapper(ret))
+            }
+
+            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(
+                r: &mut R,
+            ) -> core::result::Result<$wrapper, bitcoin::consensus::encode::Error> {
+                Self::consensus_decode_from_finite_reader(r)
+            }
+        }
+    };
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::utils::BeadHash as TestBeadHash;
+    use bitcoin::consensus::encode::{Decodable, Encodable};
+    use std::str::FromStr;
+
+    // Test 1: Unit variants only
+    braidpool_protocol! {
+        pub enum TestProtocol {
+            Variant1 = 0,
+            Variant2 = 1,
+            Variant3 = 2,
+        }
+    }
+
+    #[test]
+    fn test_unit_variants() {
+        let v1 = TestProtocol::Variant1;
+        assert_eq!(v1.msg_id(), 0);
+
+        let v2 = TestProtocol::Variant2;
+        assert_eq!(v2.msg_id(), 1);
+
+        let v3 = TestProtocol::Variant3;
+        assert_eq!(v3.msg_id(), 2);
+    }
+
+    // Test 2: Data-carrying variants
+    braidpool_protocol! {
+        pub enum DataProtocol {
+            Empty = 0,
+            Value(u32) = 5,
+            Text(String) = 10,
+        }
+    }
+
+    #[test]
+    fn test_data_carrying_variants() {
+        let d1 = DataProtocol::Empty;
+        assert_eq!(d1.msg_id(), 0);
+
+        let d2 = DataProtocol::Value(42);
+        assert_eq!(d2.msg_id(), 5);
+
+        let d3 = DataProtocol::Text("hello".to_string());
+        assert_eq!(d3.msg_id(), 10);
+    }
+
+    #[test]
+    fn test_encode_decode_unit() {
+        let original = TestProtocol::Variant2;
+        let mut encoded = Vec::new();
+        let len = original.consensus_encode(&mut encoded).unwrap();
+        assert!(len > 0);
+
+        let decoded = TestProtocol::consensus_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded.msg_id(), original.msg_id());
+        assert_eq!(decoded, TestProtocol::Variant2);
+    }
+
+    #[test]
+    fn test_encode_decode_data() {
+        let original = DataProtocol::Value(123);
+        let mut encoded = Vec::new();
+        let len = original.consensus_encode(&mut encoded).unwrap();
+        assert!(len > 0);
+
+        let decoded = DataProtocol::consensus_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded.msg_id(), original.msg_id());
+
+        if let DataProtocol::Value(val) = decoded {
+            assert_eq!(val, 123);
+        } else {
+            panic!("Expected Value variant");
+        }
+    }
+
+    // Test 3: BeadRequest pattern with Vec instead of HashSet for simplicity
+    braidpool_protocol! {
+        pub enum TestBeadRequest {
+            GetBeads(Vec<TestBeadHash>) = 0,
+            GetTips = 1,
+            GetGenesis = 2,
+        }
+    }
+
+    #[test]
+    fn test_bead_request_pattern() {
+        let mut hashes = Vec::new();
+        hashes.push(
+            TestBeadHash::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+
+        let req = TestBeadRequest::GetBeads(hashes.clone());
+        assert_eq!(req.msg_id(), 0);
+
+        let req2 = TestBeadRequest::GetTips;
+        assert_eq!(req2.msg_id(), 1);
+
+        let mut encoded = Vec::new();
+        req.consensus_encode(&mut encoded).unwrap();
+
+        let decoded = TestBeadRequest::consensus_decode(&mut encoded.as_slice()).unwrap();
+        assert_eq!(decoded.msg_id(), req.msg_id());
+    }
+
+    #[test]
+    fn test_all_variant_types() {
+        // Test we can create different variants
+        let _p1 = TestProtocol::Variant1;
+        let _p2 = TestProtocol::Variant2;
+        let _p3 = TestProtocol::Variant3;
+
+        let _d1 = DataProtocol::Empty;
+        let _d2 = DataProtocol::Value(42);
+        let _d3 = DataProtocol::Text("hello".to_string());
+
+        let mut hashes = Vec::new();
+        hashes.push(
+            TestBeadHash::from_str(
+                "0000000000000000000000000000000000000000000000000000000000000000",
+            )
+            .unwrap(),
+        );
+        let _br1 = TestBeadRequest::GetBeads(hashes);
+        let _br2 = TestBeadRequest::GetTips;
+        let _br3 = TestBeadRequest::GetGenesis;
+
+        // Just verify compilation - all enums can be created
+        assert!(true);
+    }
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -19,7 +19,7 @@ use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_R
 use node::utils::BeadHash;
 use node::SwarmHandler;
 use node::{
-    bead::{self, Bead, BeadRequest, BeadSyncError},
+    bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
     behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
     braid, cli,
     db::db_handlers::DBHandler,
@@ -34,7 +34,7 @@ use node::{
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
 use std::path::Path;
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
 use std::{collections::HashMap, error::Error};
@@ -46,8 +46,8 @@ use tracing::{debug, error, info, trace, warn};
 use behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent};
 
 use crate::behaviour::KADPROTOCOLNAME;
-const LATENCY_ALPHA: u64 = 10;
-//boot nodes peerIds
+const LATENCY_ALPHA: u64 = 10; // seconds
+                               //boot nodes peerIds
 const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
 //dns NS
 const SEED_DNS: &str = "/dnsaddr/french.braidpool.net";
@@ -70,10 +70,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let ibd_spinlock = Arc::new(ibd_or_not);
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
-    let genesis_beads = Vec::from([]);
     // Initializing the braid object with read write lock
     //for supporting concurrent readers and single writer
-    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
     //Initializing DB and db command handler
     let (mut _db_handler, db_tx) = DBHandler::new(Arc::clone(&braid)).await.unwrap();
     let db_connection_pool = _db_handler.db_connection_pool.clone();
@@ -477,7 +476,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      let mut braid_lock = braid.write().await;
                                      braid_lock.extend(&bead)
                                  };
-                                 if ibd_spinlock.load(std::sync::atomic::Ordering::SeqCst){
+                                 if ibd_spinlock.load(Ordering::SeqCst){
                                     let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
                                     let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
                                     if let Err(e) = ibd_command_tx
@@ -500,11 +499,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             swarm.behaviour_mut().bead_sync.send_request(
                                                 &peer,
                                                 BeadRequest::GetBeads(
-                                                    bead.committed_metadata
-                                                        .parents
-                                                        .clone()
-                                                        .into_iter()
-                                                        .collect(),
+                                                    BeadHashes(
+                                                        bead.committed_metadata
+                                                            .parents
+                                                            .clone()
+                                                            .into_iter()
+                                                            .collect(),
+                                                    )
                                                 ),
                                             );
                                         } else {
@@ -558,14 +559,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 continue;
                                             },
                                             braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
-                                                ibd_spinlock.store(false,std::sync::atomic::Ordering::SeqCst);
+                                                ibd_spinlock.store(false,Ordering::SeqCst);
                                                 continue;
                                             },
                                            }
 
                                         }
                                         else{
-                                            ibd_spinlock.store(false,std::sync::atomic::Ordering::SeqCst);
+                                            ibd_spinlock.store(false,Ordering::SeqCst);
                                             continue;
                                         }
                                     }
@@ -578,11 +579,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             swarm.behaviour_mut().bead_sync.send_request(
                                                 &peer,
                                                 BeadRequest::GetBeads(
-                                                    bead.committed_metadata
-                                                        .parents
-                                                        .clone()
-                                                        .into_iter()
-                                                        .collect(),
+                                                    BeadHashes(
+                                                        bead.committed_metadata
+                                                            .parents
+                                                            .clone()
+                                                            .into_iter()
+                                                            .collect(),
+                                                    )
                                                 ),
                                             );
                                         } else {
@@ -766,78 +769,116 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         } => {
                             // Handle the bead sync request here
                             match request {
-                                bead::BeadRequest::GetBeads(hashes) => {
-                                    let mut beads = Vec::new();
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        for hash in hashes.iter() {
-                                            if let Some(index) =
-                                                braid_lock.bead_index_mapping.get(hash)
-                                            {
-                                                if let Some(bead) = braid_lock.beads.get(*index) {
-                                                    beads.push(bead.clone());
+                                BeadRequest::GetBeads(hashes) => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let mut beads = Vec::new();
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            for hash in hashes.iter() {
+                                                if let Some(index) =
+                                                    braid_lock.bead_index_mapping.get(hash)
+                                                {
+                                                    if let Some(bead) = braid_lock.beads.get(*index) {
+                                                        beads.push(bead.clone());
+                                                    }
                                                 }
                                             }
                                         }
+                                        //Sending all the beads requested in the hashes supplied during `GetData` request
+                                        swarm.behaviour_mut().respond_with_beads(channel, beads);
                                     }
-                                    //Sending all the beads requested in the hashes supplied during `GetData` request
-                                    swarm.behaviour_mut().respond_with_beads(channel, beads);
                                 }
-                                bead::BeadRequest::GetTips => {
-                                    let tips;
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        tips = braid_lock
-                                            .tips
-                                            .iter()
-                                            .filter_map(|index| braid_lock.beads.get(*index))
-                                            .cloned()
-                                            .map(|bead| bead.block_header.block_hash())
-                                            .collect();
-                                    }
-                                    swarm.behaviour_mut().respond_with_tips(channel, tips);
-                                }
-                                bead::BeadRequest::GetGenesis => {
-                                    let genesis;
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        genesis = braid_lock
-                                            .genesis_beads
-                                            .iter()
-                                            .filter_map(|index| braid_lock.beads.get(*index))
-                                            .cloned()
-                                            .map(|bead| bead.block_header.block_hash())
-                                            .collect();
-                                    }
-                                    swarm.behaviour_mut().respond_with_genesis(channel, genesis);
-                                }
-                                bead::BeadRequest::GetAllBeads => {
-                                    let all_beads;
-                                    {
-                                        let braid_lock = braid.read().await;
-                                        all_beads = braid_lock.beads.iter().cloned().collect();
-                                    }
-                                    swarm.behaviour_mut().respond_with_beads(channel, all_beads);
-                                }
-                                bead::BeadRequest::GetBeadsAfter(hashes) => {
-                                    let beads = braid.read().await.get_beads_after(hashes);
-                                    if let Some(response_beads) = beads {
-                                        let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
-                                        for bead in response_beads.into_iter(){
-                                            computed_beads_hashes.push(bead.block_header.block_hash());
-                                        }
-                                        //Sending the corresponding bead hashes requested by the new peer for IBD that will
-                                        //be after the new peer's `Tips`.
-                                        swarm
-                                            .behaviour_mut()
-                                            .respond_with_beadhashes(channel, computed_beads_hashes);
-                                    } else {
+                                BeadRequest::GetTips => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
                                         swarm.behaviour_mut().respond_with_error(
                                             channel,
-                                            BeadSyncError::Other(String::from(
-                                                "provided hashes not found",
-                                            )),
+                                            BeadSyncError::PeerSyncing,
                                         );
+                                    } else {
+                                        let tips;
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            tips = braid_lock
+                                                .tips
+                                                .iter()
+                                                .filter_map(|index| braid_lock.beads.get(*index))
+                                                .cloned()
+                                                .map(|bead| bead.block_header.block_hash())
+                                                .collect();
+                                        }
+                                        swarm.behaviour_mut().respond_with_tips(channel, tips);
+                                    }
+                                }
+                                BeadRequest::GetGenesis => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let genesis;
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            genesis = braid_lock
+                                                .genesis_beads
+                                                .iter()
+                                                .filter_map(|index| braid_lock.beads.get(*index))
+                                                .cloned()
+                                                .map(|bead| bead.block_header.block_hash())
+                                                .collect();
+                                        }
+                                        swarm.behaviour_mut().respond_with_genesis(channel, genesis);
+                                    }
+                                }
+                                BeadRequest::GetAllBeads => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let all_beads;
+                                        {
+                                            let braid_lock = braid.read().await;
+                                            all_beads = braid_lock.beads.iter().cloned().collect();
+                                        }
+                                        swarm.behaviour_mut().respond_with_beads(channel, all_beads);
+                                    }
+                                }
+                                BeadRequest::GetBeadsAfter(hashes) => {
+                                    // Check if we're still in IBD
+                                    if ibd_spinlock.load(Ordering::SeqCst) {
+                                        swarm.behaviour_mut().respond_with_error(
+                                            channel,
+                                            BeadSyncError::PeerSyncing,
+                                        );
+                                    } else {
+                                        let beads = braid.read().await.get_beads_after(hashes.into());
+                                        if let Some(response_beads) = beads {
+                                            let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
+                                            for bead in response_beads.into_iter(){
+                                                computed_beads_hashes.push(bead.block_header.block_hash());
+                                            }
+                                            //Sending the corresponding bead hashes requested by the new peer for IBD that will
+                                            //be after the new peer's `Tips`.
+                                            swarm
+                                                .behaviour_mut()
+                                                .respond_with_beadhashes(channel, computed_beads_hashes);
+                                        } else {
+                                            swarm.behaviour_mut().respond_with_error(
+                                                channel,
+                                                BeadSyncError::BeadHashNotFound,
+                                            );
+                                        }
                                     }
                                 }
                             }
@@ -847,8 +888,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             response,
                         } => {
                             match response {
-                                bead::BeadResponse::Beads(beads)
-                                | bead::BeadResponse::GetAllBeads(beads) => {
+                                BeadResponse::Beads(beads)
+                                | BeadResponse::GetAllBeads(beads) => {
                                     let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
                                     //Fetching the pruned bead-hashes received during `GetBeadAfter` request
                                     match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
@@ -976,10 +1017,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     //Sleeping for a fixed duration to be set according to statistical estimates
                                                     tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
                                                     //We will check if no bead is `incoming` after the duration of 600 seconds then we will reset/set ibd_flag accordingly
-                                                    if ibd_spinlock_ref.load(std::sync::atomic::Ordering::SeqCst) == true{
+                                                    if ibd_spinlock_ref.load(Ordering::SeqCst) == true{
                                                         //If no incoming is received during the period then we can say
                                                         //that ibd wrt the given sync node is successfully completed
-                                                        ibd_spinlock_ref.store(false,std::sync::atomic::Ordering::SeqCst);
+                                                        ibd_spinlock_ref.store(false,Ordering::SeqCst);
                                                         warn!("Maximum threshold wrt IBD incoming exceeded thus ibd_flag being set to false");
                                                     }
 
@@ -1000,7 +1041,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         };
                                     }
                                 }
-                                 bead::BeadResponse::GetBeadsAfter(bead_hashes)=>{
+                                 BeadResponse::GetBeadsAfter(bead_hashes)=>{
                                     //Getting all the beadhashes after the common oldest in both the peers
                                     let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
                                     match ibd_command_tx.send(IBDCommands::FetchCachedTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
@@ -1079,7 +1120,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
 
                                 }
-                                bead::BeadResponse::Tips(tips) => {
+                                BeadResponse::Tips(tips) => {
                                     info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
                                     //If received tips are already present in the local braid arc then we can stop
                                     //IBD and continue with mining
@@ -1109,10 +1150,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         //No need to proceed further and continue to next event
                                         info!("Peer already synced to tip");
                                         //IBD flag can be set  as the current bead is already synced//
-                                        ibd_spinlock.store(false, std::sync::atomic::Ordering::SeqCst);
+                                        ibd_spinlock.store(false, Ordering::SeqCst);
                                         continue;
                                     }
-                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips, peer_id: peer.to_string() }).await{
+                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips.0, peer_id: peer.to_string() }).await{
                                     Ok(_)=>{
                                         info!("Tip cache update successfully");
                                     },
@@ -1133,15 +1174,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                        current_tip_hashes.push(current_bead.block_header.block_hash());
                                     });
                                     //Sending the current bead hashes for the receiving of beads to start in batches
-                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(current_tip_hashes);
+                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
                                     swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
 
                                 }
-                                bead::BeadResponse::Genesis(genesis) => {
+                                BeadResponse::Genesis(genesis) => {
                                     info!(genesis=?genesis,"Received genesis beads: ");
                                     let status = {
                                         let braid_lock = braid.read().await;
-                                        braid_lock.check_genesis_beads(&genesis)
+                                        braid_lock.check_genesis_beads(&genesis.0)
                                     };
                                     match status {
                                         braid::GenesisCheckStatus::GenesisBeadsValid => {
@@ -1151,24 +1192,29 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             warn!(peer = %peer, "Missing genesis bead");
                                             swarm
                                                 .behaviour_mut()
-                                                .request_beads(peer, &genesis);
+                                                .request_beads(peer, &genesis.0);
                                         }
                                         braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
                                             warn!(
-                                                received = %genesis.len(),
+                                                received = %genesis.0.len(),
                                                 peer = %peer,
                                                 "Genesis bead count mismatch"
                                             );
                                         }
                                     }
                                 }
-                                bead::BeadResponse::Error(error) => match error {
+                                BeadResponse::Error(error) => match error {
                                     BeadSyncError::GenesisMismatch => {
                                         warn!("Genesis mismatch error received");
                                         swarm.behaviour_mut().request_genesis(peer.clone());
                                     }
-                                    BeadSyncError::Other(ref err_msg) => {
-                                        error!(err_msg=?err_msg,"Error in bead sync response:");
+                                    BeadSyncError::BeadHashNotFound => {
+                                        warn!("Peer requested bead hashes not found in local store");
+                                    }
+                                    BeadSyncError::PeerSyncing => {
+                                        warn!("Peer is still in IBD, retry with different peer");
+                                        // FIXME Could retry with different peer or wait
+                                        // For now, log and continue
                                     }
                                 },
                             };


### PR DESCRIPTION
    - Copies/reimplements some macros from rust-bitcoin (that are not exported)
    - Allows an "enum" variant that can include both integer and data-carrying variants with explicit discriminant assignment (because discriminants are protocol "magic numbers" and would be needed for any alternative implementation)
    - Automatically implements consensus_encode/decode including Vec arguments
    - Update BeadRequest, BeadResponse, BeadSyncError to use braidpool_protocol!
    - Remove DRY-violating BeadRequestType
    - Add rustdoc comments to all these messages
    - Refuse to respond to most messages if ibd_spinlock is held