### PR TITLE
feat: Initial Audit mode with upstream pool proxy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3135,6 +3135,7 @@ dependencies = [
  "serde",
  "serde_json",
  "shellexpand",
+ "socket2 0.5.10",
  "sqlx",
  "strum",
  "tokio",

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -35,6 +35,7 @@ sqlx = { workspace = true}
 strum = { workspace = true }
 if-addrs = { workspace = true }
 anyhow = { workspace = true }
+socket2 = { version = "0.5", features = ["all"] }
 
 
 [build-dependencies]

--- a/node/src/audit.rs
+++ b/node/src/audit.rs
@@ -1,39 +1,258 @@
-use bitcoin::hashes::sha256;
-use bitcoin::{BlockHash, CompactTarget};
+use crate::bead::Bead;
+use crate::braid::{AddBeadStatus, Braid};
+use bitcoin::consensus::serialize;
+use bitcoin::hashes::sha256d;
+use bitcoin::BlockHash;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::SystemTime;
-use tracing::{info, warn};
-#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
-pub struct ShareId(pub [u8; 32]);
+use tokio::sync::RwLock;
+use tracing::{debug, error, info, warn};
 
-impl ShareId {
-    pub fn from_share(
-        job_id: &str,
-        extranonce2: &str,
-        nonce: &str,
-        ntime: &str,
-        worker_name: &str,
-    ) -> Self {
-        let mut engine = sha256::Hash::engine();
-        bitcoin::hashes::HashEngine::input(&mut engine, job_id.as_bytes());
-        bitcoin::hashes::HashEngine::input(&mut engine, extranonce2.as_bytes());
-        bitcoin::hashes::HashEngine::input(&mut engine, nonce.as_bytes());
-        bitcoin::hashes::HashEngine::input(&mut engine, ntime.as_bytes());
-        bitcoin::hashes::HashEngine::input(&mut engine, worker_name.as_bytes());
-        let result = sha256::Hash::from_engine(engine);
-        let mut id = [0u8; 32];
-        id.copy_from_slice(result.as_ref());
-        ShareId(id)
+pub const UPSTREAM_EXTRANONCE1_BYTES: usize = 4;
+pub const MINER_PREFIX_BYTES: usize = 2;
+pub const COMMITMENT_BYTES: usize = 5;
+pub const MINER_ROLL_BYTES: usize = 1;
+pub const TOTAL_EXTRANONCE1_BYTES: usize =
+    UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES + COMMITMENT_BYTES;
+
+pub type ShareId = BlockHash;
+
+/// Compute composite hash for audit mode: hash(block_header || committed_metadata)
+/// This is ONLY used in audit mode where we cannot use OP_RETURN commitments, which
+/// we will use as an extranonce commitment.
+pub fn compute_audit_bead_hash(bead: &Bead) -> BlockHash {
+    let header_bytes = serialize(&bead.block_header);
+    let metadata_bytes = serialize(&bead.committed_metadata);
+    let mut combined = Vec::with_capacity(header_bytes.len() + metadata_bytes.len());
+    combined.extend_from_slice(&header_bytes);
+    combined.extend_from_slice(&metadata_bytes);
+    BlockHash::from_byte_array(sha256d::Hash::hash(&combined).to_byte_array())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditCommitment {
+    pub commitment_bytes: [u8; COMMITMENT_BYTES],
+    pub parent_bead_hash: Option<BlockHash>,
+}
+
+impl Default for AuditCommitment {
+    fn default() -> Self {
+        Self {
+            commitment_bytes: [0u8; COMMITMENT_BYTES],
+            parent_bead_hash: None,
+        }
     }
 }
 
-impl std::fmt::Display for ShareId {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{}", hex::encode(&self.0[..8]))
+impl AuditCommitment {
+    pub fn genesis() -> Self {
+        Self::default()
+    }
+
+    pub fn from_audit_bead(bead: &Bead) -> Self {
+        let composite_hash = compute_audit_bead_hash(bead);
+        Self::from_bead_hash(composite_hash)
+    }
+
+    pub fn from_hash_prefix(hash_prefix: &[u8]) -> Self {
+        let mut commitment_bytes = [0u8; COMMITMENT_BYTES];
+        let len = hash_prefix.len().min(COMMITMENT_BYTES);
+        commitment_bytes[..len].copy_from_slice(&hash_prefix[..len]);
+
+        Self {
+            commitment_bytes,
+            parent_bead_hash: None,
+        }
+    }
+
+    pub fn from_bead_hash(bead_hash: BlockHash) -> Self {
+        let hash_bytes = bead_hash.to_byte_array();
+        let mut commitment_bytes = [0u8; COMMITMENT_BYTES];
+        commitment_bytes.copy_from_slice(&hash_bytes[..COMMITMENT_BYTES]);
+
+        Self {
+            commitment_bytes,
+            parent_bead_hash: Some(bead_hash),
+        }
+    }
+
+    pub fn to_hex(&self) -> String {
+        hex::encode(&self.commitment_bytes)
+    }
+
+    pub fn verify_in_extranonce1(&self, extranonce1_bytes: &[u8], miner_prefix: &[u8]) -> bool {
+        if extranonce1_bytes.len() != TOTAL_EXTRANONCE1_BYTES {
+            return false;
+        }
+        if &extranonce1_bytes
+            [UPSTREAM_EXTRANONCE1_BYTES..UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES]
+            != miner_prefix
+        {
+            return false;
+        }
+        let commitment_start = UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES;
+        let commitment_end = commitment_start + COMMITMENT_BYTES;
+        &extranonce1_bytes[commitment_start..commitment_end] == &self.commitment_bytes
+    }
+
+    pub fn extract_miner_prefix_from_ext1(extranonce1_bytes: &[u8]) -> Option<Vec<u8>> {
+        if extranonce1_bytes.len() < UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES {
+            return None;
+        }
+        Some(
+            extranonce1_bytes
+                [UPSTREAM_EXTRANONCE1_BYTES..UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES]
+                .to_vec(),
+        )
     }
 }
 
+/// Per miner audit state tracking commitment chain
+#[derive(Debug, Clone)]
+pub struct MinerAuditState {
+    pub current_commitment: AuditCommitment,
+    pub miner_prefix: Vec<u8>,
+    pub commitment_pending: bool,
+    pub previous_commitment: Option<AuditCommitment>,
+}
+
+impl MinerAuditState {
+    pub fn new(miner_prefix: Vec<u8>) -> Self {
+        Self {
+            current_commitment: AuditCommitment::genesis(),
+            miner_prefix,
+            commitment_pending: false,
+            previous_commitment: None,
+        }
+    }
+
+    pub fn update_commitment_audit(&mut self, bead: &Bead) {
+        self.previous_commitment = Some(self.current_commitment.clone());
+        let composite_hash = compute_audit_bead_hash(bead);
+        let new_commitment = AuditCommitment::from_bead_hash(composite_hash);
+        info!(
+            miner_prefix = %hex::encode(&self.miner_prefix),
+            old_commitment = %self.current_commitment.to_hex(),
+            new_commitment = %new_commitment.to_hex(),
+            block_hash = %bead.block_header.block_hash(),
+            composite_hash = %composite_hash,
+            "Updating miner audit commitment"
+        );
+        self.current_commitment = new_commitment;
+        self.commitment_pending = true;
+    }
+
+    pub fn verify_share(
+        &self,
+        extranonce1_bytes: &[u8],
+        extranonce2_hex: &str,
+    ) -> AuditVerificationResult {
+        if extranonce1_bytes.len() != TOTAL_EXTRANONCE1_BYTES {
+            return AuditVerificationResult::Invalid {
+                reason: format!(
+                    "Wrong extranonce1 length: expected {} bytes, got {}",
+                    TOTAL_EXTRANONCE1_BYTES,
+                    extranonce1_bytes.len()
+                ),
+            };
+        }
+        if extranonce2_hex.len() != MINER_ROLL_BYTES * 2 {
+            return AuditVerificationResult::Invalid {
+                reason: format!(
+                    "Wrong extranonce2 length: expected {} hex chars, got {}",
+                    MINER_ROLL_BYTES * 2,
+                    extranonce2_hex.len()
+                ),
+            };
+        }
+        if let Some(prefix) = AuditCommitment::extract_miner_prefix_from_ext1(extranonce1_bytes) {
+            if prefix != self.miner_prefix {
+                return AuditVerificationResult::Invalid {
+                    reason: format!(
+                        "Miner prefix mismatch: expected {}, got {}",
+                        hex::encode(&self.miner_prefix),
+                        hex::encode(&prefix)
+                    ),
+                };
+            }
+        } else {
+            return AuditVerificationResult::Invalid {
+                reason: "Could not extract miner prefix from extranonce1".to_string(),
+            };
+        }
+        if self
+            .current_commitment
+            .verify_in_extranonce1(extranonce1_bytes, &self.miner_prefix)
+        {
+            let miner_roll = hex::decode(extranonce2_hex)
+                .ok()
+                .and_then(|bytes| bytes.first().copied());
+
+            AuditVerificationResult::Valid {
+                commitment: self.current_commitment.clone(),
+                miner_roll,
+            }
+        } else {
+            let commitment_start = UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES;
+            let commitment_end = commitment_start + COMMITMENT_BYTES;
+            let actual = hex::encode(&extranonce1_bytes[commitment_start..commitment_end]);
+
+            AuditVerificationResult::Invalid {
+                reason: format!(
+                    "Commitment mismatch in extranonce1: expected {}, got {}",
+                    self.current_commitment.to_hex(),
+                    actual
+                ),
+            }
+        }
+    }
+
+    pub fn verify_share_with_fallback(
+        &self,
+        extranonce1_bytes: &[u8],
+        extranonce2_hex: &str,
+        previous_commitment: Option<&AuditCommitment>,
+    ) -> AuditVerificationResult {
+        let result = self.verify_share(extranonce1_bytes, extranonce2_hex);
+        if matches!(result, AuditVerificationResult::Invalid { .. }) {
+            if let Some(prev_commitment) = previous_commitment {
+                if prev_commitment.verify_in_extranonce1(extranonce1_bytes, &self.miner_prefix) {
+                    warn!(
+                        old = %prev_commitment.to_hex(),
+                        current = %self.current_commitment.to_hex(),
+                        "Share used previous commitment, accepting it as valid under conditions"
+                    );
+                    return AuditVerificationResult::Valid {
+                        commitment: prev_commitment.clone(),
+                        miner_roll: hex::decode(extranonce2_hex)
+                            .ok()
+                            .and_then(|bytes| bytes.first().copied()),
+                    };
+                }
+            }
+        }
+        result
+    }
+
+    pub fn mark_commitment_sent(&mut self) {
+        self.commitment_pending = false;
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum AuditVerificationResult {
+    Valid {
+        commitment: AuditCommitment,
+        miner_roll: Option<u8>,
+    },
+    Invalid {
+        reason: String,
+    },
+}
+
+/// Links a share to audit verification
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AuditRecord {
     pub share_id: ShareId,
@@ -41,66 +260,181 @@ pub struct AuditRecord {
     pub miner_ip: String,
     pub worker_name: String,
     pub job_id: String,
-    pub share_difficulty: CompactTarget,
     pub extranonce2: String,
     pub nonce: String,
     pub ntime: String,
-    pub block_hash: Option<BlockHash>,
-    pub valid: bool,
+    pub audit_verified: bool,
+    pub audit_commitment: Option<AuditCommitment>,
     pub upstream_accepted: Option<bool>,
-    pub parent_shares: Vec<ShareId>,
+    pub upstream_eligible: bool,
+    pub bead_hash: BlockHash,
 }
 
+/// Wraps Braid and adds audit verification layer
 pub struct AuditDAG {
+    /// The underlying braid structure
+    pub braid: Arc<RwLock<Braid>>,
+    /// Audit records for shares
     records: HashMap<ShareId, AuditRecord>,
-    latest_shares: HashMap<String, ShareId>,
+    /// Per miner audit state for commitment verification
+    pub miner_states: HashMap<String, MinerAuditState>,
+    /// Mapping from composite bead hash to share ID that created it
+    bead_to_share: HashMap<BlockHash, ShareId>,
 }
 
 impl AuditDAG {
-    pub fn new() -> Self {
+    pub fn new(braid: Arc<RwLock<Braid>>) -> Self {
         Self {
+            braid,
             records: HashMap::new(),
-            latest_shares: HashMap::new(),
+            miner_states: HashMap::new(),
+            bead_to_share: HashMap::new(),
         }
     }
 
-    pub async fn add_record(&mut self, mut record: AuditRecord) -> Result<ShareId, String> {
+    pub async fn add_and_record_bead(
+        &mut self,
+        mut record: AuditRecord,
+        bead: Bead,
+        extranonce1_bytes: &[u8],
+    ) -> Result<(ShareId, bool), String> {
         let share_id = record.share_id.clone();
-
-        if let Some(parent_id) = self.latest_shares.get(&record.miner_ip) {
-            record.parent_shares.push(parent_id.clone());
+        let miner_ip = record.miner_ip.clone();
+        let composite_hash = compute_audit_bead_hash(&bead);
+        if let Some(miner_state) = self.miner_states.get_mut(&miner_ip) {
+            let verification = miner_state.verify_share_with_fallback(
+                extranonce1_bytes,
+                &record.extranonce2,
+                miner_state.previous_commitment.as_ref(),
+            );
+            match verification {
+                AuditVerificationResult::Valid {
+                    commitment,
+                    miner_roll,
+                } => {
+                    record.audit_commitment = Some(commitment);
+                    record.audit_verified = true;
+                    debug!(
+                        share_id = %share_id,
+                        miner = %miner_ip,
+                        miner_roll = ?miner_roll,
+                        extranonce1 = %hex::encode(extranonce1_bytes),
+                        extranonce2 = %record.extranonce2,
+                        block_hash = %bead.block_header.block_hash(),
+                        composite_hash = %composite_hash,
+                        "Bead passed audit verification"
+                    );
+                }
+                AuditVerificationResult::Invalid { reason } => {
+                    record.audit_verified = false;
+                    error!(
+                        share_id = %share_id,
+                        miner = %miner_ip,
+                        reason = %reason,
+                        extranonce1 = %hex::encode(extranonce1_bytes),
+                        extranonce2 = %record.extranonce2,
+                        "Bead failed audit verification thus rejecting."
+                    );
+                    return Err(format!("Audit verification failed: {}", reason));
+                }
+            }
+        } else {
+            warn!(miner = %miner_ip, "No miner state for audit verification");
+            record.audit_verified = false;
+            return Err("No miner state".to_string());
         }
-
-        info!(
-            "Recording share {} from {} (job: {}, parents: {})",
-            share_id,
-            record.worker_name,
-            record.job_id,
-            record.parent_shares.len()
-        );
-
-        // Update latest share for this miner
-        self.latest_shares
-            .insert(record.miner_ip.clone(), share_id.clone());
-
-        // Store the record
+        record.bead_hash = composite_hash;
+        let mut bead_added = false;
+        {
+            let mut braid = self.braid.write().await;
+            let status = braid.extend(&bead);
+            match status {
+                AddBeadStatus::BeadAdded => {
+                    bead_added = true;
+                    info!(
+                        block_hash = %bead.block_header.block_hash(),
+                        composite_hash = %composite_hash,
+                        parents = ?bead.committed_metadata.parents,
+                        miner = %miner_ip,
+                        "Bead added to braid"
+                    );
+                }
+                AddBeadStatus::DagAlreadyContainsBead => {
+                    warn!(
+                        composite_hash = %composite_hash,
+                        "Bead already in DAG, treating as idempotent success"
+                    );
+                    // Do not return error as this process can be re-trigger by the same miner who got disconnect
+                    // for a reason but and now retrying to submit that share again
+                    bead_added = false;
+                }
+                AddBeadStatus::InvalidBead => {
+                    error!(
+                        composite_hash = %composite_hash,
+                        "Invalid bead"
+                    );
+                    return Err("Invalid bead".to_string());
+                }
+                AddBeadStatus::ParentsNotYetReceived => {
+                    warn!(
+                        composite_hash = %composite_hash,
+                        parents = ?bead.committed_metadata.parents,
+                        "Parents not yet received, treating as orphan"
+                    );
+                }
+            }
+        }
         self.records.insert(share_id.clone(), record);
-
-        info!("Audit DAG now contains {} records", self.records.len());
-
-        Ok(share_id)
+        self.bead_to_share.insert(composite_hash, share_id.clone());
+        info!(
+            composite_hash = %composite_hash,
+            block_hash = %bead.block_header.block_hash(),
+            share_id = %share_id,
+            miner = %miner_ip,
+            total_beads = %self.records.len(),
+            "Bead recorded successfully"
+        );
+        Ok((share_id, bead_added))
     }
 
-    pub fn update_upstream_result(&mut self, share_id: &ShareId, accepted: bool) {
+    pub fn mark_upstream_forwarded(&mut self, share_id: &ShareId) {
+        if let Some(record) = self.records.get_mut(share_id) {
+            record.upstream_eligible = true;
+            info!(
+                share_id = %share_id,
+                "Bead marked as forwarded to upstream"
+            );
+        }
+    }
+
+    pub fn update_upstream_response(&mut self, share_id: &ShareId, accepted: bool) {
         if let Some(record) = self.records.get_mut(share_id) {
             record.upstream_accepted = Some(accepted);
             info!(
-                "Updated share {} upstream_accepted = {}",
-                share_id, accepted
+                share_id = %share_id,
+                accepted = %accepted,
+                "Updated upstream response"
             );
-        } else {
-            warn!("Cannot update share {} - not found in record", share_id);
         }
+    }
+
+    pub fn register_miner(&mut self, miner_ip: String, prefix: Vec<u8>) {
+        let prefix_hex = hex::encode(&prefix);
+        let state = MinerAuditState::new(prefix);
+        self.miner_states.insert(miner_ip.clone(), state);
+        info!(
+            miner = %miner_ip,
+            prefix = %prefix_hex,
+            "Registered miner for audit tracking"
+        );
+    }
+
+    pub fn get_record(&self, share_id: &ShareId) -> Option<&AuditRecord> {
+        self.records.get(share_id)
+    }
+
+    pub fn get_share_for_bead(&self, bead_hash: &BlockHash) -> Option<&ShareId> {
+        self.bead_to_share.get(bead_hash)
     }
 
     pub fn get_miner_stats(&self, miner_ip: &str) -> MinerStats {
@@ -110,46 +444,51 @@ impl AuditDAG {
             .filter(|r| r.miner_ip == miner_ip)
             .collect();
 
-        let total_shares = miner_records.len();
-        let valid_shares = miner_records.iter().filter(|r| r.valid).count();
-        let accepted_shares = miner_records
+        let total_beads = miner_records.len();
+        let upstream_eligible = miner_records.iter().filter(|r| r.upstream_eligible).count();
+        let upstream_accepted = miner_records
             .iter()
             .filter(|r| r.upstream_accepted == Some(true))
             .count();
-        let rejected_shares = miner_records
+        let upstream_rejected = miner_records
             .iter()
             .filter(|r| r.upstream_accepted == Some(false))
             .count();
-        let pending_shares = miner_records
-            .iter()
-            .filter(|r| r.upstream_accepted.is_none())
-            .count();
+        let audit_verified = miner_records.iter().filter(|r| r.audit_verified).count();
+
+        let miner_state = self.miner_states.get(miner_ip);
 
         MinerStats {
-            total_shares,
-            valid_shares,
-            accepted_shares,
-            rejected_shares,
-            pending_shares,
-            rejection_rate: if total_shares > 0 {
-                rejected_shares as f64 / total_shares as f64
+            total_beads,
+            audit_verified_beads: audit_verified,
+            audit_failed_beads: total_beads - audit_verified,
+            upstream_eligible_beads: upstream_eligible,
+            upstream_accepted_beads: upstream_accepted,
+            upstream_rejected_beads: upstream_rejected,
+            current_commitment: miner_state.map(|s| s.current_commitment.to_hex()),
+            audit_rate: if total_beads > 0 {
+                audit_verified as f64 / total_beads as f64
+            } else {
+                0.0
+            },
+            upstream_acceptance_rate: if upstream_eligible > 0 {
+                upstream_accepted as f64 / upstream_eligible as f64
             } else {
                 0.0
             },
         }
     }
-
-    pub fn len(&self) -> usize {
-        self.records.len()
-    }
 }
 
 #[derive(Debug, Clone)]
 pub struct MinerStats {
-    pub total_shares: usize,
-    pub valid_shares: usize,
-    pub accepted_shares: usize,
-    pub rejected_shares: usize,
-    pub pending_shares: usize,
-    pub rejection_rate: f64,
+    pub total_beads: usize,
+    pub audit_verified_beads: usize,
+    pub audit_failed_beads: usize,
+    pub upstream_eligible_beads: usize,
+    pub upstream_accepted_beads: usize,
+    pub upstream_rejected_beads: usize,
+    pub current_commitment: Option<String>,
+    pub audit_rate: f64,
+    pub upstream_acceptance_rate: f64,
 }

--- a/node/src/audit.rs
+++ b/node/src/audit.rs
@@ -1,0 +1,155 @@
+use bitcoin::hashes::sha256;
+use bitcoin::{BlockHash, CompactTarget};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::time::SystemTime;
+use tracing::{info, warn};
+#[derive(Debug, Clone, Serialize, Deserialize, Hash, Eq, PartialEq)]
+pub struct ShareId(pub [u8; 32]);
+
+impl ShareId {
+    pub fn from_share(
+        job_id: &str,
+        extranonce2: &str,
+        nonce: &str,
+        ntime: &str,
+        worker_name: &str,
+    ) -> Self {
+        let mut engine = sha256::Hash::engine();
+        bitcoin::hashes::HashEngine::input(&mut engine, job_id.as_bytes());
+        bitcoin::hashes::HashEngine::input(&mut engine, extranonce2.as_bytes());
+        bitcoin::hashes::HashEngine::input(&mut engine, nonce.as_bytes());
+        bitcoin::hashes::HashEngine::input(&mut engine, ntime.as_bytes());
+        bitcoin::hashes::HashEngine::input(&mut engine, worker_name.as_bytes());
+        let result = sha256::Hash::from_engine(engine);
+        let mut id = [0u8; 32];
+        id.copy_from_slice(result.as_ref());
+        ShareId(id)
+    }
+}
+
+impl std::fmt::Display for ShareId {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", hex::encode(&self.0[..8]))
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AuditRecord {
+    pub share_id: ShareId,
+    pub timestamp: SystemTime,
+    pub miner_ip: String,
+    pub worker_name: String,
+    pub job_id: String,
+    pub share_difficulty: CompactTarget,
+    pub extranonce2: String,
+    pub nonce: String,
+    pub ntime: String,
+    pub block_hash: Option<BlockHash>,
+    pub valid: bool,
+    pub upstream_accepted: Option<bool>,
+    pub parent_shares: Vec<ShareId>,
+}
+
+pub struct AuditDAG {
+    records: HashMap<ShareId, AuditRecord>,
+    latest_shares: HashMap<String, ShareId>,
+}
+
+impl AuditDAG {
+    pub fn new() -> Self {
+        Self {
+            records: HashMap::new(),
+            latest_shares: HashMap::new(),
+        }
+    }
+
+    pub async fn add_record(&mut self, mut record: AuditRecord) -> Result<ShareId, String> {
+        let share_id = record.share_id.clone();
+
+        if let Some(parent_id) = self.latest_shares.get(&record.miner_ip) {
+            record.parent_shares.push(parent_id.clone());
+        }
+
+        info!(
+            "Recording share {} from {} (job: {}, parents: {})",
+            share_id,
+            record.worker_name,
+            record.job_id,
+            record.parent_shares.len()
+        );
+
+        // Update latest share for this miner
+        self.latest_shares
+            .insert(record.miner_ip.clone(), share_id.clone());
+
+        // Store the record
+        self.records.insert(share_id.clone(), record);
+
+        info!("Audit DAG now contains {} records", self.records.len());
+
+        Ok(share_id)
+    }
+
+    pub fn update_upstream_result(&mut self, share_id: &ShareId, accepted: bool) {
+        if let Some(record) = self.records.get_mut(share_id) {
+            record.upstream_accepted = Some(accepted);
+            info!(
+                "Updated share {} upstream_accepted = {}",
+                share_id, accepted
+            );
+        } else {
+            warn!("Cannot update share {} - not found in record", share_id);
+        }
+    }
+
+    pub fn get_miner_stats(&self, miner_ip: &str) -> MinerStats {
+        let miner_records: Vec<&AuditRecord> = self
+            .records
+            .values()
+            .filter(|r| r.miner_ip == miner_ip)
+            .collect();
+
+        let total_shares = miner_records.len();
+        let valid_shares = miner_records.iter().filter(|r| r.valid).count();
+        let accepted_shares = miner_records
+            .iter()
+            .filter(|r| r.upstream_accepted == Some(true))
+            .count();
+        let rejected_shares = miner_records
+            .iter()
+            .filter(|r| r.upstream_accepted == Some(false))
+            .count();
+        let pending_shares = miner_records
+            .iter()
+            .filter(|r| r.upstream_accepted.is_none())
+            .count();
+
+        MinerStats {
+            total_shares,
+            valid_shares,
+            accepted_shares,
+            rejected_shares,
+            pending_shares,
+            rejection_rate: if total_shares > 0 {
+                rejected_shares as f64 / total_shares as f64
+            } else {
+                0.0
+            },
+        }
+    }
+
+    pub fn len(&self) -> usize {
+        self.records.len()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct MinerStats {
+    pub total_shares: usize,
+    pub valid_shares: usize,
+    pub accepted_shares: usize,
+    pub rejected_shares: usize,
+    pub pending_shares: usize,
+    pub rejection_rate: f64,
+}

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -70,4 +70,8 @@ pub struct Cli {
     /// Upstream pool password (default: "x")
     #[arg(long, default_value = "x")]
     pub upstream_password: String,
+
+    /// Weak difficulty for the miner in audit mode
+    #[arg(long, default_value = "100.0")]
+    pub miner_difficulty: f64,
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -50,4 +50,24 @@ pub struct Cli {
     /// Path to Bitcoin Core IPC socket
     #[arg(long, default_value = "/tmp/bitcoin-cpunet.sock")]
     pub ipc_socket: String,
+
+    /// Enable audit mode (proxy to upstream pool)
+    #[arg(long, default_value = "false")]
+    pub audit: bool,
+
+    /// Upstream pool hostname (required if audit is enabled)
+    #[arg(long)]
+    pub upstream_host: Option<String>,
+
+    /// Upstream pool port the default is 3334 (for Ocean)
+    #[arg(long, default_value = "3334")]
+    pub upstream_port: u16,
+
+    /// Upstream pool username (Bitcoin address for payout)
+    #[arg(long)]
+    pub upstream_username: Option<String>,
+
+    /// Upstream pool password (default: "x")
+    #[arg(long, default_value = "x")]
+    pub upstream_password: String,
 }

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -221,6 +221,9 @@ pub enum StratumErrors {
     UpstreamShareForwardFailed {
         error: String,
     },
+    UpstreamNotReady {
+        error: String,
+    },
 }
 pub enum StratumResponseErrors {}
 impl fmt::Display for StratumErrors {
@@ -353,6 +356,9 @@ impl fmt::Display for StratumErrors {
             }
             StratumErrors::UpstreamShareForwardFailed { error } => {
                 write!(f, "Failed to forward share to upstream: {}", error)
+            }
+            StratumErrors::UpstreamNotReady { error } => {
+                write!(f, "Upstream pool is not ready: {}", error)
             }
         }
     }

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -215,6 +215,12 @@ pub enum StratumErrors {
     ErrorFetchingCurrentUNIXTimestamp {
         error: String,
     },
+    UpstreamConnectionFailed {
+        error: String,
+    },
+    UpstreamShareForwardFailed {
+        error: String,
+    },
 }
 pub enum StratumResponseErrors {}
 impl fmt::Display for StratumErrors {
@@ -341,6 +347,12 @@ impl fmt::Display for StratumErrors {
             }
             StratumErrors::MiningJobInsertError { mining_job } => {
                 write!(f,"An error occurred while inserting the following job into the mining map - {:?}",mining_job)
+            }
+            StratumErrors::UpstreamConnectionFailed { error } => {
+                write!(f, "Failed to connect to upstream pool: {}", error)
+            }
+            StratumErrors::UpstreamShareForwardFailed { error } => {
+                write!(f, "Failed to forward share to upstream: {}", error)
             }
         }
     }

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -169,6 +169,9 @@ pub enum StratumErrors {
         error: std::io::Error,
     },
     InvalidCoinbase,
+    InvalidShare {
+        reason: String,
+    },
     PeerNotFoundInConnectionMapping {
         peer_addr: String,
     },
@@ -313,6 +316,9 @@ impl fmt::Display for StratumErrors {
             }
             StratumErrors::InvalidCoinbase => {
                 write!(f, "Provided coinbase is invalid")
+            }
+            StratumErrors::InvalidShare { reason } => {
+                write!(f, "Invalid share: {}", reason)
             }
             StratumErrors::ResponseWriteError { error } => {
                 write!(f, "{:?}", error)

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -262,7 +262,7 @@ pub async fn ipc_block_listener(
                                     ipc_template,
                                     header,
                                     bitcoin::consensus::encode::serialize(&coinbase_transaction),
-                                    template_id,
+                                    template_id.clone(),
                                     Some(RequestPriority::Critical),
                                 )
                                 .await

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -37,6 +37,7 @@ use crate::{
 use std::error::Error;
 #[macro_use]
 pub mod macros;
+pub mod audit;
 pub mod bead;
 pub mod behaviour;
 pub mod braid;
@@ -52,7 +53,9 @@ pub mod rpc_server;
 pub mod stratum;
 pub mod template_creator;
 pub mod uncommitted_metadata;
+pub mod upstream_pool;
 pub mod utils;
+use std::fmt;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 //Including the capnp modules after building while compiling the workspace.package
@@ -72,15 +75,41 @@ pub mod init_capnp {
     include!(concat!(env!("OUT_DIR"), "/init_capnp.rs"));
 }
 
-/// Unique identifier assigned to each block template.
-pub type TemplateId = u64;
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub enum TemplateId {
+    /// Internal Braidpool template (sequential counter)
+    Braidpool(u64),
+    /// Upstream pool template (arbitrary string from upstream)
+    Upstream(String),
+}
+
+impl TemplateId {
+    pub fn from_upstream_string(job_id: &str) -> Self {
+        TemplateId::Upstream(job_id.to_string())
+    }
+}
+
+impl Default for TemplateId {
+    fn default() -> Self {
+        TemplateId::Braidpool(0)
+    }
+}
+
+impl fmt::Display for TemplateId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TemplateId::Braidpool(id) => write!(f, "Braidpool({})", id),
+            TemplateId::Upstream(id) => write!(f, "Upstream({})", id),
+        }
+    }
+}
 
 /// Global template ID counter that persists across the application lifetime
 static GLOBAL_TEMPLATE_COUNTER: AtomicU64 = AtomicU64::new(1);
 
 /// Get the next unique template ID (increments on each call)
 pub fn get_next_template_id() -> TemplateId {
-    GLOBAL_TEMPLATE_COUNTER.fetch_add(1, Ordering::SeqCst)
+    TemplateId::Braidpool(GLOBAL_TEMPLATE_COUNTER.fetch_add(1, Ordering::SeqCst))
 }
 
 /// **Length of the extranonce prefix (in bytes).**
@@ -153,17 +182,17 @@ pub async fn ipc_template_consumer(
             let template_id = get_next_template_id();
             {
                 let mut latest_id = latest_template_id.lock().await;
-                *latest_id = template_id;
+                *latest_id = template_id.clone();
             }
 
             // Cache the IPC template with this new ID
             {
                 let mut cache = template_cache.lock().await;
-                cache.insert(template_id, ipc_template.clone());
+                cache.insert(template_id.clone(), ipc_template.clone());
 
                 // Cleanup old templates
                 if cache.len() > MAX_CACHED_TEMPLATES {
-                    let mut ids: Vec<TemplateId> = cache.keys().copied().collect();
+                    let mut ids: Vec<TemplateId> = cache.keys().cloned().collect();
                     ids.sort_unstable();
 
                     let remove_count = cache.len() - MAX_CACHED_TEMPLATES;
@@ -230,7 +259,7 @@ pub async fn ipc_template_consumer(
                 .send(NotifyCmd::SendToAll {
                     template: template,
                     merkle_branch_coinbase,
-                    template_id,
+                    template_id: template_id.clone(),
                 })
                 .await;
             match notification_sent_or_not {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -17,8 +17,8 @@ use libp2p::{
 use node::audit;
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
-use node::utils::BeadHash;
 use node::upstream_pool;
+use node::utils::BeadHash;
 use node::SwarmHandler;
 use node::{
     bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
@@ -70,8 +70,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let _ibd_handler = tokio::spawn(async move {
         ibd_manager.run_ibd_handler().await;
     });
-    //False if not under ibd otherwise true at start will be in IBD by default
-    let ibd_or_not: AtomicBool = AtomicBool::new(true);
+    //False if not under ibd or in audit mode otherwise true at start will be in IBD by default
+    let ibd_or_not: AtomicBool = if args.audit {
+        AtomicBool::new(false)
+    } else {
+        AtomicBool::new(true)
+    };
     let ibd_spinlock = Arc::new(ibd_or_not);
     // Initializing the braid object with read write lock
     //for supporting concurrent readers and single writer
@@ -149,27 +153,32 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //Stratum configuration initialization
     let stratum_config = StratumServerConfig {
         audit_mode: args.audit,
+        audit_miner_difficulty: args.miner_difficulty,
         ..Default::default()
     };
     let (block_submission_tx, block_submission_rx) =
         tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
     //IBD notifier task after peer_discovery
     let swarm_command_sender_ref = swarm_command_sender.clone();
-    let _ibd_trigger_handler = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-        //Sending IBD initiating command
-        match swarm_command_sender_ref
-            .send(SwarmCommand::InitiateIBD)
-            .await
-        {
-            Ok(_) => {
-                info!("IBD trigger sent");
-            }
-            Err(error) => {
-                error!(error=?error,"An error occurred while initiating IBD after waiting for peer discovery - ");
-            }
-        };
-    });
+    if !args.audit {
+        let _ibd_trigger_handler = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+            //Sending IBD initiating command
+            match swarm_command_sender_ref
+                .send(SwarmCommand::InitiateIBD)
+                .await
+            {
+                Ok(_) => {
+                    info!("IBD trigger sent");
+                }
+                Err(error) => {
+                    error!(error=?error,"An error occurred while initiating IBD after waiting for peer discovery - ");
+                }
+            };
+        });
+    } else {
+        info!("Skipping IBD invoking, currently in audit mode.")
+    }
     //Initializing stratum server
     let mut stratum_server = Server::new(
         stratum_config,
@@ -183,7 +192,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let ipc_task_token = main_task_token.clone();
     let mut upstream_cache_for_notifier = None;
     let (upstream_ready_tx, upstream_ready_rx) = tokio::sync::oneshot::channel::<()>();
-    let (upstream_share_tx_option, upstream_configure_tx_option, audit_dag_option) = if args.audit {
+    let (
+        upstream_share_tx_option,
+        upstream_configure_tx_option,
+        audit_dag_option,
+        audit_dag_for_notifier,
+    ) = if args.audit {
         // Validate CLI arguments for audit mode
         if args.upstream_host.is_none() {
             error!("--upstream-host is required when --audit is enabled");
@@ -193,7 +207,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             error!("--upstream-username is required when --audit is enabled");
             std::process::exit(1);
         }
-
         info!("Audit mode is enabled acting as a proxy to the upstream pool");
         info!(
             "Upstream: {}:{}",
@@ -202,9 +215,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
 
         // Initialize audit records
-        let audit_dag = Arc::new(Mutex::new(audit::AuditDAG::new()));
+        let audit_dag = Arc::new(Mutex::new(audit::AuditDAG::new(Arc::clone(&braid))));
+        let audit_dag_for_notifier_inner: Option<Arc<Mutex<audit::AuditDAG>>> =
+            Some(audit_dag.clone());
         let audit_dag_for_stratum = audit_dag.clone();
-
+        let audit_dag_for_audit_log = audit_dag.clone();
         // Setting upstream pool configuration from CLI args
         let upstream_config = upstream_pool::UpstreamPoolConfig {
             hostname: args.upstream_host.clone().unwrap(),
@@ -212,40 +227,106 @@ async fn main() -> Result<(), Box<dyn Error>> {
             username: args.upstream_username.clone().unwrap(),
             password: args.upstream_password.clone(),
         };
-
         // Initialize upstream cache
         let upstream_cache = upstream_pool::UpstreamCache::new();
         let upstream_cache_clone = upstream_cache.clone();
         upstream_cache_for_notifier = Some(upstream_cache.clone());
         let mining_job_map_for_upstream_cleanup = mining_job_map.clone();
-
         // For forwarding shares to upstream pool (stratum server -> upstream client), using Arc<Mutex<Receiver>> so the receiver survives reconnections,
         // Buffer 50,000 shares to survive upstream lag spikes without blocking miners
         let (upstream_share_tx, upstream_share_rx) =
             mpsc::channel::<upstream_pool::UpstreamShare>(50000);
         let upstream_share_rx = Arc::new(tokio::sync::Mutex::new(upstream_share_rx));
-
         // For receiving jobs from upstream pool (upstream client -> notifier)
         let (upstream_job_tx, upstream_job_rx) =
             mpsc::channel::<node::stratum::JobNotification>(1024);
         let upstream_job_rx = Arc::new(tokio::sync::Mutex::new(upstream_job_rx));
-
         // For receiving responses from upstream (upstream client -> stratum server)
         let (upstream_response_tx, upstream_response_rx) =
             mpsc::channel::<(String, serde_json::Value, u64)>(1024);
         let upstream_response_rx = Arc::new(tokio::sync::Mutex::new(upstream_response_rx));
-
+        let (audit_log_tx, mut audit_log_rx) =
+            tokio::sync::mpsc::channel::<(crate::audit::ShareId, serde_json::Value)>(2048);
         // For forwarding configure requests to upstream pool
         let (configure_tx, configure_rx) =
             mpsc::channel::<(serde_json::Value, u64, mpsc::Sender<serde_json::Value>)>(50000);
         let configure_rx = Arc::new(tokio::sync::Mutex::new(configure_rx));
-
         // cancellation tokens
         let upstream_response_task_token = main_task_token.clone();
         let upstream_job_task_token = main_task_token.clone();
 
         let connection_mapping_for_responses = connection_mapping.clone();
         let upstream_response_rx_clone = upstream_response_rx.clone();
+        tokio::spawn(async move {
+            info!(component = "audit", "Starting audit log listener");
+            let mut total_shares = 0u64;
+            let mut accepted_shares = 0u64;
+            let mut rejected_shares = 0u64;
+
+            while let Some((share_id, response)) = audit_log_rx.recv().await {
+                total_shares += 1;
+                let error = response.get("error").filter(|v| !v.is_null());
+                let result_is_success = match response.get("result") {
+                    Some(val) if val.is_boolean() => val.as_bool().unwrap_or(false),
+                    Some(val) if val.is_null() => true,
+                    None => error.is_none(),
+                    _ => false,
+                };
+
+                let mut dag = audit_dag_for_audit_log.lock().await;
+                dag.update_upstream_response(&share_id, result_is_success);
+                debug!(
+                    share_id = %share_id,
+                    accepted = %result_is_success,
+                    "Updated audit record with upstream response"
+                );
+                drop(dag);
+
+                if let Some(err) = error {
+                    rejected_shares += 1;
+                    warn!(
+                        component = "audit",
+                        total = total_shares,
+                        accepted = accepted_shares,
+                        rejected = rejected_shares,
+                        acceptance_rate = format!(
+                            "{:.2}%",
+                            (accepted_shares as f64 / total_shares as f64) * 100.0
+                        ),
+                        "Upstream REJECTED share: {:?}",
+                        err
+                    );
+                } else if result_is_success {
+                    accepted_shares += 1;
+                    debug!(
+                        component = "audit",
+                        total = total_shares,
+                        acceptance_rate = format!(
+                            "{:.2}%",
+                            (accepted_shares as f64 / total_shares as f64) * 100.0
+                        ),
+                        "Upstream confirmed share"
+                    );
+                } else {
+                    rejected_shares += 1;
+                    warn!(component = "audit", "Upstream returned invalid result");
+                }
+                if total_shares % 10 == 0 {
+                    info!(
+                        component = "audit",
+                        total = total_shares,
+                        accepted = accepted_shares,
+                        rejected = rejected_shares,
+                        acceptance_rate = format!(
+                            "{:.2}%",
+                            (accepted_shares as f64 / total_shares as f64) * 100.0
+                        ),
+                        "Audit statistics"
+                    );
+                }
+            }
+        });
+
         tokio::spawn(async move {
             info!("Starting upstream response handler");
             loop {
@@ -347,6 +428,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let connection_mapping_for_upstream = connection_mapping.clone();
         let upstream_task_token = main_task_token.clone();
         let mut upstream_ready_tx_option = Some(upstream_ready_tx);
+        let braid_for_upstream = braid.clone();
         tokio::spawn(async move {
             // Reconnection state
             let mut retry_count: u32 = 0;
@@ -447,6 +529,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     Some(upstream_difficulty_tx),
                     configure_rx.clone(),
                     upstream_cache_clone.clone(),
+                    Arc::clone(&braid_for_upstream),
+                    audit_log_tx.clone(),
                 );
 
                 // Mark upstream as connected
@@ -551,10 +635,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             Some(upstream_share_tx),
             Some(configure_tx),
             Some(audit_dag_for_stratum),
+            audit_dag_for_notifier_inner,
         )
     } else {
         info!("Audit mode disabled, running in normal pool mode");
-        (None, None, None)
+        (None, None, None, None)
     };
 
     if args.audit {
@@ -587,6 +672,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &mut latest_template_merkle_branch_ref,
                 latest_template_id_for_notifier,
                 upstream_cache_for_notifier,
+                audit_dag_for_notifier,
             )
             .await;
     });
@@ -606,11 +692,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .await;
     });
 
-    let (main_shutdown_tx, _main_shutdown_rx) =
-        mpsc::channel::<tokio::signal::unix::SignalKind>(32);
-    let main_task_token = CancellationToken::new();
-    let ipc_task_token = main_task_token.clone();
-    let args = cli::Cli::parse();
     let datadir_str = args.datadir.to_str().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -141,6 +141,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let notification_tx_clone = notification_tx.clone();
     //Connection mapping for all the downstream connection connected to the stratum server
     let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
+    let connection_mapping_for_shutdown = connection_mapping.clone();
     //Mining job map keeping all the jobs provided to the downstream
     let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
     //Intializing `notifier` for mining.notify
@@ -176,6 +177,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some(block_submission_tx),
     );
 
+    let (main_shutdown_tx, _main_shutdown_rx) =
+        mpsc::channel::<tokio::signal::unix::SignalKind>(32);
+    let main_task_token = CancellationToken::new();
+    let ipc_task_token = main_task_token.clone();
+    let mut upstream_cache_for_notifier = None;
     let (upstream_ready_tx, upstream_ready_rx) = tokio::sync::oneshot::channel::<()>();
     let (upstream_share_tx_option, upstream_configure_tx_option, audit_dag_option) = if args.audit {
         // Validate CLI arguments for audit mode
@@ -207,146 +213,338 @@ async fn main() -> Result<(), Box<dyn Error>> {
             password: args.upstream_password.clone(),
         };
 
-        // For forwarding shares to upstream pool
-        let (upstream_share_tx, upstream_share_rx) = mpsc::channel(1024);
-        // For receiving jobs from the upstream pool
-        let (upstream_job_tx, mut upstream_job_rx) = mpsc::channel(1024);
-        // For receiving responses from upstream (share accepted etc.)
-        let (upstream_response_tx, mut upstream_response_rx) =
+        // Initialize upstream cache
+        let upstream_cache = upstream_pool::UpstreamCache::new();
+        let upstream_cache_clone = upstream_cache.clone();
+        upstream_cache_for_notifier = Some(upstream_cache.clone());
+        let mining_job_map_for_upstream_cleanup = mining_job_map.clone();
+
+        // For forwarding shares to upstream pool (stratum server -> upstream client), using Arc<Mutex<Receiver>> so the receiver survives reconnections,
+        // Buffer 50,000 shares to survive upstream lag spikes without blocking miners
+        let (upstream_share_tx, upstream_share_rx) =
+            mpsc::channel::<upstream_pool::UpstreamShare>(50000);
+        let upstream_share_rx = Arc::new(tokio::sync::Mutex::new(upstream_share_rx));
+
+        // For receiving jobs from upstream pool (upstream client -> notifier)
+        let (upstream_job_tx, upstream_job_rx) =
+            mpsc::channel::<node::stratum::JobNotification>(1024);
+        let upstream_job_rx = Arc::new(tokio::sync::Mutex::new(upstream_job_rx));
+
+        // For receiving responses from upstream (upstream client -> stratum server)
+        let (upstream_response_tx, upstream_response_rx) =
             mpsc::channel::<(String, serde_json::Value, u64)>(1024);
-        // For receiving extranounce values
-        let (upstream_extranonce_tx, mut upstream_extranonce_rx) =
-            mpsc::channel::<(String, usize)>(1);
-        // For receiving difficulty updates
-        let (upstream_difficulty_tx, mut upstream_difficulty_rx) = mpsc::channel::<f64>(1);
-        // For forwarding configure request to upstream pool
-        let (configure_tx, configure_rx) = mpsc::channel(10);
-        // Stores the most recent upstream job notification received from the upstream pool. Used for relaying the latest job to
-        // miners or for auditing purposes.
-        // TODO: implement caching the latest template for the upcoming miners
-        let last_upstream_job: Arc<Mutex<Option<node::stratum::JobNotification>>> =
-            Arc::new(Mutex::new(None));
-        let last_upstream_job_for_relay = last_upstream_job.clone();
+        let upstream_response_rx = Arc::new(tokio::sync::Mutex::new(upstream_response_rx));
+
+        // For forwarding configure requests to upstream pool
+        let (configure_tx, configure_rx) =
+            mpsc::channel::<(serde_json::Value, u64, mpsc::Sender<serde_json::Value>)>(50000);
+        let configure_rx = Arc::new(tokio::sync::Mutex::new(configure_rx));
+
+        // cancellation tokens
+        let upstream_response_task_token = main_task_token.clone();
+        let upstream_job_task_token = main_task_token.clone();
+
         let connection_mapping_for_responses = connection_mapping.clone();
+        let upstream_response_rx_clone = upstream_response_rx.clone();
         tokio::spawn(async move {
-            while let Some((worker_name, response, original_request_id)) =
-                upstream_response_rx.recv().await
-            {
-                info!("Upstream response for {}: {:?}", worker_name, response);
+            info!("Starting upstream response handler");
+            loop {
+                tokio::select! {
+                            received = async {
+                                let mut rx = upstream_response_rx_clone.lock().await;
+                                rx.recv().await
+                        } => {
+                        match received {
+                            Some((worker_name, response, original_request_id)) => {
+                                debug!("Upstream response for {}: {:?}", worker_name, response);
+                                let conn_map = connection_mapping_for_responses.lock().await;
+                                if let Some(channel) = conn_map.get_channel_for_worker(&worker_name) {
+                                    let miner_response = serde_json::json!({
+                                        "id": original_request_id,
+                                        "result": response.get("result").unwrap_or(&serde_json::json!(null)),
+                                        "error": response.get("error").unwrap_or(&serde_json::json!(null))
+                                    });
 
-                // Get the correct peer address for this worker
-                let conn_map = connection_mapping_for_responses.lock().await;
-
-                if let Some(channel) = conn_map.get_channel_for_worker(&worker_name) {
-                    let miner_response = serde_json::json!({
-                        "id": original_request_id,
-                        "result": response.get("result").unwrap_or(&serde_json::json!(null)),
-                        "error": response.get("error").unwrap_or(&serde_json::json!(null))
-                    });
-
-                    if let Err(e) = channel
-                        .send(serde_json::to_string(&miner_response).unwrap())
-                        .await
-                    {
-                        error!(
-                            "Failed to forward response to worker {}: {}",
-                            worker_name, e
-                        );
-                    } else {
-                        info!(
-                            "Forwarded upstream response to worker {} (id={})",
-                            worker_name, original_request_id
-                        );
+                                    if let Err(e) = channel
+                                        .send(serde_json::to_string(&miner_response).unwrap())
+                                        .await
+                                    {
+                                        error!(
+                                            "Failed to forward response to worker {}: {}",
+                                            worker_name, e
+                                        );
+                                    } else {
+                                        trace!(
+                                            "Forwarded upstream response to worker {} (id={})",
+                                            worker_name, original_request_id
+                                        );
+                                    }
+                                } else {
+                                    warn!("Worker '{}' not found in connection mapping", worker_name);
+                                }
+                            }
+                            None => {
+                                // Channel closed, this means all senders were dropped
+                                // In our design, this shouldn't happen because we clone senders
+                                // But if it does, log and wait before checking again
+                                if upstream_response_task_token.is_cancelled() {
+                                    break;
+                                }
+                                warn!("Upstream response channel returned None - waiting for reconnection");
+                                tokio::time::sleep(Duration::from_secs(1)).await;
+                            }
+                        }
                     }
-                } else {
-                    warn!("Worker '{}' not found in connection mapping", worker_name);
+                    _ = upstream_response_task_token.cancelled() => {
+                        info!("Upstream response handler shutting down");
+                        break;
+                    }
+                }
+            }
+        });
+
+        // Forwards jobs from upstream to the notifier
+        let notification_tx_for_upstream_jobs = notification_tx.clone();
+        let upstream_job_rx_clone = upstream_job_rx.clone();
+        tokio::spawn(async move {
+            info!("Starting persistent upstream job handler");
+            loop {
+                tokio::select! {
+                        received = async {
+                        let mut rx = upstream_job_rx_clone.lock().await;
+                        rx.recv().await
+                    } => {
+                    match received {
+                        Some(job) => {
+                            info!("Received job from upstream pool: {}", job.job_id);
+
+                            if let Err(e) = notification_tx_for_upstream_jobs
+                                .send(NotifyCmd::SendUpstreamJob {
+                                    job_notification: job,
+                                })
+                                .await
+                            {
+                                error!("Failed to forward upstream job: {}", e);
+                            } else {
+                                debug!("Forwarded upstream job to notifier");
+                            }
+                        }
+                        None => {
+                            warn!("Upstream job channel returned None, waiting for reconnection...");
+                            tokio::time::sleep(Duration::from_secs(1)).await;
+                        }
+                    }
+                }
+                _ = upstream_job_task_token.cancelled() => {
+                            info!("Upstream job handler shutting down");
+                            break;
+                    }
                 }
             }
         });
 
         let notification_tx_for_upstream_difficulty = notification_tx.clone();
         let connection_mapping_for_upstream = connection_mapping.clone();
-
-        // Spawn upstream pool client with reconnection logic
+        let upstream_task_token = main_task_token.clone();
+        let mut upstream_ready_tx_option = Some(upstream_ready_tx);
         tokio::spawn(async move {
-            info!("Starting upstream pool client...");
-            let upstream_client = upstream_pool::UpstreamPoolClient::new(
-                upstream_config.clone(),
-                upstream_share_rx,
-                upstream_job_tx.clone(),
-                notification_tx_for_upstream_difficulty,
-                upstream_response_tx.clone(),
-                Some(upstream_extranonce_tx),
-                Some(upstream_difficulty_tx),
-                configure_rx,
-            );
-            {
-                let mut conn_map = connection_mapping_for_upstream.lock().await;
-                conn_map.set_upstream_connected(true);
-            }
-            match upstream_client.run().await {
-                Ok(_) => {
-                    warn!("Upstream pool client exited gracefully");
-                }
-                Err(e) => {
-                    error!("Upstream pool client error: {:?}", e);
-                }
-            }
-            {
-                let mut conn_map = connection_mapping_for_upstream.lock().await;
-                conn_map.set_upstream_connected(false);
-            }
-            error!("Upstream connection lost - restarting...");
-        });
+            // Reconnection state
+            let mut retry_count: u32 = 0;
+            let base_delay = Duration::from_secs(5);
+            let max_delay = Duration::from_secs(60);
+            let mut last_successful_connection = std::time::Instant::now();
 
-        let connection_mapping_for_extranonce = connection_mapping.clone();
-        tokio::spawn(async move {
-            if let Some((extranonce1, extranonce2_size)) = upstream_extranonce_rx.recv().await {
+            loop {
+                if upstream_task_token.is_cancelled() {
+                    info!("Upstream pool task received shutdown signal");
+                    break;
+                }
                 info!(
-                    "Received upstream extranonce: {}, size: {}",
-                    extranonce1, extranonce2_size
+                    "Starting upstream pool connection attempt #{} to {}:{}",
+                    retry_count + 1,
+                    upstream_config.hostname,
+                    upstream_config.port
                 );
 
-                let mut conn_map = connection_mapping_for_extranonce.lock().await;
-                conn_map.set_upstream_extranonce(extranonce1, extranonce2_size);
+                // These are recreated for each connection attempt
+                let (upstream_extranonce_tx, mut upstream_extranonce_rx) =
+                    mpsc::channel::<(String, usize)>(1);
+                let (upstream_difficulty_tx, mut upstream_difficulty_rx) = mpsc::channel::<f64>(1);
+                let first_connection_ready_tx = upstream_ready_tx_option.take();
+                let connection_mapping_for_extranonce = connection_mapping_for_upstream.clone();
+                let extranonce_task = tokio::spawn(async move {
+                    let mut ready_tx = first_connection_ready_tx;
 
-                let _ = upstream_ready_tx.send(());
-                info!("Stratum server updated with upstream extranonce");
-            }
-        });
+                    while let Some((extranonce1, extranonce2_size)) =
+                        upstream_extranonce_rx.recv().await
+                    {
+                        info!(
+                            "Received upstream extranonce: {}, size: {}",
+                            extranonce1, extranonce2_size
+                        );
+                        let mut conn_map = connection_mapping_for_extranonce.lock().await;
+                        let old_extranonce = conn_map.upstream_extranonce1.as_ref();
+                        let changed =
+                            old_extranonce.is_some() && old_extranonce != Some(&extranonce1);
 
-        let connection_mapping_for_difficulty = connection_mapping.clone();
-        tokio::spawn(async move {
-            while let Some(difficulty) = upstream_difficulty_rx.recv().await {
-                info!("Received upstream difficulty: {}", difficulty);
-                let mut conn_map = connection_mapping_for_difficulty.lock().await;
-                conn_map.set_upstream_difficulty(difficulty);
-                info!("Stratum server updated with upstream difficulty");
-            }
-            warn!("Upstream difficulty channel closed");
-        });
+                        if changed {
+                            warn!(
+                                old = ?old_extranonce,
+                                new = %extranonce1,
+                                "Extranonce changed - disconnecting all miners"
+                            );
 
-        // Handle jobs from upstream pool (relay to notifier)
-        let notification_tx_for_upstream = notification_tx.clone();
-        tokio::spawn(async move {
-            while let Some(job) = upstream_job_rx.recv().await {
-                info!("Received job from upstream pool: {}", job.job_id);
+                            // Disconnect miners
+                            let peers: Vec<String> =
+                                conn_map.get_channels().keys().cloned().collect();
 
-                // Store last upstream job
-                *last_upstream_job_for_relay.lock().await = Some(job.clone());
+                            warn!(
+                                count = peers.len(),
+                                "Disconnecting all miners due to extranonce change"
+                            );
+                            for peer_addr in peers {
+                                conn_map.disconnect_peer(&peer_addr, "Upstream extranonce changed");
+                            }
+                        }
 
-                // Forward to notifier
-                if let Err(e) = notification_tx_for_upstream
-                    .send(NotifyCmd::SendUpstreamJob {
-                        job_notification: job,
-                    })
-                    .await
+                        // Update the state, this guarantees that the next miner to grab the lock sees the new extranonce
+                        conn_map.set_upstream_extranonce(extranonce1, extranonce2_size);
+                        drop(conn_map);
+
+                        // Signal ready only on first connection
+                        if let Some(tx) = ready_tx.take() {
+                            if let Err(_) = tx.send(()) {
+                                warn!("Failed to signal upstream ready (receiver dropped)");
+                            } else {
+                                info!("Signaled upstream ready to main thread");
+                            }
+                        }
+                        debug!("Stratum server updated with upstream extranonce");
+                    }
+                    debug!("Extranonce handler exiting for this connection");
+                });
+
+                // Spawn difficulty handler for this connection
+                let connection_mapping_for_difficulty = connection_mapping_for_upstream.clone();
+                let difficulty_task = tokio::spawn(async move {
+                    while let Some(difficulty) = upstream_difficulty_rx.recv().await {
+                        info!("Received upstream difficulty: {}", difficulty);
+                        let mut conn_map = connection_mapping_for_difficulty.lock().await;
+                        conn_map.set_upstream_difficulty(difficulty);
+                        drop(conn_map);
+                        debug!("Stratum server updated with upstream difficulty");
+                    }
+                    debug!("Difficulty handler exiting for this connection");
+                });
+
+                let upstream_client = upstream_pool::UpstreamPoolClient::new(
+                    upstream_config.clone(),
+                    upstream_share_rx.clone(),
+                    upstream_job_tx.clone(),
+                    notification_tx_for_upstream_difficulty.clone(),
+                    upstream_response_tx.clone(),
+                    Some(upstream_extranonce_tx),
+                    Some(upstream_difficulty_tx),
+                    configure_rx.clone(),
+                    upstream_cache_clone.clone(),
+                );
+
+                // Mark upstream as connected
                 {
-                    error!("Failed to forward upstream job: {}", e);
-                } else {
-                    info!("Forwarded upstream job to notifier");
+                    let mut conn_map = connection_mapping_for_upstream.lock().await;
+                    conn_map.set_upstream_connected(true);
+                }
+
+                // Run the client with cancellation support
+                let result = tokio::select! {
+                    result = upstream_client.run() => result,
+                    _ = upstream_task_token.cancelled() => {
+                        info!("Upstream client received shutdown signal during connection");
+                        // Return Ok to break the reconnection loop gracefully
+                        Ok(())
+                    }
+                };
+
+                // Mark upstream as disconnected
+                {
+                    let mut conn_map = connection_mapping_for_upstream.lock().await;
+                    conn_map.set_upstream_connected(false);
+                }
+
+                // Cleanup per-connection tasks
+                extranonce_task.abort();
+                difficulty_task.abort();
+
+                // Invalidate cached job on disconnect
+                {
+                    let mut cache = upstream_cache_clone.write().await;
+                    cache.invalidate_job();
+                    info!("Invalidated cached job due to upstream disconnect");
+                }
+
+                match result {
+                    Ok(_) => {
+                        warn!("Upstream pool client exited gracefully");
+
+                        // If cancelled, break immediately
+                        if upstream_task_token.is_cancelled() {
+                            break;
+                        }
+                        break;
+                    }
+                    Err(e) => {
+                        error!("Upstream pool client error: {:?}", e);
+
+                        // Check if shutdown was triggered before retrying
+                        if upstream_task_token.is_cancelled() {
+                            info!("Shutdown requested, stopping upstream reconnection");
+                            break;
+                        }
+                        info!("Invalidating all upstream jobs to prevent stale shares...");
+                        let global_map = mining_job_map_for_upstream_cleanup.lock().await;
+                        for miner_job_map in global_map.values() {
+                            let mut map = miner_job_map.lock().await;
+                            map.clear_upstream_jobs();
+                        }
+                        info!(
+                            "Upstream job cache cleared for {} miners.",
+                            global_map.len()
+                        );
+
+                        // Calculate backoff delay with jitter
+                        let delay = std::cmp::min(
+                            base_delay * 2u32.saturating_pow(retry_count.min(6)),
+                            max_delay,
+                        );
+                        let jitter = Duration::from_millis(rand::random::<u64>() % 1000);
+                        let total_delay = delay + jitter;
+                        error!(
+                            "Upstream connection lost - reconnecting in {:?} (attempt #{})",
+                            total_delay,
+                            retry_count + 1
+                        );
+                        tokio::select! {
+                            _ = tokio::time::sleep(total_delay) => {
+                                // Normal sleep completed
+                            }
+                            _ = upstream_task_token.cancelled() => {
+                                info!("Shutdown requested during reconnection backoff");
+                                break;
+                            }
+                        }
+                        retry_count += 1;
+
+                        // Reset retry count if we've been connected successfully for a while
+                        if last_successful_connection.elapsed() > Duration::from_secs(300) {
+                            info!("Resetting retry count due to previous stable connection");
+                            retry_count = 0;
+                        }
+                        last_successful_connection = std::time::Instant::now();
+                    }
                 }
             }
+
+            info!("Upstream pool client task shutting down");
         });
 
         (
@@ -360,14 +558,24 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
 
     if args.audit {
-        info!("Waiting for upstream pool...");
-        match tokio::time::timeout(std::time::Duration::from_secs(30), upstream_ready_rx).await {
-            Ok(Ok(())) => info!("Upstream is ready"),
-            _ => {
-                error!("Upstream pool connection failed");
+        info!("Waiting for upstream pool (timeout: 30s)...");
+        match tokio::time::timeout(Duration::from_secs(60), upstream_ready_rx).await {
+            // Changed from 30s
+            Ok(Ok(())) => {
+                info!("Upstream pool connected successfully");
+            }
+            Ok(Err(_)) => {
+                error!("Upstream ready channel closed unexpectedly");
+                std::process::exit(1);
+            }
+            Err(_) => {
+                error!("Upstream pool failed to connect within 60 seconds");
+                error!("Check --upstream-host, --upstream-username, and network connectivity");
+                error!("Process will exit and should be restarted by user");
                 std::process::exit(1);
             }
         }
+        info!("Upstream reconnection monitoring active, will auto-reconnect on disconnects");
     }
 
     //Running the notification service
@@ -378,6 +586,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &mut latest_template_ref,
                 &mut latest_template_merkle_branch_ref,
                 latest_template_id_for_notifier,
+                upstream_cache_for_notifier,
             )
             .await;
     });
@@ -1684,11 +1893,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let shutdown_signal = tokio::signal::ctrl_c().await;
     match shutdown_signal {
         Ok(_) => {
+            info!(component = "shutdown", "Graceful shutdown initiated");
+            info!(
+                component = "stratum",
+                "Disconnecting all miners gracefully..."
+            );
+            {
+                let mut conn_map = connection_mapping_for_shutdown.lock().await;
+                let miner_count = conn_map.get_channels().len();
+                info!(miners = miner_count, "Sending shutdown notice to miners");
+                conn_map
+                    .disconnect_all_with_message("Pool server restarting")
+                    .await;
+            }
+
+            // Cancel all audit mode tasks first
+            info!(component = "audit", "Cancelling upstream pool tasks");
+            main_task_token.cancel();
+
             info!(component = "database", "Closing connection pool");
             let pool = db_connection_pool.lock().await;
             //Closing all the existing connections to pool and committing from .db-wal to .db
             pool.close().await;
             info!(component = "database", "Connections closed");
+
+            // Give tasks time to drain
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
             info!(component = "swarm", "Shutting down network swarm");
             swarm_handle.abort();
             tokio::time::sleep(Duration::from_millis(1)).await;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -14,9 +14,11 @@ use libp2p::{
     swarm::SwarmEvent,
     PeerId,
 };
+use node::audit;
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
+use node::upstream_pool;
 use node::SwarmHandler;
 use node::{
     bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
@@ -60,6 +62,7 @@ use tokio::sync::{
 };
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
+    let args = cli::Cli::parse();
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
     let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
@@ -143,7 +146,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //Intializing `notifier` for mining.notify
     let mut notifier: Notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
     //Stratum configuration initialization
-    let stratum_config: StratumServerConfig = StratumServerConfig::default();
+    let stratum_config = StratumServerConfig {
+        audit_mode: args.audit,
+        ..Default::default()
+    };
     let (block_submission_tx, block_submission_rx) =
         tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
     //IBD notifier task after peer_discovery
@@ -169,6 +175,201 @@ async fn main() -> Result<(), Box<dyn Error>> {
         connection_mapping.clone(),
         Some(block_submission_tx),
     );
+
+    let (upstream_ready_tx, upstream_ready_rx) = tokio::sync::oneshot::channel::<()>();
+    let (upstream_share_tx_option, upstream_configure_tx_option, audit_dag_option) = if args.audit {
+        // Validate CLI arguments for audit mode
+        if args.upstream_host.is_none() {
+            error!("--upstream-host is required when --audit is enabled");
+            std::process::exit(1);
+        }
+        if args.upstream_username.is_none() {
+            error!("--upstream-username is required when --audit is enabled");
+            std::process::exit(1);
+        }
+
+        info!("Audit mode is enabled acting as a proxy to the upstream pool");
+        info!(
+            "Upstream: {}:{}",
+            args.upstream_host.as_ref().unwrap(),
+            args.upstream_port
+        );
+
+        // Initialize audit records
+        let audit_dag = Arc::new(Mutex::new(audit::AuditDAG::new()));
+        let audit_dag_for_stratum = audit_dag.clone();
+
+        // Setting upstream pool configuration from CLI args
+        let upstream_config = upstream_pool::UpstreamPoolConfig {
+            hostname: args.upstream_host.clone().unwrap(),
+            port: args.upstream_port,
+            username: args.upstream_username.clone().unwrap(),
+            password: args.upstream_password.clone(),
+        };
+
+        // For forwarding shares to upstream pool
+        let (upstream_share_tx, upstream_share_rx) = mpsc::channel(1024);
+        // For receiving jobs from the upstream pool
+        let (upstream_job_tx, mut upstream_job_rx) = mpsc::channel(1024);
+        // For receiving responses from upstream (share accepted etc.)
+        let (upstream_response_tx, mut upstream_response_rx) =
+            mpsc::channel::<(String, serde_json::Value, u64)>(1024);
+        // For receiving extranounce values
+        let (upstream_extranonce_tx, mut upstream_extranonce_rx) =
+            mpsc::channel::<(String, usize)>(1);
+        // For receiving difficulty updates
+        let (upstream_difficulty_tx, mut upstream_difficulty_rx) = mpsc::channel::<f64>(1);
+        // For forwarding configure request to upstream pool
+        let (configure_tx, configure_rx) = mpsc::channel(10);
+        // Stores the most recent upstream job notification received from the upstream pool. Used for relaying the latest job to
+        // miners or for auditing purposes.
+        // TODO: implement caching the latest template for the upcoming miners
+        let last_upstream_job: Arc<Mutex<Option<node::stratum::JobNotification>>> =
+            Arc::new(Mutex::new(None));
+        let last_upstream_job_for_relay = last_upstream_job.clone();
+        let connection_mapping_for_responses = connection_mapping.clone();
+        tokio::spawn(async move {
+            while let Some((worker_name, response, original_request_id)) =
+                upstream_response_rx.recv().await
+            {
+                info!("Upstream response for {}: {:?}", worker_name, response);
+
+                // Get the correct peer address for this worker
+                let conn_map = connection_mapping_for_responses.lock().await;
+
+                if let Some(channel) = conn_map.get_channel_for_worker(&worker_name) {
+                    let miner_response = serde_json::json!({
+                        "id": original_request_id,
+                        "result": response.get("result").unwrap_or(&serde_json::json!(null)),
+                        "error": response.get("error").unwrap_or(&serde_json::json!(null))
+                    });
+
+                    if let Err(e) = channel
+                        .send(serde_json::to_string(&miner_response).unwrap())
+                        .await
+                    {
+                        error!(
+                            "Failed to forward response to worker {}: {}",
+                            worker_name, e
+                        );
+                    } else {
+                        info!(
+                            "Forwarded upstream response to worker {} (id={})",
+                            worker_name, original_request_id
+                        );
+                    }
+                } else {
+                    warn!("Worker '{}' not found in connection mapping", worker_name);
+                }
+            }
+        });
+
+        let notification_tx_for_upstream_difficulty = notification_tx.clone();
+        let connection_mapping_for_upstream = connection_mapping.clone();
+
+        // Spawn upstream pool client with reconnection logic
+        tokio::spawn(async move {
+            info!("Starting upstream pool client...");
+            let upstream_client = upstream_pool::UpstreamPoolClient::new(
+                upstream_config.clone(),
+                upstream_share_rx,
+                upstream_job_tx.clone(),
+                notification_tx_for_upstream_difficulty,
+                upstream_response_tx.clone(),
+                Some(upstream_extranonce_tx),
+                Some(upstream_difficulty_tx),
+                configure_rx,
+            );
+            {
+                let mut conn_map = connection_mapping_for_upstream.lock().await;
+                conn_map.set_upstream_connected(true);
+            }
+            match upstream_client.run().await {
+                Ok(_) => {
+                    warn!("Upstream pool client exited gracefully");
+                }
+                Err(e) => {
+                    error!("Upstream pool client error: {:?}", e);
+                }
+            }
+            {
+                let mut conn_map = connection_mapping_for_upstream.lock().await;
+                conn_map.set_upstream_connected(false);
+            }
+            error!("Upstream connection lost - restarting...");
+        });
+
+        let connection_mapping_for_extranonce = connection_mapping.clone();
+        tokio::spawn(async move {
+            if let Some((extranonce1, extranonce2_size)) = upstream_extranonce_rx.recv().await {
+                info!(
+                    "Received upstream extranonce: {}, size: {}",
+                    extranonce1, extranonce2_size
+                );
+
+                let mut conn_map = connection_mapping_for_extranonce.lock().await;
+                conn_map.set_upstream_extranonce(extranonce1, extranonce2_size);
+
+                let _ = upstream_ready_tx.send(());
+                info!("Stratum server updated with upstream extranonce");
+            }
+        });
+
+        let connection_mapping_for_difficulty = connection_mapping.clone();
+        tokio::spawn(async move {
+            while let Some(difficulty) = upstream_difficulty_rx.recv().await {
+                info!("Received upstream difficulty: {}", difficulty);
+                let mut conn_map = connection_mapping_for_difficulty.lock().await;
+                conn_map.set_upstream_difficulty(difficulty);
+                info!("Stratum server updated with upstream difficulty");
+            }
+            warn!("Upstream difficulty channel closed");
+        });
+
+        // Handle jobs from upstream pool (relay to notifier)
+        let notification_tx_for_upstream = notification_tx.clone();
+        tokio::spawn(async move {
+            while let Some(job) = upstream_job_rx.recv().await {
+                info!("Received job from upstream pool: {}", job.job_id);
+
+                // Store last upstream job
+                *last_upstream_job_for_relay.lock().await = Some(job.clone());
+
+                // Forward to notifier
+                if let Err(e) = notification_tx_for_upstream
+                    .send(NotifyCmd::SendUpstreamJob {
+                        job_notification: job,
+                    })
+                    .await
+                {
+                    error!("Failed to forward upstream job: {}", e);
+                } else {
+                    info!("Forwarded upstream job to notifier");
+                }
+            }
+        });
+
+        (
+            Some(upstream_share_tx),
+            Some(configure_tx),
+            Some(audit_dag_for_stratum),
+        )
+    } else {
+        info!("Audit mode disabled, running in normal pool mode");
+        (None, None, None)
+    };
+
+    if args.audit {
+        info!("Waiting for upstream pool...");
+        match tokio::time::timeout(std::time::Duration::from_secs(30), upstream_ready_rx).await {
+            Ok(Ok(())) => info!("Upstream is ready"),
+            _ => {
+                error!("Upstream pool connection failed");
+                std::process::exit(1);
+            }
+        }
+    }
+
     //Running the notification service
     tokio::spawn(async move {
         let _res = notifier
@@ -189,6 +390,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 notification_tx_clone,
                 swarm_handler_arc.clone(),
                 spin_lock_ref,
+                audit_dag_option,
+                upstream_share_tx_option,
+                upstream_configure_tx_option,
             )
             .await;
     });
@@ -407,18 +611,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
 
     // Spawn IPC handler
-    let _ipc_handler = tokio::task::spawn_blocking(move || {
-        let rt = match tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-        {
-            Ok(rt) => rt,
-            Err(e) => {
-                error!(error = %e, "Failed to create tokio runtime for IPC handler");
-                return;
-            }
-        };
-        rt.block_on(async {
+    let _ipc_handler = if !args.audit {
+        Some(tokio::task::spawn_blocking(move || {
+            let rt = tokio::runtime::Builder::new_current_thread()
+                .enable_all()
+                .build()
+                .expect("Failed to create tokio runtime");
+            rt.block_on(async {
             let local_set = tokio::task::LocalSet::new();
 
             local_set
@@ -485,7 +684,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 })
                 .await;
         });
-    });
+        }))
+    } else {
+        info!("Skipping IPC connection, audit mode enabled using upstream pool jobs");
+        None
+    };
 
     if let Some(addnode) = args.addnode {
         for node in addnode.iter() {

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -216,6 +216,12 @@ pub struct DownstreamClient {
     version_rolling_min_bit: Option<u32>,
     /// The expected size of the extranonce2 field provided by the miner.
     extranonce2_len: usize,
+    /// Unique 2-byte prefix for this miner's extranonce partitioning which is currently supported by audit mode only,
+    /// although this will be appended into the extranonce1 field while sending to the miner, but we are appending
+    /// this to extranonce2 while submitting to the upstream pool.
+    pub extranonce2_prefix: Option<Vec<u8>>,
+    /// The size of extranonce2 that the miner rolls, after prefix is subtracted
+    pub miner_extranonce2_size: usize,
     /// Optional per-connection monitoring target (stricter than share/weak target).
     /// Used to sample miner health at a higher rate than the share target.
     pub monitor_target: Option<bitcoin::Target>,
@@ -544,7 +550,7 @@ impl DownstreamClient {
                 })
             }
         };
-        let expected_hex_len = self.extranonce2_len * 2;
+        let expected_hex_len = self.miner_extranonce2_size * 2;
         if extranonce2.len() != expected_hex_len {
             error!(
                 "Miner {} submitted extranonce2 '{}' with wrong length: expected {} hex chars, got {}",
@@ -562,6 +568,14 @@ impl DownstreamClient {
                 ),
             });
         }
+
+        debug!(
+            worker = %worker_name,
+            miner_extranonce2 = %extranonce2,
+            extranonce1 = %hex::encode(&self.extranonce1),
+            prefix_in_extranonce1 = ?self.extranonce2_prefix.as_ref().map(|p| hex::encode(p)),
+            "Extranonce2 prefix handled via extranonce1; using miner-submitted extranonce2 unchanged"
+        );
 
         if hex::decode(extranonce2).is_err() {
             error!(
@@ -677,10 +691,30 @@ impl DownstreamClient {
             // Forward to upstream without validation
             // TODO: Implement validation logic.
             if let Some(ref upstream_tx) = upstream_share_tx {
+                // For upstream, we need to reconstruct the full 8-byte extranonce2
+                let full_extranonce2_for_upstream =
+                    if let Some(ref prefix) = self.extranonce2_prefix {
+                        // Prepend the prefix (2 bytes) to create the full 8 bytes extranonce2
+                        let prefix_hex = hex::encode(prefix);
+                        format!("{}{}", prefix_hex, extranonce2)
+                    } else {
+                        extranonce2.to_string()
+                    };
+                debug!(
+                    worker = %worker_name,
+                    job_id = %job_id_str,
+                    miner_extranonce2 = %extranonce2,
+                    miner_extranonce2_len_bytes = %(extranonce2.len() / 2),
+                    prefix = ?self.extranonce2_prefix.as_ref().map(|p| hex::encode(p)),
+                    full_extranonce2_for_upstream = %full_extranonce2_for_upstream,
+                    full_extranonce2_len_bytes = %(full_extranonce2_for_upstream.len() / 2),
+                    "Reconstructing full extranonce2 for upstream"
+                );
+
                 let upstream_share = crate::upstream_pool::UpstreamShare {
                     worker_name: worker_name.to_string(),
                     job_id: job_id_str.to_string(),
-                    extranonce2: extranonce2.to_string(),
+                    extranonce2: full_extranonce2_for_upstream,
                     ntime: ntime.to_string(),
                     nonce: nonce.to_string(),
                     version_bits: param_array
@@ -1405,20 +1439,33 @@ impl DownstreamClient {
         ];
         self.subscribed = true;
         let extranonce1_hex_str = hex::encode(&self.extranonce1);
+
+        // In audit mode with prefix, tell miner their rollable size
+        let extranonce2_size_for_miner = if self.extranonce2_prefix.is_some() {
+            self.miner_extranonce2_size
+        } else {
+            self.extranonce2_len
+        };
         info!(
-            "Subscribe response: mode={}, extranonce1={}, extranonce2_size={}",
+            "Subscribe response: mode={}, extranonce1={}, extranonce2_size={}, prefix={:?}",
             if self.is_proxy_mode {
                 "AUDIT"
             } else {
                 "BRAIDPOOL"
             },
             extranonce1_hex_str,
-            self.extranonce2_len
+            extranonce2_size_for_miner,
+            self.extranonce2_prefix.as_ref().map(|p| hex::encode(p))
         );
+
         Ok(StratumResponses::StandardResponse {
             std_response: StandardResponse::new_ok(
                 Some(client_request_id),
-                json!([subscriptions, extranonce1_hex_str, self.extranonce2_len]),
+                json!([
+                    subscriptions,
+                    extranonce1_hex_str,
+                    extranonce2_size_for_miner
+                ]),
             ),
         })
     }
@@ -1450,6 +1497,8 @@ impl Default for DownstreamClient {
             version_rolling_mask: None,
             version_rolling_min_bit: None,
             extranonce2_len: EXTRANONCE2_SIZE,
+            extranonce2_prefix: None,
+            miner_extranonce2_size: EXTRANONCE2_SIZE,
             monitor_target: None,
             block_submission_tx: None,
             is_proxy_mode: false,
@@ -2483,6 +2532,21 @@ impl Notifier {
         Ok(())
     }
 }
+
+#[derive(Debug, Clone)]
+pub struct PrefixStats {
+    pub total_assigned: usize,
+    pub available_for_reuse: usize,
+    pub next_new_prefix: u16,
+    pub total_capacity: u16,
+}
+
+impl PrefixStats {
+    pub fn utilization_percentage(&self) -> f64 {
+        (self.total_assigned as f64 / self.total_capacity as f64) * 100.0
+    }
+}
+
 ///Connection information associated with each downstream peer associated along with the mapped `Sender_channel` for sending downstream responses and communication.
 #[derive(Debug, Clone)]
 pub struct ConnectionInfo {
@@ -2498,6 +2562,12 @@ pub struct ConnectionMapping {
     pub upstream_difficulty: Option<f64>,
     worker_to_peer: HashMap<String, String>,
     pub upstream_connected: bool,
+    /// Counter for assigning unique extranonce2 prefixes in audit mode, wraps around at 65535 (2 bytes)
+    next_extranonce2_prefix: u16,
+    /// Track assigned prefixes to detect reuse, peer_addr -> prefix
+    assigned_prefixes: HashMap<String, u16>,
+    /// Pool of released prefixes available for reuse
+    available_prefixes: std::collections::VecDeque<u16>,
 }
 
 impl ConnectionMapping {
@@ -2509,6 +2579,106 @@ impl ConnectionMapping {
             upstream_difficulty: None,
             worker_to_peer: HashMap::new(),
             upstream_connected: false,
+            next_extranonce2_prefix: 1, // Start at 1, by design
+            assigned_prefixes: HashMap::new(),
+            available_prefixes: std::collections::VecDeque::new(),
+        }
+    }
+
+    /// Allocate a unique 2-byte prefix for a new miner in audit mode
+    pub fn allocate_extranonce2_prefix(&mut self) -> (Vec<u8>, usize) {
+        // This will try to reuse a released prefix first
+        let prefix = if let Some(reused_prefix) = self.available_prefixes.pop_front() {
+            debug!(
+                prefix = %hex::encode(reused_prefix.to_be_bytes()),
+                available_count = %self.available_prefixes.len(),
+                "Reusing released prefix"
+            );
+            reused_prefix
+        } else {
+            // Otherwise allocate a new prefix
+            let new_prefix: u16 = self.next_extranonce2_prefix;
+            self.next_extranonce2_prefix = self.next_extranonce2_prefix.wrapping_add(1);
+
+            if self.next_extranonce2_prefix == 0 {
+                warn!("Extranonce2 prefix wrapped around to 0, resetting to 1");
+                self.next_extranonce2_prefix = 1;
+            }
+
+            if self.next_extranonce2_prefix > 60000 && self.available_prefixes.is_empty() {
+                warn!(
+                    used_prefixes = %self.next_extranonce2_prefix,
+                    total_capacity = 65535,
+                    "Approaching prefix exhaustion!"
+                );
+            }
+
+            new_prefix
+        };
+
+        let prefix_bytes = prefix.to_be_bytes().to_vec();
+        let miner_size = self
+            .upstream_extranonce2_size
+            .map(|size| size.saturating_sub(2))
+            .unwrap_or(6);
+
+        debug!(
+            prefix = %hex::encode(&prefix_bytes),
+            miner_extranonce2_size = %miner_size,
+            allocation_type = if self.available_prefixes.len() > 0 { "reused" } else { "new" },
+            available_count = %self.available_prefixes.len(),
+            "Allocated extranonce2 prefix"
+        );
+
+        (prefix_bytes, miner_size)
+    }
+
+    /// Track which prefix was assigned to which peer
+    pub fn register_prefix(&mut self, peer_addr: String, prefix: u16) {
+        if let Some(old_prefix) = self.assigned_prefixes.insert(peer_addr.clone(), prefix) {
+            warn!(
+                peer = %peer_addr,
+                old_prefix = %hex::encode(old_prefix.to_be_bytes()),
+                new_prefix = %hex::encode(prefix.to_be_bytes()),
+                "Peer reconnected and received new prefix"
+            );
+        }
+        debug!(
+            peer = %peer_addr,
+            prefix = %hex::encode(prefix.to_be_bytes()),
+            total_assigned = %self.assigned_prefixes.len(),
+            "Registered prefix assignment"
+        );
+    }
+
+    /// Release a prefix back to the available pool when a miner disconnects
+    fn release_prefix(&mut self, peer_addr: &str) {
+        if let Some(prefix) = self.assigned_prefixes.remove(peer_addr) {
+            if prefix < 65000 {
+                self.available_prefixes.push_back(prefix);
+                info!(
+                    peer = %peer_addr,
+                    prefix = %hex::encode(prefix.to_be_bytes()),
+                    available_count = %self.available_prefixes.len(),
+                    "Released prefix for reuse"
+                );
+            } else {
+                warn!(
+                    peer = %peer_addr,
+                    prefix = %hex::encode(prefix.to_be_bytes()),
+                    "Prefix too high, not reusing (near wrap-around range)"
+                );
+            }
+        }
+    }
+
+    // Returns statistics about prefix usage
+    pub fn get_prefix_stats(&self) -> PrefixStats {
+        PrefixStats {
+            total_assigned: self.assigned_prefixes.len(),
+            available_for_reuse: self.available_prefixes.len(),
+            next_new_prefix: self.next_extranonce2_prefix,
+            total_capacity: 65535,
         }
     }
 
@@ -2522,6 +2692,9 @@ impl ConnectionMapping {
     }
 
     pub fn remove_peer(&mut self, peer_addr: &str) {
+        // Release the prefix before removing peer
+        self.release_prefix(peer_addr);
+
         // Remove from channel mapping
         self.downstream_channel_mapping.remove(peer_addr);
 
@@ -2529,7 +2702,12 @@ impl ConnectionMapping {
         self.worker_to_peer
             .retain(|_worker_name, mapped_peer| mapped_peer != peer_addr);
 
-        debug!("Removed peer {} and associated workers", peer_addr);
+        debug!(
+            peer = %peer_addr,
+            remaining_peers = %self.downstream_channel_mapping.len(),
+            available_prefixes = %self.available_prefixes.len(),
+            "Removed peer and associated workers"
+        );
     }
 
     pub async fn disconnect_all_with_message(&mut self, reason: &str) {
@@ -2537,6 +2715,9 @@ impl ConnectionMapping {
             self.downstream_channel_mapping.drain().collect();
 
         for (peer_addr, connection_info) in peers {
+            // Release prefix before disconnecting
+            self.release_prefix(&peer_addr);
+
             // Send stratum error before closing
             let error_msg = serde_json::json!({
                 "id": null,
@@ -2559,11 +2740,18 @@ impl ConnectionMapping {
             );
         }
 
+        debug!(
+            available_prefixes = %self.available_prefixes.len(),
+            "All miners disconnected, prefixes released"
+        );
         // Clear worker mappings
         self.worker_to_peer.clear();
     }
 
     pub fn disconnect_peer(&mut self, peer_addr: &str, reason: &str) {
+        // Release prefix
+        self.release_prefix(peer_addr);
+
         if let Some(connection_info) = self.downstream_channel_mapping.remove(peer_addr) {
             info!(
                 peer = %peer_addr,
@@ -2727,23 +2915,52 @@ impl Server {
                          let (reader, writer) = stream.into_split();
 
                             // This will determine extranonce before creating client
-                            let (assigned_extranonce1, assigned_extranonce2_size, is_proxy) = {
-                                let mapping = self.downstream_connection_mapping.lock().await;
+                            let (assigned_extranonce1, assigned_extranonce2_size, extranonce2_prefix, is_proxy) = {
+                                let mut mapping = self.downstream_connection_mapping.lock().await;
 
+                                // In audit mode use upstream extranonce1 and allocate unique prefix
                                 if self.stratum_config.audit_mode {
+                                    let upstream_ext1_clone = mapping.upstream_extranonce1.clone();
+                                    let upstream_ext2_size = mapping.upstream_extranonce2_size;
+
                                     // This must have upstream connection
-                                    if let (Some(ref upstream_ext1), Some(upstream_ext2_size)) =
-                                        (&mapping.upstream_extranonce1, mapping.upstream_extranonce2_size)
+                                    if let (Some(upstream_ext1), Some(_ext2_size)) =
+                                        (upstream_ext1_clone, upstream_ext2_size)
                                     {
                                         info!("New audit mode connection using upstream extranonce: {}", upstream_ext1);
 
-                                        match hex::decode(upstream_ext1) {
-                                            Ok(bytes) => (bytes, upstream_ext2_size, true),
+                                        // Allocate unique 2-byte prefix for this miner
+                                        let (prefix_bytes, miner_ext2_size) = mapping.allocate_extranonce2_prefix();
+                                        let prefix_u16 = u16::from_be_bytes([prefix_bytes[0], prefix_bytes[1]]);
+                                        mapping.register_prefix(peer_addr.to_string(), prefix_u16);
+
+                                        let upstream_ext1_bytes = match hex::decode(&upstream_ext1) {
+                                            Ok(bytes) => bytes,
                                             Err(e) => {
                                                 error!("Failed to decode upstream extranonce: {}", e);
-                                                continue; // Skip this connection
+                                                continue;
                                             }
-                                        }
+                                        };
+
+                                        let mut extended_extranonce1 = upstream_ext1_bytes;
+                                        extended_extranonce1.extend_from_slice(&prefix_bytes);
+
+                                        let stats = mapping.get_prefix_stats();
+                                        debug!(
+                                            audit_mode = true,
+                                            peer = %peer_addr,
+                                            upstream_extranonce1 = %upstream_ext1,
+                                            assigned_prefix = %hex::encode(&prefix_bytes),
+                                            full_extranonce1 = %hex::encode(&extended_extranonce1),
+                                            miner_extranonce2_size_bytes = %miner_ext2_size,
+                                            assigned_prefixes_count = %stats.total_assigned,
+                                            available_prefixes_count = %stats.available_for_reuse,
+                                            prefix_utilization_percent = %format!("{:.2}%", stats.utilization_percentage()),
+                                            "New audit-mode miner: extranonce1 extended with unique prefix; assigned {}-byte rollable extranonce2",
+                                            miner_ext2_size
+                                        );
+
+                                        (extended_extranonce1, miner_ext2_size, Some(prefix_bytes), true)
                                     } else {
                                         // That means audit mode enabled but upstream not ready
                                         error!("Miner {} tried to connect in audit mode, but upstream pool is not ready yet", peer_addr);
@@ -2755,7 +2972,7 @@ impl Server {
                                     let mut bytes = [0u8; 4];
                                     rand::thread_rng().fill_bytes(&mut bytes);
                                     info!("New Braidpool connection using local extranonce: {}", hex::encode(&bytes));
-                                    (bytes.to_vec(), EXTRANONCE2_SIZE, false)
+                                    (bytes.to_vec(), EXTRANONCE2_SIZE, None, false)
                                 }
                             };
                             // Create client with correct state
@@ -2770,6 +2987,8 @@ impl Server {
                                 version_rolling_mask: None,
                                 version_rolling_min_bit: None,
                                 extranonce2_len: assigned_extranonce2_size,
+                                extranonce2_prefix: extranonce2_prefix,
+                                miner_extranonce2_size: assigned_extranonce2_size,
                                 monitor_target: None,
                                 block_submission_tx: self.block_submission_tx.clone(),
                                 is_proxy_mode: is_proxy,

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -4,6 +4,7 @@ use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRAN
 use bitcoin::block::HeaderExt;
 use bitcoin::consensus::serialize;
 use bitcoin::io::Cursor;
+use bitcoin::pow::CompactTargetExt;
 use bitcoin::{absolute::Decodable, Transaction};
 use bitcoin::{BlockHash, BlockHeader, BlockTime, TxMerkleNode, Txid, Witness};
 use futures::{lock::Mutex, FutureExt};
@@ -26,6 +27,8 @@ use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
+
+pub const DISCONNECT_SIGNAL: &str = "!!!_INTERNAL_DISCONNECT_SIGNAL_!!!";
 
 #[derive(Debug, Clone)]
 pub struct BlockSubmissionRequest {
@@ -1555,6 +1558,26 @@ impl MiningJobMap {
             string_job_id_map: HashMap::new(),
         }
     }
+    pub fn clear_upstream_jobs(&mut self) {
+        if self.string_job_id_map.is_empty() {
+            return;
+        }
+        info!(
+            count = %self.string_job_id_map.len(),
+            "Clearing stale upstream jobs from map due to disconnect"
+        );
+        let stale_template_ids: Vec<TemplateId> = self
+            .string_job_id_map
+            .values()
+            .map(|(tid, _)| tid.clone())
+            .collect();
+
+        self.string_job_id_map.clear();
+        for tid in stale_template_ids {
+            self.mining_jobs.remove(&tid);
+        }
+    }
+
     ///Inserting a suitable mining job which has been passed to the downstream being constructed from a suitable block template .
     pub async fn insert_mining_job(
         &mut self,
@@ -1808,6 +1831,133 @@ impl Notifier {
             parsed_bits: None,
         })
     }
+    async fn send_upstream_job_notification_to_miner(
+        peer_addr: &str,
+        connection_entry: &ConnectionInfo,
+        job_notification: &crate::stratum::JobNotification,
+        mining_job_map: &Arc<Mutex<MiningJobMap>>,
+    ) -> Result<(), StratumErrors> {
+        let mut curr_peer_mining_job_map = mining_job_map.lock().await;
+        let compact_bits = match job_notification.parsed_bits {
+            Some(bits) => bits,
+            None => {
+                error!(
+                    peer = %peer_addr,
+                    job_id = %job_notification.job_id,
+                    "Upstream job missing parsed_bits, attempting hex parse"
+                );
+
+                // Try fallback parse, but this indicates upstream handler issue
+                bitcoin::CompactTarget::from_hex(&job_notification.nbits).map_err(|e| {
+                    StratumErrors::InvalidMethodParams {
+                        method: format!("Invalid nbits in upstream job: {}", e),
+                    }
+                })?
+            }
+        };
+
+        // Reconstruct template from job notification
+        let mut template = crate::stratum::BlockTemplate::default();
+        template.bits = compact_bits;
+
+        // Parse version
+        let version_u32 = u32::from_str_radix(&job_notification.version, 16).map_err(|e| {
+            StratumErrors::InvalidMethodParams {
+                method: format!("Invalid version hex: {}", e),
+            }
+        })?;
+        template.version = bitcoin::block::Version::from_consensus(version_u32 as i32);
+
+        // Parse and reverse prevhash
+        if let Ok(prevhash_bytes) = hex::decode(&job_notification.prevhash) {
+            if prevhash_bytes.len() != 32 {
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: format!("Invalid prevhash length: {}", prevhash_bytes.len()),
+                });
+            }
+            let mut reversed = [0u8; 32];
+            for i in 0..32 {
+                reversed[i] = prevhash_bytes[31 - i];
+            }
+            template.previousblockhash = bitcoin::BlockHash::from_byte_array(reversed);
+        } else {
+            return Err(StratumErrors::InvalidMethodParams {
+                method: "Failed to decode prevhash".to_string(),
+            });
+        }
+
+        let unix_timestamp = u32::from_str_radix(&job_notification.ntime, 16).unwrap_or_else(|e| {
+            warn!(
+                peer = %peer_addr,
+                ntime = %job_notification.ntime,
+                error = %e,
+                "Failed to parse ntime from upstream job, using current time as fallback"
+            );
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_secs() as u32)
+                .unwrap_or(0)
+        });
+
+        template.curtime = bitcoin::BlockTime::from_u32(unix_timestamp);
+        let template_id = TemplateId::from_upstream_string(&job_notification.job_id);
+        let job_details = crate::stratum::JobDetails {
+            blocktemplate: template,
+            coinbase1: job_notification.coinbase1.clone(),
+            coinbase2: job_notification.coinbase2.clone(),
+            coinbase_merkle_path: job_notification.merkle_branches.clone(),
+            coinbase_witness_commitment: job_notification.coinbase_witness_commitment.clone(),
+            job_sent_time: unix_timestamp,
+            is_upstream_job: true,
+        };
+
+        let upstream_job_id = curr_peer_mining_job_map
+            .insert_upstream_job(
+                job_notification.job_id.clone(),
+                template_id.clone(),
+                job_details,
+            )
+            .await;
+
+        let job_notification_response = serde_json::json!({
+            "method": "mining.notify",
+            "params": [
+                upstream_job_id,
+                job_notification.prevhash,
+                job_notification.coinbase1,
+                job_notification.coinbase2,
+                job_notification.merkle_branches,
+                job_notification.version,
+                job_notification.nbits,
+                job_notification.ntime,
+                job_notification.clean_jobs
+            ]
+        });
+
+        let json_str = serde_json::to_string(&job_notification_response).map_err(|e| {
+            StratumErrors::InvalidMethodParams {
+                method: format!("Failed to serialize job notification: {}", e),
+            }
+        })?;
+
+        connection_entry
+            .sender
+            .send(json_str.clone())
+            .await
+            .map_err(|e| StratumErrors::NotifyMessageNotSent {
+                error: format!("Failed to send upstream job to {}: {}", peer_addr, e),
+                msg: json_str,
+                msg_type: "UpstreamJob".to_string(),
+            })?;
+
+        info!(
+            "Sent upstream job {} to {} (bits: {})",
+            upstream_job_id, peer_addr, job_notification.nbits
+        );
+
+        Ok(())
+    }
+
     /// Runs the Stratum notifier task that handles broadcasting mining jobs to downstream miners.
     ///
     /// This asynchronous function continuously listens for notification commands and performs
@@ -1831,6 +1981,7 @@ impl Notifier {
         latest_template_arc: &mut Arc<Mutex<BlockTemplate>>,
         latest_template_merkle_branch_arc: &mut Arc<Mutex<Vec<Vec<u8>>>>,
         latest_template_id: Arc<Mutex<TemplateId>>,
+        upstream_cache: Option<Arc<tokio::sync::RwLock<crate::upstream_pool::UpstreamCache>>>,
     ) -> Result<(), StratumErrors> {
         debug!("Stratum notifier task started");
         while let Some(notification_command) = self.notification_receiver.recv().await {
@@ -1973,6 +2124,62 @@ impl Notifier {
                 NotifyCmd::SendLatestTemplateToNewDownstream {
                     new_downstream_addr,
                 } => {
+                    if let Some(cache_lock) = &upstream_cache {
+                        let cache = cache_lock.read().await;
+                        if let Some(job_notification) = cache.get_latest_job() {
+                            info!(
+                                "Sending cached upstream job {} to new miner {}",
+                                job_notification.job_id, new_downstream_addr
+                            );
+
+                            let connection_entry = {
+                                let current_downstream_mapping =
+                                    downstream_connection_map.lock().await;
+                                current_downstream_mapping
+                                    .downstream_channel_mapping
+                                    .get(&new_downstream_addr)
+                                    .cloned()
+                            };
+
+                            let mining_job_map = {
+                                let global_map = self.job_map_arc.lock().await;
+                                global_map.get(&new_downstream_addr).cloned()
+                            };
+
+                            if let (Some(connection_entry), Some(map)) =
+                                (connection_entry, mining_job_map)
+                            {
+                                match Self::send_upstream_job_notification_to_miner(
+                                    &new_downstream_addr,
+                                    &connection_entry,
+                                    &job_notification,
+                                    &map,
+                                )
+                                .await
+                                {
+                                    Ok(_) => {
+                                        debug!(
+                                            peer = %new_downstream_addr,
+                                            "Successfully sent cached upstream job"
+                                        );
+                                    }
+                                    Err(e) => {
+                                        error!(
+                                            peer = %new_downstream_addr,
+                                            error = %e,
+                                            "Failed to send cached upstream job"
+                                        );
+                                    }
+                                }
+                            } else {
+                                warn!(
+                                    peer = %new_downstream_addr,
+                                    "Connection or job map not found for new downstream"
+                                );
+                            }
+                            continue;
+                        }
+                    }
                     let current_template_id = latest_template_id.lock().await.clone();
                     let connection_entry = {
                         let current_downstream_mapping = downstream_connection_map.lock().await;
@@ -2325,6 +2532,64 @@ impl ConnectionMapping {
         debug!("Removed peer {} and associated workers", peer_addr);
     }
 
+    pub async fn disconnect_all_with_message(&mut self, reason: &str) {
+        let peers: Vec<(String, ConnectionInfo)> =
+            self.downstream_channel_mapping.drain().collect();
+
+        for (peer_addr, connection_info) in peers {
+            // Send stratum error before closing
+            let error_msg = serde_json::json!({
+                "id": null,
+                "result": null,
+                "error": [20, reason, null]
+            });
+            let _ = connection_info
+                .sender
+                .try_send(serde_json::to_string(&error_msg).unwrap());
+
+            // Then send disconnect signal
+            let _ = connection_info
+                .sender
+                .try_send(DISCONNECT_SIGNAL.to_string());
+            info!(
+                peer = %peer_addr,
+                connection_id = %connection_info.connection_id,
+                reason = %reason,
+                "Sent shutdown notice to miner"
+            );
+        }
+
+        // Clear worker mappings
+        self.worker_to_peer.clear();
+    }
+
+    pub fn disconnect_peer(&mut self, peer_addr: &str, reason: &str) {
+        if let Some(connection_info) = self.downstream_channel_mapping.remove(peer_addr) {
+            info!(
+                peer = %peer_addr,
+                connection_id = %connection_info.connection_id,
+                reason = %reason,
+                "Disconnecting miner..."
+            );
+
+            // Send the explicit signal
+            let _ = connection_info
+                .sender
+                .try_send(DISCONNECT_SIGNAL.to_string());
+
+            // Drop the connection info, closes the channel
+            drop(connection_info);
+
+            info!(peer = %peer_addr, "Miner disconnected (Signal Sent & Channel Dropped)");
+        } else {
+            warn!(peer = %peer_addr, "Peer not found in connection mapping");
+        }
+
+        // cleanup workers
+        self.worker_to_peer
+            .retain(|_worker_name, mapped_peer| mapped_peer != peer_addr);
+    }
+
     pub fn set_upstream_extranonce(&mut self, extranonce1: String, extranonce2_size: usize) {
         self.upstream_extranonce1 = Some(extranonce1);
         self.upstream_extranonce2_size = Some(extranonce2_size);
@@ -2627,22 +2892,28 @@ impl Server {
 
         loop {
             tokio::select! {
-                Some(message) = downstream_receiver.recv() => {
-                    debug!("Message to send to {}: {}", peer_addr, message);
-
-                    if let Err(e) = stream_writer.write_all(format!("{}\n", message).as_bytes()).await {
-                        error!("Failed to write to {}: {}", peer_addr, e);
-                        break;
+                msg_option = downstream_receiver.recv() => {
+                    match msg_option {
+                        Some(message) => {
+                            if message == DISCONNECT_SIGNAL {
+                                info!(peer = %peer_addr, "Received explicit disconnect signal");
+                                break;
+                            }
+                            debug!("Sending to {}: {}", peer_addr, message);
+                            if let Err(e) = tokio::time::timeout(
+                                std::time::Duration::from_secs(5),
+                                stream_writer.write_all(format!("{}\n", message).as_bytes())
+                            ).await {
+                                error!("Write error to {}: {}", peer_addr, e);
+                                break;
+                            }
+                        }
+                        None => {
+                            info!(peer = %peer_addr, "Channel closed by main, disconnecting miner");
+                            break;
+                        }
                     }
-
-                    if let Err(e) = stream_writer.flush().await {
-                        error!("Failed to flush to {}: {}", peer_addr, e);
-                        break;
-                    }
-
-                    info!("Response has been written to the TcpStream successfully");
                 }
-
                 // Process incoming requests from miner
                 line = framed.next().fuse() => {
                     match line {

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -12,6 +12,7 @@ use num::ToPrimitive;
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
+use std::collections::VecDeque;
 use std::sync::atomic::AtomicBool;
 use std::time::UNIX_EPOCH;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
@@ -29,6 +30,13 @@ use tokio_util::codec::{FramedRead, LinesCodec};
 use tracing::{debug, error, info, trace, warn};
 
 pub const DISCONNECT_SIGNAL: &str = "!!!_INTERNAL_DISCONNECT_SIGNAL_!!!";
+const PREFIX_EXHAUSTION_WARNING_THRESHOLD: u16 = 60000;
+const PREFIX_MAX_VALUE: u16 = u16::MAX; // Maximum prefix value in audit mode
+const PREFIX_BYTES_SIZE: usize = 2; // Size of prefix in bytes
+const COMMITMENT_SIZE: usize = 5; // Size of bead hash commitment in bytes
+const DEFAULT_VERSION_ROLLING_MASK: u32 = 0x1FFFE000; // BIP 310 default mask
+const UPSTREAM_EXTRANONCE1_SIZE: usize = 4; // Standard upstream extranonce1 size
+const COMMITMENT_HISTORY_SIZE: usize = 5; // Number of historical commitments to track
 
 #[derive(Debug, Clone)]
 pub struct BlockSubmissionRequest {
@@ -115,8 +123,10 @@ pub struct StratumServerConfig {
     pub maximum_difficulty: Option<u64>,
     /// Optional payout address for solo mining mode.
     pub solo_address: Option<String>,
-    /// Indicate for audit mode
+    /// Indicates audit mode.
     pub audit_mode: bool,
+    /// Audit mode miner weak difficulty
+    pub audit_miner_difficulty: f64,
 }
 
 impl Default for StratumServerConfig {
@@ -130,6 +140,7 @@ impl Default for StratumServerConfig {
             maximum_difficulty: None,
             solo_address: None,
             audit_mode: false,
+            audit_miner_difficulty: 100.0,
         }
     }
 }
@@ -207,6 +218,8 @@ pub struct DownstreamClient {
     connection_id: u32,
     /// The extranonce1 value assigned to this downstream miner.
     extranonce1: Vec<u8>,
+    // Stores the extranonce commitment history for audit mode
+    pub extranonce_history: VecDeque<Vec<u8>>,
     /// `extranonce1` to be sent to the Downstream in the SV1 `mining.subscribe` message response.
     //extranonce1: Vec<u8>,
     //extranonce2_size: usize,
@@ -229,6 +242,10 @@ pub struct DownstreamClient {
     pub block_submission_tx: Option<mpsc::UnboundedSender<BlockSubmissionRequest>>,
     /// Indicates whether this downstream client is operating in proxy/audit mode (connected via an upstream pool).
     pub is_proxy_mode: bool,
+    // Payout address used in the audit mode
+    pub payout_address: Option<String>,
+    // Refers to the miner difficulty in audit mode
+    pub audit_miner_difficulty: f64,
 }
 impl DownstreamClient {
     /// A helper function to keep connection_id immutable after assignment
@@ -285,6 +302,10 @@ impl DownstreamClient {
                 .await
             }
             "mining.submit" => {
+                let upstream_diff = {
+                    let mapping = connection_mapping.lock().await;
+                    mapping.upstream_difficulty
+                };
                 Self::handle_submit(
                     self,
                     &req_params,
@@ -293,6 +314,7 @@ impl DownstreamClient {
                     swarm_handler,
                     audit_dag,
                     upstream_share_tx,
+                    upstream_diff,
                 )
                 .await
             }
@@ -390,21 +412,27 @@ impl DownstreamClient {
                     let upstream_diff = {
                         let mapping = connection_mapping.lock().await;
                         mapping.upstream_difficulty
-                    }; // Lock is always dropped here
-
+                    };
                     if let Some(diff) = upstream_diff {
+                        let miner_difficulty: f64 = if self.is_proxy_mode {
+                            self.audit_miner_difficulty
+                        } else {
+                            diff
+                        };
                         let set_difficulty_msg = serde_json::json!({
                             "method": "mining.set_difficulty",
-                            "params": [diff]
+                            "params": [miner_difficulty]
                         });
-
                         if let Err(e) = response_message_sender
                             .send(serde_json::to_string(&set_difficulty_msg).unwrap())
                             .await
                         {
-                            error!("Failed to send upstream difficulty to miner: {}", e);
+                            error!("Failed to send difficulty to miner: {}", e);
                         } else {
-                            info!("Sent upstream difficulty {} to miner {}", diff, peer_addr);
+                            info!(
+                                "Sent difficulty {} to miner {}",
+                                miner_difficulty, peer_addr
+                            );
                         }
                     }
                 }
@@ -485,6 +513,7 @@ impl DownstreamClient {
         swarm_handler: Arc<Mutex<SwarmHandler>>,
         audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
         upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
+        upstream_difficulty: Option<f64>,
     ) -> Result<StratumResponses, StratumErrors> {
         let connection_id_hex = format!("{:x}", self.connection_id());
         let param_array = match submit_work_params.as_array() {
@@ -515,7 +544,7 @@ impl DownstreamClient {
             Ok(name) => name,
             Err(error) => return Err(error),
         };
-        info!(
+        debug!(
             connection_id = %connection_id_hex,
             worker = %worker_name,
             "Mining worker connected"
@@ -606,13 +635,16 @@ impl DownstreamClient {
                 })
             }
         };
+
+        let rolled_version_bits: Option<&str> = param_array.get(5).and_then(|v| v.as_str());
+
         //Acquiring lock on the mining map and fetching the submitted job from the memory
         let (submitted_job, template_id) = {
             let job_mapping = mining_job_map.lock().await;
 
             // Try string lookup first (upstream jobs)
             if let Ok((job, tid)) = job_mapping.get_by_string_job_id(job_id_str) {
-                info!(
+                debug!(
                     jobid = job_id_str,
                     mode = "upstream",
                     "Found job by string ID"
@@ -651,91 +683,23 @@ impl DownstreamClient {
         };
 
         if submitted_job.is_upstream_job {
-            info!("Forwarding upstream job share from {}", worker_name);
-
-            let share_id = crate::audit::ShareId::from_share(
-                job_id_str,
-                extranonce2,
-                nonce,
-                ntime,
-                worker_name,
-            );
-            // Record in audit record
-            // Note: For now its only adding entry one-by-one in records without any DAG, this feature does not represent the final audit records, it's just the
-            // initial way of showing things, subsequent changes will use proper DAG based auditing and validation of shares.
-            // TODO: Implement DAG based auditing
-            if let Some(ref audit_dag_arc) = audit_dag {
-                let audit_record = crate::audit::AuditRecord {
-                    share_id: share_id.clone(),
-                    timestamp: std::time::SystemTime::now(),
-                    miner_ip: self.downstream_ip.clone(),
-                    worker_name: worker_name.to_string(),
-                    job_id: job_id_str.to_string(),
-                    share_difficulty: submitted_job.blocktemplate.bits,
-                    extranonce2: extranonce2.to_string(),
-                    nonce: nonce.to_string(),
-                    ntime: ntime.to_string(),
-                    block_hash: None,
-                    valid: true,
-                    upstream_accepted: None,
-                    parent_shares: vec![],
-                };
-
-                let mut dag = audit_dag_arc.lock().await;
-                match dag.add_record(audit_record).await {
-                    Ok(id) => info!("Recorded share {} in audit DAG", id),
-                    Err(e) => warn!("Failed to record audit entry: {}", e),
-                }
-            }
-
-            // Forward to upstream without validation
-            // TODO: Implement validation logic.
-            if let Some(ref upstream_tx) = upstream_share_tx {
-                // For upstream, we need to reconstruct the full 8-byte extranonce2
-                let full_extranonce2_for_upstream =
-                    if let Some(ref prefix) = self.extranonce2_prefix {
-                        // Prepend the prefix (2 bytes) to create the full 8 bytes extranonce2
-                        let prefix_hex = hex::encode(prefix);
-                        format!("{}{}", prefix_hex, extranonce2)
-                    } else {
-                        extranonce2.to_string()
-                    };
-                debug!(
-                    worker = %worker_name,
-                    job_id = %job_id_str,
-                    miner_extranonce2 = %extranonce2,
-                    miner_extranonce2_len_bytes = %(extranonce2.len() / 2),
-                    prefix = ?self.extranonce2_prefix.as_ref().map(|p| hex::encode(p)),
-                    full_extranonce2_for_upstream = %full_extranonce2_for_upstream,
-                    full_extranonce2_len_bytes = %(full_extranonce2_for_upstream.len() / 2),
-                    "Reconstructing full extranonce2 for upstream"
-                );
-
-                let upstream_share = crate::upstream_pool::UpstreamShare {
-                    worker_name: worker_name.to_string(),
-                    job_id: job_id_str.to_string(),
-                    extranonce2: full_extranonce2_for_upstream,
-                    ntime: ntime.to_string(),
-                    nonce: nonce.to_string(),
-                    version_bits: param_array
-                        .get(5)
-                        .and_then(|v| v.as_str())
-                        .map(String::from),
-                    original_request_id: client_request_id,
-                };
-                info!(
-                    "Forwarding share to upstream pool (worker: {}, job: {})",
-                    worker_name, job_id_str
-                );
-
-                if let Err(e) = upstream_tx.send(upstream_share).await {
-                    error!("Failed to forward share to upstream: {}", e);
-                    return Err(StratumErrors::UpstreamShareForwardFailed {
-                        error: e.to_string(),
-                    });
-                }
-            }
-            return Ok(StratumResponses::PendingUpstreamResponse);
+            return self
+                .validate_and_forward_upstream_share(
+                    &connection_id_hex,
+                    worker_name,
+                    job_id_str,
+                    extranonce2,
+                    ntime,
+                    nonce,
+                    rolled_version_bits,
+                    &submitted_job,
+                    client_request_id,
+                    audit_dag,
+                    upstream_share_tx,
+                    upstream_difficulty,
+                    swarm_handler,
+                )
+                .await;
         }
 
         //Building the coinbase and then eventually the block and testing for the validation against the
@@ -1023,7 +987,7 @@ impl DownstreamClient {
                 }
             }
             Err(e) => {
-                debug!(
+                warn!(
                     connection_id = %connection_id_hex,
                     error = %e,
                     target = %target.to_hex(),
@@ -1085,6 +1049,473 @@ impl DownstreamClient {
             std_response: StandardResponse::new_ok(Some(client_request_id), json!(true)),
         })
     }
+
+    /// Validate an upstream job share and create a bead then forward to the upstream pool if valid
+    async fn validate_and_forward_upstream_share(
+        &self,
+        connection_id_hex: &str,
+        worker_name: &str,
+        job_id_str: &str,
+        extranonce2: &str,
+        ntime: &str,
+        nonce: &str,
+        rolled_version_bits: Option<&str>,
+        submitted_job: &JobDetails,
+        client_request_id: u64,
+        audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
+        upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
+        upstream_difficulty: Option<f64>,
+        swarm_handler: Arc<Mutex<SwarmHandler>>,
+    ) -> Result<StratumResponses, StratumErrors> {
+        let ntime_u32 =
+            u32::from_str_radix(ntime, 16).map_err(|e| StratumErrors::InvalidMethodParams {
+                method: format!("mining.submit: invalid ntime hex: {}", e),
+            })?;
+
+        let nonce_u32 =
+            u32::from_str_radix(nonce, 16).map_err(|e| StratumErrors::InvalidMethodParams {
+                method: format!("mining.submit: invalid nonce hex: {}", e),
+            })?;
+
+        let raw_bytes = submitted_job
+            .blocktemplate
+            .previousblockhash
+            .to_byte_array();
+        let mut prevhash_for_header = [0u8; 32];
+
+        for chunk_idx in 0..8 {
+            let offset = chunk_idx * 4;
+            prevhash_for_header[offset] = raw_bytes[offset + 3];
+            prevhash_for_header[offset + 1] = raw_bytes[offset + 2];
+            prevhash_for_header[offset + 2] = raw_bytes[offset + 1];
+            prevhash_for_header[offset + 3] = raw_bytes[offset];
+        }
+
+        let base_version = submitted_job.blocktemplate.version.to_consensus();
+        let final_version = if let Some(rolled_hex) = rolled_version_bits {
+            let rolled = u32::from_str_radix(rolled_hex, 16).unwrap_or(0) as i32;
+            let mask = self
+                .version_rolling_mask
+                .as_ref()
+                .and_then(|s| u32::from_str_radix(s, 16).ok())
+                .unwrap_or(DEFAULT_VERSION_ROLLING_MASK) as i32;
+            (base_version & !mask) | (rolled & mask)
+        } else {
+            base_version
+        };
+
+        let mut valid_header = None;
+        let mut valid_block_hash = None;
+        let mut used_extranonce1 = vec![];
+        let mut meets_upstream = false;
+        let mut candidates = vec![self.extranonce1.clone()];
+        candidates.extend(self.extranonce_history.iter().cloned());
+        let miner_difficulty = if self.is_proxy_mode {
+            self.audit_miner_difficulty
+        } else {
+            100.0
+        };
+        let miner_target = Self::target_from_difficulty(miner_difficulty);
+        let upstream_target = upstream_difficulty
+            .map(|d| Self::target_from_difficulty(d))
+            .unwrap_or_else(|| bitcoin::Target::from_compact(submitted_job.blocktemplate.bits));
+
+        for (idx, extranonce1_candidate) in candidates.iter().enumerate() {
+            let coinbase_tx_hex = format!(
+                "{}{}{}{}",
+                submitted_job.coinbase1,
+                hex::encode(extranonce1_candidate),
+                extranonce2.to_ascii_lowercase(),
+                submitted_job.coinbase2
+            );
+            let coinbase_bytes = match hex::decode(&coinbase_tx_hex) {
+                Ok(b) => b,
+                Err(_) => continue,
+            };
+            let mut cursor = Cursor::new(coinbase_bytes);
+            let coinbase_tx: Transaction = match bitcoin::Transaction::consensus_decode(&mut cursor)
+            {
+                Ok(tx) => tx,
+                Err(_) => continue,
+            };
+
+            let mut merkle_branches_bytes: Vec<Vec<u8>> = Vec::new();
+            for merkle_branch in &submitted_job.coinbase_merkle_path {
+                let mut bytes = [0u8; 32];
+                if hex::decode_to_slice(merkle_branch, &mut bytes).is_err() {
+                    continue;
+                }
+                merkle_branches_bytes.push(bytes.to_vec());
+            }
+
+            let merkle_root_bytes =
+                calculate_merkle_root(coinbase_tx.compute_txid(), &merkle_branches_bytes);
+            let merkle_root = TxMerkleNode::from_byte_array(merkle_root_bytes);
+            let header = BlockHeader {
+                version: bitcoin::block::Version::from_consensus(final_version),
+                prev_blockhash: BlockHash::from_byte_array(prevhash_for_header),
+                merkle_root,
+                time: BlockTime::from_u32(ntime_u32),
+                bits: submitted_job.blocktemplate.bits,
+                nonce: nonce_u32,
+            };
+            let header_bytes = bitcoin::consensus::serialize(&header);
+            let block_hash_d = bitcoin::hashes::sha256d::Hash::hash(&header_bytes);
+            let block_hash = bitcoin::BlockHash::from_byte_array(block_hash_d.to_byte_array());
+
+            if Self::validate_share_against_target(block_hash, &miner_target) {
+                valid_header = Some(header);
+                valid_block_hash = Some(block_hash);
+                used_extranonce1 = extranonce1_candidate.clone();
+                meets_upstream = Self::validate_share_against_target(block_hash, &upstream_target);
+                debug!(
+                    connection_id = %connection_id_hex,
+                    worker = %worker_name,
+                    job_id = %job_id_str,
+                    block_hash = %block_hash,
+                    miner_target = %miner_target.to_hex(),
+                    upstream_target = %upstream_target.to_hex(),
+                    meets_miner_diff = true,
+                    meets_upstream_diff = %meets_upstream,
+                    "Share difficulty validation results"
+                );
+                if idx > 0 {
+                    debug!(
+                        "Valid upstream share found using extranonce1 (Depth: {})",
+                        idx
+                    );
+                }
+                break;
+            }
+        }
+
+        if let (Some(header), Some(block_hash)) = (valid_header, valid_block_hash) {
+            let share_id = block_hash;
+
+            let bead = {
+                let swarm = swarm_handler.lock().await;
+                let payout_address = self
+                    .payout_address
+                    .as_ref()
+                    .ok_or_else(|| StratumErrors::InvalidMethodParams {
+                        method: "mining.submit: payout address not set".to_string(),
+                    })?
+                    .parse::<bitcoin::Address<bitcoin::address::NetworkUnchecked>>()
+                    .map_err(|e| {
+                        error!(
+                            worker = %worker_name,
+                            error = %e,
+                            "Invalid payout address during share submission"
+                        );
+                        StratumErrors::InvalidMethodParams {
+                            method: format!("mining.submit: invalid payout address: {}", e),
+                        }
+                    })?
+                    .require_network(bitcoin::Network::Bitcoin)
+                    .map_err(|e| {
+                        error!(
+                            worker = %worker_name,
+                            error = ?e,
+                            "Payout address network mismatch, please use mainnet address"
+                        );
+                        StratumErrors::InvalidMethodParams {
+                            method: format!("mining.submit: address is for wrong network: {:?}", e),
+                        }
+                    })?
+                    .to_string();
+
+                let (parent_hash_set, time_hash_set) = {
+                    let braid = swarm.braid_arc.read().await;
+                    let mut parents = std::collections::HashSet::new();
+                    let mut timestamps = crate::committed_metadata::TimeVec(Vec::new());
+                    for &tip_idx in braid.tips.iter() {
+                        if let Some(tip_bead) = braid.beads.get(tip_idx) {
+                            let standard_hash = tip_bead.block_header.block_hash();
+                            parents.insert(crate::utils::BeadHash::from(standard_hash));
+                            timestamps
+                                .0
+                                .push(tip_bead.committed_metadata.start_timestamp);
+                        }
+                    }
+                    if parents.is_empty() {
+                        info!(worker = %worker_name, "Genesis bead, no parents exist");
+                    }
+                    (parents, timestamps)
+                };
+
+                let weak_target = miner_target.to_compact_lossy();
+                let min_target = upstream_difficulty
+                    .map(|d| Self::target_from_difficulty(d).to_compact_lossy())
+                    .unwrap_or(submitted_job.blocktemplate.bits);
+                debug!(
+                    worker = %worker_name,
+                    weak_target_bits = %format!("{:08x}", weak_target.to_consensus()),
+                    min_target_bits = %format!("{:08x}", min_target.to_consensus()),
+                    upstream_difficulty = ?upstream_difficulty,
+                    "Calculated bead difficulty targets"
+                );
+                let public_key =
+                    "020202020202020202020202020202020202020202020202020202020202020202"
+                        .parse::<bitcoin::PublicKey>()
+                        .unwrap();
+                let job_time = bitcoin::absolute::Time::from_consensus(submitted_job.job_sent_time)
+                    .map_err(|e| {
+                        error!(
+                            worker = %worker_name,
+                            error = %e,
+                            "Invalid job timestamp"
+                        );
+                        StratumErrors::InvalidMethodParams {
+                            method: format!("mining.submit: invalid job timestamp: {}", e),
+                        }
+                    })?;
+
+                let committed_metadata = crate::committed_metadata::CommittedMetadata {
+                    comm_pub_key: public_key,
+                    miner_ip: self.downstream_ip.clone(),
+                    start_timestamp: job_time,
+                    transaction_ids: crate::committed_metadata::TxIdVec(Vec::new()),
+                    parents: parent_hash_set,
+                    parent_bead_timestamps: time_hash_set,
+                    payout_address: payout_address,
+                    min_target,
+                    weak_target,
+                };
+
+                let broadcast_time = std::time::SystemTime::now()
+                    .duration_since(std::time::UNIX_EPOCH)
+                    .map(|d| {
+                        bitcoin::absolute::MedianTimePast::from_u32(d.as_secs() as u32).unwrap()
+                    })
+                    .unwrap();
+                let (extranonce_1_raw_value, extranonce_2_raw_value) = {
+                    if used_extranonce1.len() < UPSTREAM_EXTRANONCE1_SIZE {
+                        error!(
+                            worker = %worker_name,
+                            extranonce1_len = %used_extranonce1.len(),
+                            required = UPSTREAM_EXTRANONCE1_SIZE,
+                            "extranonce1 too short, expected at least 4 bytes, this upstream pool is not supported yet."
+                        );
+                        return Err(StratumErrors::InvalidMethodParams {
+                            method: "mining.submit: extranonce1 too short for audit mode"
+                                .to_string(),
+                        });
+                    }
+                    let upstream_bytes = &used_extranonce1[..UPSTREAM_EXTRANONCE1_SIZE];
+                    let upstream_u32 = u32::from_be_bytes([
+                        upstream_bytes[0],
+                        upstream_bytes[1],
+                        upstream_bytes[2],
+                        upstream_bytes[3],
+                    ]);
+                    const MAX_AUDIT_BYTES: usize = 64;
+                    let audit_bytes = &used_extranonce1[UPSTREAM_EXTRANONCE1_SIZE..];
+                    if audit_bytes.len() > MAX_AUDIT_BYTES {
+                        return Err(StratumErrors::InvalidMethodParams {
+                            method: "mining.submit: audit extranonce too long".to_string(),
+                        });
+                    }
+                    let audit_hash = bitcoin::hashes::sha256::Hash::hash(audit_bytes);
+                    let audit_hash_bytes = audit_hash.to_byte_array();
+                    let audit_hash_u32 = u32::from_be_bytes([
+                        audit_hash_bytes[0],
+                        audit_hash_bytes[1],
+                        audit_hash_bytes[2],
+                        audit_hash_bytes[3],
+                    ]);
+                    debug!(
+                        worker = %worker_name,
+                        extranonce1_len = %used_extranonce1.len(),
+                        upstream_ext1 = %hex::encode(upstream_bytes),
+                        upstream_ext1_u32 = %format!("{:08x}", upstream_u32),
+                        audit_portion_len = %audit_bytes.len(),
+                        audit_portion = %hex::encode(audit_bytes),
+                        audit_hash_u32 = %format!("{:08x}", audit_hash_u32),
+                        "Parsed extranonce values for bead metadata"
+                    );
+
+                    (upstream_u32, audit_hash_u32)
+                };
+                let placeholder_sig_bytes = [0u8; 64];
+                let sig = bitcoin::ecdsa::Signature {
+                    signature: secp256k1::ecdsa::Signature::from_compact(&placeholder_sig_bytes)
+                        .expect("Valid placeholder signature"),
+                    sighash_type: bitcoin::EcdsaSighashType::All,
+                };
+
+                let uncommitted_metadata = crate::uncommitted_metadata::UnCommittedMetadata {
+                    broadcast_timestamp: broadcast_time,
+                    extra_nonce_1: extranonce_1_raw_value,
+                    extra_nonce_2: extranonce_2_raw_value,
+                    signature: sig,
+                };
+
+                let bead = crate::bead::Bead {
+                    committed_metadata,
+                    block_header: header,
+                    uncommitted_metadata,
+                };
+
+                debug!(
+                    worker = %worker_name,
+                    block_hash = %bead.block_header.block_hash(),
+                    parent_count = %bead.committed_metadata.parents.len(),
+                    parents = ?bead.committed_metadata.parents.iter().map(|p| format!("{:?}", p)).collect::<Vec<_>>(),
+                    weak_target = %format!("{:08x}", bead.committed_metadata.weak_target.to_consensus()),
+                    min_target = %format!("{:08x}", bead.committed_metadata.min_target.to_consensus()),
+                    "Constructed audit mode bead"
+                );
+                bead
+            };
+
+            let audit_record = crate::audit::AuditRecord {
+                share_id: share_id.clone(),
+                timestamp: std::time::SystemTime::now(),
+                miner_ip: self.downstream_ip.clone(),
+                worker_name: worker_name.to_string(),
+                job_id: job_id_str.to_string(),
+                extranonce2: extranonce2.to_string(),
+                nonce: nonce.to_string(),
+                ntime: ntime.to_string(),
+                audit_verified: false,
+                audit_commitment: None,
+                upstream_accepted: None,
+                upstream_eligible: meets_upstream,
+                bead_hash: block_hash,
+            };
+
+            if let Some(ref audit_dag_arc) = audit_dag {
+                let mut dag = audit_dag_arc.lock().await;
+                match dag
+                    .add_and_record_bead(audit_record, bead, &used_extranonce1)
+                    .await
+                {
+                    Ok((_, bead_added)) => {
+                        if !bead_added {
+                            warn!("Bead already in DAG, rejecting share and skipping upstream forward");
+                            return Ok(StratumResponses::StandardResponse {
+                                std_response: StandardResponse::new_ok(
+                                    Some(client_request_id),
+                                    json!(false),
+                                ),
+                            });
+                        }
+                        if meets_upstream {
+                            if let Some(ref upstream_tx) = upstream_share_tx {
+                                dag.mark_upstream_forwarded(&share_id);
+                                drop(dag);
+                                let full_extranonce2 = if let Some(ref prefix) =
+                                    self.extranonce2_prefix
+                                {
+                                    let commitment_start =
+                                        UPSTREAM_EXTRANONCE1_SIZE + PREFIX_BYTES_SIZE;
+                                    let commitment_end = commitment_start + COMMITMENT_SIZE;
+                                    if used_extranonce1.len() < commitment_end {
+                                        error!(
+                                            worker = %worker_name,
+                                            extranonce1_len = %used_extranonce1.len(),
+                                            required = %commitment_end,
+                                            "Extranonce1 too short"
+                                        );
+                                        return Err(StratumErrors::InvalidMethodParams {
+                                            method: "mining.submit: malformed extranonce1"
+                                                .to_string(),
+                                        });
+                                    }
+                                    let commitment = hex::encode(
+                                        &used_extranonce1[commitment_start..commitment_end],
+                                    );
+                                    format!("{}{}{}", hex::encode(prefix), commitment, extranonce2)
+                                } else {
+                                    extranonce2.to_string()
+                                };
+                                let upstream_share = crate::upstream_pool::UpstreamShare {
+                                    worker_name: worker_name.to_string(),
+                                    job_id: job_id_str.to_string(),
+                                    extranonce2: full_extranonce2,
+                                    ntime: ntime.to_string(),
+                                    nonce: nonce.to_string(),
+                                    version_bits: rolled_version_bits.map(String::from),
+                                    original_request_id: client_request_id,
+                                    share_id: share_id.clone(),
+                                };
+                                if let Err(e) = upstream_tx.send(upstream_share).await {
+                                    error!("Failed to forward to upstream: {}", e);
+                                    return Ok(StratumResponses::StandardResponse {
+                                        std_response: StandardResponse::new_ok(
+                                            Some(client_request_id),
+                                            json!(false),
+                                        ),
+                                    });
+                                } else {
+                                    return Ok(StratumResponses::StandardResponse {
+                                        std_response: StandardResponse::new_ok(
+                                            Some(client_request_id),
+                                            json!(true),
+                                        ),
+                                    });
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        warn!("Audit DAG rejected bead: {}", e);
+                        return Ok(StratumResponses::StandardResponse {
+                            std_response: StandardResponse::new_ok(
+                                Some(client_request_id),
+                                json!(false),
+                            ),
+                        });
+                    }
+                }
+            }
+            return Ok(StratumResponses::StandardResponse {
+                std_response: StandardResponse::new_ok(Some(client_request_id), json!(true)),
+            });
+        } else {
+            warn!("Share below minimum difficulty");
+            return Ok(StratumResponses::StandardResponse {
+                std_response: StandardResponse::new_ok(Some(client_request_id), json!(false)),
+            });
+        }
+    }
+
+    fn target_from_difficulty(difficulty: f64) -> bitcoin::Target {
+        if difficulty < 1.0 || !difficulty.is_finite() {
+            return bitcoin::Target::from_compact(bitcoin::CompactTarget::from_consensus(
+                0x1d00ffff,
+            ));
+        }
+
+        let diff1_target =
+            bitcoin::Target::from_compact(bitcoin::CompactTarget::from_consensus(0x1d00ffff));
+
+        let mut diff1_f64: f64 = 0.0;
+        let diff1_bytes = diff1_target.to_le_bytes();
+        for (i, byte) in diff1_bytes.iter().enumerate() {
+            diff1_f64 += (*byte as f64) * 256.0f64.powi(i as i32);
+        }
+
+        let new_target_val = diff1_f64 / difficulty;
+        let mut le_bytes = [0u8; 32];
+        let mut v = new_target_val;
+        for i in (0..32).rev() {
+            let power = 256.0f64.powi(i as i32);
+            let byte_val = (v / power).floor();
+            if byte_val >= 256.0 {
+                le_bytes[i] = 0xff;
+            } else {
+                le_bytes[i] = byte_val as u8;
+            }
+            v -= le_bytes[i] as f64 * power;
+        }
+        bitcoin::Target::from_le_bytes(le_bytes)
+    }
+
+    fn validate_share_against_target(block_hash: BlockHash, target: &bitcoin::Target) -> bool {
+        target.is_met_by(block_hash)
+    }
+
     /// Processes a `mining.set_difficulty` request from the client.
     ///
     /// Attempts to read a new difficulty value from the first element of the
@@ -1172,13 +1603,23 @@ impl DownstreamClient {
                 return Err(error);
             }
         };
+
+        let bitcoin_address = if let Some(dot_pos) = username.rfind('.') {
+            username[..dot_pos].to_string()
+        } else {
+            username.to_string()
+        };
+
+        self.payout_address = Some(bitcoin_address.clone());
         self.authorized = true;
         info!(
             connection_id = %format!("{:x}", self.connection_id()),
             username = %username,
+            payout_address = %bitcoin_address,
             "Miner authorized"
         );
-        let mut conn_map = connection_mapping.lock().await;
+        let mut conn_map: futures::lock::MutexGuard<'_, ConnectionMapping> =
+            connection_mapping.lock().await;
         conn_map.register_worker(peer_addr.clone(), username.to_string());
         drop(conn_map);
         info!("Registered worker '{}' for peer {}", username, peer_addr);
@@ -1475,7 +1916,7 @@ impl Default for DownstreamClient {
     fn default() -> Self {
         //ExtraNonce1. - Hex-encoded, per-connection unique string which will be used for creating generation transactions later.
         //4 bytes
-        let mut extranonce1_bytes = [0; 4];
+        let mut extranonce1_bytes = [0; UPSTREAM_EXTRANONCE1_SIZE];
         rand::thread_rng().fill_bytes(&mut extranonce1_bytes);
         let connection_id = rand::thread_rng().next_u32(); // FIXME use a counter here, not an RNG
                                                            // (will collide with 65k mining devices)
@@ -1494,6 +1935,7 @@ impl Default for DownstreamClient {
             //generating a random u32 client connection id
             connection_id,
             extranonce1: Vec::from(extranonce1_bytes),
+            extranonce_history: VecDeque::new(),
             version_rolling_mask: None,
             version_rolling_min_bit: None,
             extranonce2_len: EXTRANONCE2_SIZE,
@@ -1502,6 +1944,8 @@ impl Default for DownstreamClient {
             monitor_target: None,
             block_submission_tx: None,
             is_proxy_mode: false,
+            payout_address: None,
+            audit_miner_difficulty: 100.0,
         }
     }
 }
@@ -1537,6 +1981,9 @@ pub enum NotifyCmd {
     },
     BroadcastDifficulty {
         difficulty: f64,
+    },
+    UpdateExtranonce {
+        new_bead_hash: bitcoin::BlockHash,
     },
 }
 /// Represents a `mining.notify` job message in the Stratum protocol.
@@ -1904,37 +2351,32 @@ impl Notifier {
                 })?
             }
         };
-
-        // Reconstruct template from job notification
         let mut template = crate::stratum::BlockTemplate::default();
         template.bits = compact_bits;
-
-        // Parse version
         let version_u32 = u32::from_str_radix(&job_notification.version, 16).map_err(|e| {
             StratumErrors::InvalidMethodParams {
                 method: format!("Invalid version hex: {}", e),
             }
         })?;
         template.version = bitcoin::block::Version::from_consensus(version_u32 as i32);
-
-        // Parse and reverse prevhash
-        if let Ok(prevhash_bytes) = hex::decode(&job_notification.prevhash) {
-            if prevhash_bytes.len() != 32 {
+        match hex::decode(&job_notification.prevhash) {
+            Ok(bytes) => {
+                if bytes.len() == 32 {
+                    let mut hash_bytes = [0u8; 32];
+                    hash_bytes.copy_from_slice(&bytes);
+                    template.previousblockhash = bitcoin::BlockHash::from_byte_array(hash_bytes);
+                } else {
+                    return Err(StratumErrors::InvalidMethodParams {
+                        method: format!("Invalid prevhash length: {}", bytes.len()),
+                    });
+                }
+            }
+            Err(e) => {
                 return Err(StratumErrors::InvalidMethodParams {
-                    method: format!("Invalid prevhash length: {}", prevhash_bytes.len()),
+                    method: format!("Failed to decode prevhash: {}", e),
                 });
             }
-            let mut reversed = [0u8; 32];
-            for i in 0..32 {
-                reversed[i] = prevhash_bytes[31 - i];
-            }
-            template.previousblockhash = bitcoin::BlockHash::from_byte_array(reversed);
-        } else {
-            return Err(StratumErrors::InvalidMethodParams {
-                method: "Failed to decode prevhash".to_string(),
-            });
         }
-
         let unix_timestamp = u32::from_str_radix(&job_notification.ntime, 16).unwrap_or_else(|e| {
             warn!(
                 peer = %peer_addr,
@@ -1947,7 +2389,6 @@ impl Notifier {
                 .map(|d| d.as_secs() as u32)
                 .unwrap_or(0)
         });
-
         template.curtime = bitcoin::BlockTime::from_u32(unix_timestamp);
         let template_id = TemplateId::from_upstream_string(&job_notification.job_id);
         let job_details = crate::stratum::JobDetails {
@@ -1959,7 +2400,6 @@ impl Notifier {
             job_sent_time: unix_timestamp,
             is_upstream_job: true,
         };
-
         let upstream_job_id = curr_peer_mining_job_map
             .insert_upstream_job(
                 job_notification.job_id.clone(),
@@ -1967,7 +2407,6 @@ impl Notifier {
                 job_details,
             )
             .await;
-
         let job_notification_response = serde_json::json!({
             "method": "mining.notify",
             "params": [
@@ -1982,13 +2421,11 @@ impl Notifier {
                 job_notification.clean_jobs
             ]
         });
-
         let json_str = serde_json::to_string(&job_notification_response).map_err(|e| {
             StratumErrors::InvalidMethodParams {
                 method: format!("Failed to serialize job notification: {}", e),
             }
         })?;
-
         connection_entry
             .sender
             .send(json_str.clone())
@@ -1998,7 +2435,6 @@ impl Notifier {
                 msg: json_str,
                 msg_type: "UpstreamJob".to_string(),
             })?;
-
         info!(
             "Sent upstream job {} to {} (bits: {})",
             upstream_job_id, peer_addr, job_notification.nbits
@@ -2031,6 +2467,7 @@ impl Notifier {
         latest_template_merkle_branch_arc: &mut Arc<Mutex<Vec<Vec<u8>>>>,
         latest_template_id: Arc<Mutex<TemplateId>>,
         upstream_cache: Option<Arc<tokio::sync::RwLock<crate::upstream_pool::UpstreamCache>>>,
+        audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
     ) -> Result<(), StratumErrors> {
         debug!("Stratum notifier task started");
         while let Some(notification_command) = self.notification_receiver.recv().await {
@@ -2274,7 +2711,6 @@ impl Notifier {
                         current_template_id, new_downstream_addr
                     );
 
-                    let latest_template = latest_template_arc.lock().await.to_owned();
                     let latest_template_merkle_branch =
                         latest_template_merkle_branch_arc.lock().await.to_owned();
                     info!(
@@ -2394,10 +2830,50 @@ impl Notifier {
                                 job_notification.job_id
                             );
                             error!("   Raw nbits from upstream: '{}'", job_notification.nbits);
-                            // Don't broadcast invalid jobs, miners would submit unpayable shares
+                            // Don't broadcast invalid jobs, miners would submit invalid shares
                             continue;
                         }
                     };
+                    let mut base_template = crate::stratum::BlockTemplate::default();
+                    base_template.bits = compact_bits;
+                    if let Ok(version_u32) = u32::from_str_radix(&job_notification.version, 16) {
+                        base_template.version =
+                            bitcoin::block::Version::from_consensus(version_u32 as i32);
+                    }
+                    match hex::decode(&job_notification.prevhash) {
+                        Ok(bytes) => {
+                            if bytes.len() == 32 {
+                                let mut hash_bytes = [0u8; 32];
+                                hash_bytes.copy_from_slice(&bytes);
+                                base_template.previousblockhash =
+                                    bitcoin::BlockHash::from_byte_array(hash_bytes);
+                            } else {
+                                error!("Invalid upstream prevhash length: {}", bytes.len());
+                                continue;
+                            }
+                        }
+                        Err(e) => {
+                            error!("Failed to decode upstream prevhash in notifier: {}", e);
+                            continue;
+                        }
+                    }
+                    let unix_timestamp = match u32::from_str_radix(&job_notification.ntime, 16) {
+                        Ok(ts) => ts,
+                        Err(e) => {
+                            error!(
+                                job_id = %job_notification.job_id,
+                                ntime = %job_notification.ntime,
+                                error = %e,
+                                "Upstream job has malformed ntime, skipping broadcast to prevent invalid shares"
+                            );
+                            continue;
+                        }
+                    };
+                    let current_system_time = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as u32)
+                        .unwrap_or(0);
+                    base_template.curtime = bitcoin::BlockTime::from_u32(unix_timestamp);
 
                     let downstream_channel_mapping = downstream_connection_map
                         .lock()
@@ -2407,41 +2883,17 @@ impl Notifier {
 
                     let miner_count = downstream_channel_mapping.len();
                     if miner_count == 0 {
-                        // TODO: Implement the job caching logic
                         info!(
                             "No miners connected, caching job {} for future connections",
                             job_notification.job_id
                         );
                         continue;
                     }
-                    let unix_timestamp = std::time::SystemTime::now()
-                        .duration_since(std::time::UNIX_EPOCH)
-                        .map(|d| d.as_secs() as u32)
-                        .unwrap_or_else(|e| {
-                            error!("System time is before Unix epoch: {}", e);
-                            0u32
-                        });
 
                     // Broadcast to all connected miners
                     for (peer_addr, mining_job_arc) in self.job_map_arc.lock().await.iter() {
                         let mut curr_peer_mining_job_map = mining_job_arc.lock().await;
-                        let mut template = crate::stratum::BlockTemplate::default();
-                        template.bits = compact_bits;
-                        if let Ok(version_u32) = u32::from_str_radix(&job_notification.version, 16)
-                        {
-                            template.version =
-                                bitcoin::block::Version::from_consensus(version_u32 as i32);
-                        }
-                        if let Ok(prevhash_bytes) = hex::decode(&job_notification.prevhash) {
-                            if prevhash_bytes.len() == 32 {
-                                let mut reversed = [0u8; 32];
-                                for i in 0..32 {
-                                    reversed[i] = prevhash_bytes[31 - i];
-                                }
-                                let hash = bitcoin::BlockHash::from_byte_array(reversed);
-                                template.previousblockhash = hash;
-                            }
-                        }
+                        let template = base_template.clone();
                         let template_id =
                             TemplateId::from_upstream_string(&job_notification.job_id);
 
@@ -2454,7 +2906,7 @@ impl Notifier {
                             coinbase_witness_commitment: job_notification
                                 .coinbase_witness_commitment
                                 .clone(),
-                            job_sent_time: unix_timestamp,
+                            job_sent_time: current_system_time,
                             is_upstream_job: true,
                         };
 
@@ -2499,6 +2951,111 @@ impl Notifier {
                         }
                     }
                 }
+                NotifyCmd::UpdateExtranonce { new_bead_hash } => {
+                    info!(
+                        bead_hash = %new_bead_hash,
+                        "Updating extranonce1 for all miners with new bead commitment"
+                    );
+                    let (
+                        old_commitment_bytes,
+                        new_commitment,
+                        upstream_ext1_bytes,
+                        downstream_mapping,
+                        assigned_prefixes,
+                    ) = {
+                        let mut mapping = downstream_connection_map.lock().await;
+                        let old = mapping.current_bead_commitment.clone();
+                        mapping.update_bead_commitment(new_bead_hash);
+                        let new = mapping.get_current_bead_commitment();
+                        let upstream = if let Some(ref s) = mapping.upstream_extranonce1 {
+                            match hex::decode(s) {
+                                Ok(bytes) => Some(bytes),
+                                Err(e) => {
+                                    error!(error = %e, upstream = %s, "Failed to decode upstream extranonce");
+                                    None
+                                }
+                            }
+                        } else {
+                            None
+                        };
+                        let downstream = mapping.downstream_channel_mapping.clone();
+                        let prefixes = mapping.assigned_prefixes.clone();
+                        (old, new, upstream, downstream, prefixes)
+                    };
+
+                    if let Some(ref audit_dag_arc) = audit_dag {
+                        let mut dag = audit_dag_arc.lock().await;
+                        for (peer_addr, miner_state) in dag.miner_states.iter_mut() {
+                            if miner_state.current_commitment.commitment_bytes
+                                != new_commitment.as_slice()
+                            {
+                                miner_state.previous_commitment =
+                                    Some(miner_state.current_commitment.clone());
+                                miner_state.current_commitment =
+                                    crate::audit::AuditCommitment::from_hash_prefix(
+                                        &new_commitment,
+                                    );
+                                debug!(
+                                    peer = %peer_addr,
+                                    old = %hex::encode(&old_commitment_bytes),
+                                    new = %hex::encode(&new_commitment),
+                                    "Updated miner commitment with fallback"
+                                );
+                            } else {
+                                debug!(peer = %peer_addr, "Skipping duplicate commitment update");
+                            }
+                        }
+                    }
+
+                    if let Some(upstream_bytes) = upstream_ext1_bytes {
+                        let mut failed_peers = Vec::new();
+                        for (peer_addr, connection_entry) in downstream_mapping.iter() {
+                            if let Some(&prefix_u16) = assigned_prefixes.get(peer_addr) {
+                                let prefix_bytes = prefix_u16.to_be_bytes().to_vec();
+                                let mut new_extranonce1 = upstream_bytes.clone();
+                                new_extranonce1.extend_from_slice(&prefix_bytes);
+                                new_extranonce1.extend_from_slice(&new_commitment);
+
+                                let new_extranonce1_hex = hex::encode(&new_extranonce1);
+                                if let Err(e) = connection_entry.control_tx.try_send(
+                                    crate::stratum::ControlMsg::UpdateExtranonce(
+                                        new_extranonce1.clone(),
+                                    ),
+                                ) {
+                                    error!(peer = %peer_addr, "Failed to send internal control msg: {}. Flagging for disconnect.", e);
+                                    failed_peers.push(peer_addr.clone());
+                                    continue;
+                                }
+                                let set_extranonce_msg = serde_json::json!({
+                                    "id": null,
+                                    "method": "mining.set_extranonce",
+                                    "params": [new_extranonce1_hex, 1]
+                                });
+                                if let Err(e) = connection_entry
+                                    .sender
+                                    .try_send(serde_json::to_string(&set_extranonce_msg).unwrap())
+                                {
+                                    error!(peer = %peer_addr, "Miner buffer full or closed. Disconnecting: {}", e);
+                                    failed_peers.push(peer_addr.clone());
+                                } else {
+                                    info!(peer = %peer_addr, commitment = %hex::encode(&new_commitment), "Sent mining.set_extranonce");
+                                }
+                            }
+                        }
+                        if !failed_peers.is_empty() {
+                            let mut mapping = downstream_connection_map.lock().await;
+                            for peer in failed_peers {
+                                mapping.disconnect_peer(
+                                    &peer,
+                                    "Failed to update extranonce, stale connection",
+                                );
+                            }
+                        }
+                    } else {
+                        warn!("Cannot update extranonce, upstream not configured");
+                    }
+                }
+
                 NotifyCmd::BroadcastDifficulty { difficulty } => {
                     info!("Broadcasting difficulty {} to all miners", difficulty);
 
@@ -2546,12 +3103,16 @@ impl PrefixStats {
         (self.total_assigned as f64 / self.total_capacity as f64) * 100.0
     }
 }
+pub enum ControlMsg {
+    UpdateExtranonce(Vec<u8>),
+}
 
 ///Connection information associated with each downstream peer associated along with the mapped `Sender_channel` for sending downstream responses and communication.
 #[derive(Debug, Clone)]
 pub struct ConnectionInfo {
     pub connection_id: u32,
     pub sender: mpsc::Sender<String>,
+    pub control_tx: mpsc::Sender<ControlMsg>,
 }
 
 #[derive(Debug, Clone)]
@@ -2565,9 +3126,10 @@ pub struct ConnectionMapping {
     /// Counter for assigning unique extranonce2 prefixes in audit mode, wraps around at 65535 (2 bytes)
     next_extranonce2_prefix: u16,
     /// Track assigned prefixes to detect reuse, peer_addr -> prefix
-    assigned_prefixes: HashMap<String, u16>,
+    pub assigned_prefixes: HashMap<String, u16>,
     /// Pool of released prefixes available for reuse
     available_prefixes: std::collections::VecDeque<u16>,
+    pub current_bead_commitment: Vec<u8>,
 }
 
 impl ConnectionMapping {
@@ -2582,7 +3144,23 @@ impl ConnectionMapping {
             next_extranonce2_prefix: 1, // Start at 1, by design
             assigned_prefixes: HashMap::new(),
             available_prefixes: std::collections::VecDeque::new(),
+            current_bead_commitment: vec![0u8; COMMITMENT_SIZE],
         }
+    }
+
+    pub fn update_bead_commitment(&mut self, bead_hash: bitcoin::BlockHash) {
+        let hash_bytes = bead_hash.to_byte_array();
+        self.current_bead_commitment = hash_bytes[..COMMITMENT_SIZE].to_vec();
+        info!(
+            commitment = %hex::encode(&self.current_bead_commitment),
+            bead_hash = %bead_hash,
+            "Updated global bead commitment"
+        );
+    }
+
+    /// Get current bead commitment (used when assigning extranonce1 to new miners)
+    pub fn get_current_bead_commitment(&self) -> Vec<u8> {
+        self.current_bead_commitment.clone()
     }
 
     /// Allocate a unique 2-byte prefix for a new miner in audit mode
@@ -2605,10 +3183,12 @@ impl ConnectionMapping {
                 self.next_extranonce2_prefix = 1;
             }
 
-            if self.next_extranonce2_prefix > 60000 && self.available_prefixes.is_empty() {
+            if self.next_extranonce2_prefix > PREFIX_EXHAUSTION_WARNING_THRESHOLD
+                && self.available_prefixes.is_empty()
+            {
                 warn!(
                     used_prefixes = %self.next_extranonce2_prefix,
-                    total_capacity = 65535,
+                    total_capacity = PREFIX_MAX_VALUE,
                     "Approaching prefix exhaustion!"
                 );
             }
@@ -2619,8 +3199,8 @@ impl ConnectionMapping {
         let prefix_bytes = prefix.to_be_bytes().to_vec();
         let miner_size = self
             .upstream_extranonce2_size
-            .map(|size| size.saturating_sub(2))
-            .unwrap_or(6);
+            .expect("Upstream extranonce2 size must be set before allocating prefix")
+            .saturating_sub(PREFIX_BYTES_SIZE);
 
         debug!(
             prefix = %hex::encode(&prefix_bytes),
@@ -2654,7 +3234,7 @@ impl ConnectionMapping {
     /// Release a prefix back to the available pool when a miner disconnects
     fn release_prefix(&mut self, peer_addr: &str) {
         if let Some(prefix) = self.assigned_prefixes.remove(peer_addr) {
-            if prefix < 65000 {
+            if prefix < PREFIX_MAX_VALUE {
                 self.available_prefixes.push_back(prefix);
                 info!(
                     peer = %peer_addr,
@@ -2678,7 +3258,7 @@ impl ConnectionMapping {
             total_assigned: self.assigned_prefixes.len(),
             available_for_reuse: self.available_prefixes.len(),
             next_new_prefix: self.next_extranonce2_prefix,
-            total_capacity: 65535,
+            total_capacity: PREFIX_MAX_VALUE,
         }
     }
 
@@ -2815,12 +3395,14 @@ impl ConnectionMapping {
         peer_addr: String,
         connection_id: u32,
         peer_msg_sender: mpsc::Sender<String>,
+        control_tx: mpsc::Sender<ControlMsg>,
     ) {
         self.downstream_channel_mapping.insert(
             peer_addr,
             ConnectionInfo {
                 connection_id,
                 sender: peer_msg_sender,
+                control_tx,
             },
         );
     }
@@ -2930,7 +3512,7 @@ impl Server {
                                         info!("New audit mode connection using upstream extranonce: {}", upstream_ext1);
 
                                         // Allocate unique 2-byte prefix for this miner
-                                        let (prefix_bytes, miner_ext2_size) = mapping.allocate_extranonce2_prefix();
+                                        let (prefix_bytes, _miner_ext2_size) = mapping.allocate_extranonce2_prefix();
                                         let prefix_u16 = u16::from_be_bytes([prefix_bytes[0], prefix_bytes[1]]);
                                         mapping.register_prefix(peer_addr.to_string(), prefix_u16);
 
@@ -2944,6 +3526,46 @@ impl Server {
 
                                         let mut extended_extranonce1 = upstream_ext1_bytes;
                                         extended_extranonce1.extend_from_slice(&prefix_bytes);
+                                        let bead_hash_commitment = mapping.get_current_bead_commitment();
+                                        extended_extranonce1.extend_from_slice(&bead_hash_commitment);
+                                        let upstream_ext2_size = mapping.upstream_extranonce2_size.unwrap_or(8);
+                                        let miner_ext2_size = upstream_ext2_size
+                                            .saturating_sub(prefix_bytes.len())
+                                            .saturating_sub(bead_hash_commitment.len());
+
+                                        if miner_ext2_size < 1 {
+                                            error!(
+                                                "Insufficient extranonce space! Upstream: {}, Prefix: {}, Commitment: {}",
+                                                upstream_ext2_size,
+                                                prefix_bytes.len(),
+                                                bead_hash_commitment.len()
+                                            );
+                                            continue;
+                                        }
+
+                                        if let Some(ref dag) = audit_dag {
+                                            info!(
+                                                "Registering miner {} with prefix {} and commitment {} in AuditDAG",
+                                                peer_addr,
+                                                hex::encode(&prefix_bytes),
+                                                hex::encode(&bead_hash_commitment)
+                                            );
+                                            {
+                                                let mut dag_guard = dag.lock().await;
+                                                dag_guard.register_miner(peer_addr.to_string(), prefix_bytes.clone());
+                                                if let Some(miner_state) = dag_guard.miner_states.get_mut(&peer_addr.to_string()) {
+                                                    let commitment = crate::audit::AuditCommitment::from_hash_prefix(&bead_hash_commitment);
+                                                    miner_state.current_commitment = commitment;
+                                                    miner_state.previous_commitment = None;
+                                                    miner_state.commitment_pending = false;
+                                                } else {
+                                                    // If we can't register the miner, we must reject the connection.
+                                                    // Otherwise, they will mine "ghost/stale" shares that fail every audit.
+                                                    error!(peer = %peer_addr, "Failed to initialize AuditDAG state for miner. Rejecting.");
+                                                    continue;
+                                                }
+                                            }
+                                        }
 
                                         let stats = mapping.get_prefix_stats();
                                         debug!(
@@ -2975,6 +3597,7 @@ impl Server {
                                     (bytes.to_vec(), EXTRANONCE2_SIZE, None, false)
                                 }
                             };
+
                             // Create client with correct state
                             let downstream_client = Arc::new(Mutex::new(DownstreamClient {
                                 authorized: false,
@@ -2984,6 +3607,7 @@ impl Server {
                                 channel_configured: false,
                                 connection_id: rand::thread_rng().next_u32(),
                                 extranonce1: assigned_extranonce1,
+                                extranonce_history: VecDeque::new(),
                                 version_rolling_mask: None,
                                 version_rolling_min_bit: None,
                                 extranonce2_len: assigned_extranonce2_size,
@@ -2992,6 +3616,8 @@ impl Server {
                                 monitor_target: None,
                                 block_submission_tx: self.block_submission_tx.clone(),
                                 is_proxy_mode: is_proxy,
+                                payout_address: None,
+                                audit_miner_difficulty: self.stratum_config.audit_miner_difficulty,
                             }));
 
                          //Notification sender to the `Notifier` task
@@ -3002,11 +3628,12 @@ impl Server {
                          mining_job_map.lock().await.insert(peer_addr.to_string(), self_mining_map.clone());
                          //downstream channel for server2client communication to take place
                          let (downstream_tx,mut downstream_rx) = mpsc::channel(1024);
+                         let (control_tx, control_rx) = mpsc::channel(10);
                          //adding the new connection to the connection map
                          self.downstream_connection_mapping
                                     .lock()
                                     .await
-                                    .new_connection(peer_addr.to_string(), connection_id, downstream_tx.clone());
+                                    .new_connection(peer_addr.to_string(), connection_id, downstream_tx.clone(), control_tx,);
                          info!(
                                     connection_id = %connection_id_hex,
                                     peer = %peer_addr,
@@ -3025,7 +3652,7 @@ impl Server {
 
                             // catering each new connection as seperate process
                             tokio::spawn(async move{
-                                let _=  Self::handle_connection(downstream_client.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref,audit_dag_clone,upstream_share_tx_clone,connection_mapping_clone,upstream_configure_tx_clone,).await;
+                                let _=  Self::handle_connection(downstream_client.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref,audit_dag_clone,upstream_share_tx_clone,connection_mapping_clone,upstream_configure_tx_clone,control_rx,).await;
                                 debug!("Cleaning up disconnected miner: {}", peer_addr_string);
 
                                 // cleanup after connection closes, remove from connection mapping
@@ -3093,6 +3720,7 @@ impl Server {
         upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
         connection_mapping: Arc<Mutex<ConnectionMapping>>,
         upstream_configure_tx: Option<mpsc::Sender<(Value, u64, mpsc::Sender<Value>)>>,
+        mut control_rx: mpsc::Receiver<ControlMsg>,
     ) -> Result<(), Box<StratumErrors>> {
         const MAX_LINE_LENGTH: usize = 2_usize.pow(16);
         //It can be excessively inefficient to work directly with a AsyncRead instance. A BufReader performs large, infrequent reads on the underlying AsyncRead and maintains an in-memory buffer of the results.
@@ -3133,6 +3761,27 @@ impl Server {
                         }
                     }
                 }
+                ctrl_msg = control_rx.recv() => {
+                    match ctrl_msg {
+                        Some(ControlMsg::UpdateExtranonce(new_bytes)) => {
+                            // We are inside the miner's own task. We can lock quickly because we own this loop. This does not block the Notifier.
+                            let mut client = downstream_client.lock().await;
+                            let old_extranonce = client.extranonce1.clone();
+                            client.extranonce_history.push_front(old_extranonce);
+                            // This specify the size of extranonce commitment we need to track, so we can't forefully reject the shares
+                            // from the miner due to latency.
+                            if client.extranonce_history.len() > COMMITMENT_HISTORY_SIZE {
+                                client.extranonce_history.pop_back();
+                            }
+
+                            client.extranonce1 = new_bytes;
+                            debug!("Internal state updated, extranonce1 changed via control msg");
+                        }
+                        None => {
+                        }
+                    }
+                }
+
                 // Process incoming requests from miner
                 line = framed.next().fuse() => {
                     match line {
@@ -3244,6 +3893,162 @@ mod test {
     };
 
     #[tokio::test]
+    async fn test_connection_mapping_prefix_allocation() {
+        let mut mapping = ConnectionMapping::new();
+
+        mapping.set_upstream_extranonce("aabbccdd".to_string(), 8);
+
+        // Allocate multiple prefixes
+        let (prefix1, size1) = mapping.allocate_extranonce2_prefix();
+        let (prefix2, size2) = mapping.allocate_extranonce2_prefix();
+        let (prefix3, size3) = mapping.allocate_extranonce2_prefix();
+
+        // Each prefix should be unique
+        assert_ne!(prefix1, prefix2, "Prefixes should be unique");
+        assert_ne!(prefix2, prefix3, "Prefixes should be unique");
+        assert_ne!(prefix1, prefix3, "Prefixes should be unique");
+
+        assert_eq!(size1, size2);
+        assert_eq!(size2, size3);
+    }
+
+    #[tokio::test]
+    async fn test_connection_mapping_prefix_reuse() {
+        let mut mapping = ConnectionMapping::new();
+        mapping.set_upstream_extranonce("aabbccdd".to_string(), 8);
+
+        // Allocate and register a prefix
+        let (prefix1, _) = mapping.allocate_extranonce2_prefix();
+        let prefix1_u16 = u16::from_be_bytes([prefix1[0], prefix1[1]]);
+        mapping.register_prefix("peer1".to_string(), prefix1_u16);
+
+        // Get stats before release
+        let stats_before = mapping.get_prefix_stats();
+        assert_eq!(stats_before.total_assigned, 1);
+        assert_eq!(stats_before.available_for_reuse, 0);
+
+        // Release the prefix
+        mapping.remove_peer("peer1");
+
+        // Get stats after release
+        let stats_after = mapping.get_prefix_stats();
+        assert_eq!(stats_after.total_assigned, 0);
+        assert_eq!(stats_after.available_for_reuse, 1);
+
+        // Allocate again, this should reuse the released prefix
+        let (prefix2, _) = mapping.allocate_extranonce2_prefix();
+        assert_eq!(prefix1, prefix2, "Should reuse released prefix");
+    }
+
+    #[tokio::test]
+    async fn test_mining_job_map_operations() {
+        let mut job_map = MiningJobMap::new();
+
+        // Create test job details
+        let template = BlockTemplate::default();
+        let job_details = JobDetails {
+            blocktemplate: template,
+            coinbase1: "test_coinbase1".to_string(),
+            coinbase2: "test_coinbase2".to_string(),
+            coinbase_merkle_path: vec![],
+            coinbase_witness_commitment: None,
+            job_sent_time: 1234567890,
+            is_upstream_job: false,
+        };
+
+        // Insert Braidpool job
+        let job_id = job_map
+            .insert_mining_job(TemplateId::Braidpool(1), job_details.clone())
+            .await;
+        assert_eq!(job_id, 0, "First job ID should be 0");
+
+        // Retrieve by job_id
+        let retrieved = job_map.get_by_job_id(job_id);
+        assert!(retrieved.is_ok(), "Should retrieve inserted job");
+
+        // Retrieve by template_id
+        let retrieved_by_template = job_map.get_by_template_id(&TemplateId::Braidpool(1));
+        assert!(
+            retrieved_by_template.is_ok(),
+            "Should retrieve by template_id"
+        );
+
+        // Insert another job
+        let job_id_2 = job_map
+            .insert_mining_job(TemplateId::Braidpool(2), job_details.clone())
+            .await;
+        assert_eq!(job_id_2, 1, "Second job ID should be 1");
+    }
+
+    #[tokio::test]
+    async fn test_upstream_job_storage() {
+        let mut job_map = MiningJobMap::new();
+
+        let template = BlockTemplate::default();
+        let job_details = JobDetails {
+            blocktemplate: template,
+            coinbase1: "upstream_coinbase1".to_string(),
+            coinbase2: "upstream_coinbase2".to_string(),
+            coinbase_merkle_path: vec![],
+            coinbase_witness_commitment: None,
+            job_sent_time: 1234567890,
+            is_upstream_job: true,
+        };
+
+        // Insert upstream job with string ID
+        let upstream_id = "upstream_job_abc123";
+        let returned_id = job_map
+            .insert_upstream_job(
+                upstream_id.to_string(),
+                TemplateId::from_upstream_string(upstream_id),
+                job_details.clone(),
+            )
+            .await;
+
+        assert_eq!(
+            returned_id, upstream_id,
+            "Should return same upstream job ID"
+        );
+
+        // Retrieve by string job_id
+        let retrieved = job_map.get_by_string_job_id(upstream_id);
+        assert!(
+            retrieved.is_ok(),
+            "Should retrieve upstream job by string ID"
+        );
+
+        let (retrieved_job, retrieved_template_id) = retrieved.unwrap();
+        assert!(
+            retrieved_job.is_upstream_job,
+            "Job should be marked as upstream"
+        );
+    }
+
+    #[test]
+    fn test_difficulty_100_conversion() {
+        let difficulty = 100.5;
+        let target_100 = DownstreamClient::target_from_difficulty(difficulty);
+
+        let compact_100 = target_100.to_compact_lossy();
+        println!("--- Difficulty 100.0 Test ---");
+        println!("Difficulty: {}", difficulty);
+        println!("Target (Hex): {}", target_100.to_hex());
+        println!("Target (nBits): {:#x}", compact_100.to_consensus());
+
+        let expected_prefix = "00000000028c";
+        let actual_hex = target_100.to_hex();
+
+        assert!(
+            actual_hex.starts_with(expected_prefix),
+            "Target for Diff 100 should start with {}, got {}",
+            expected_prefix,
+            actual_hex
+        );
+
+        println!("Assertion Passed: Target matches expected value for Diff 100.");
+    }
+
+    #[tokio::test]
     pub async fn server_start_test() {
         let ibd_or_not: AtomicBool = AtomicBool::new(false);
         let test_ibd_spinlock = Arc::new(ibd_or_not);
@@ -3267,7 +4072,7 @@ mod test {
 
         let server_task = tokio::spawn(async move {
             let _ = server
-                .run_stratum_service(    
+                .run_stratum_service(
                     mining_job_map,
                     notify_tx,
                     swarm_handler_arc,
@@ -3673,6 +4478,7 @@ mod test {
                 swarm_handler_arc,
                 None,
                 None,
+                None, // Add upstream_difficulty argument
             )
             .await
             .unwrap();

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -112,6 +112,8 @@ pub struct StratumServerConfig {
     pub maximum_difficulty: Option<u64>,
     /// Optional payout address for solo mining mode.
     pub solo_address: Option<String>,
+    /// Indicate for audit mode
+    pub audit_mode: bool,
 }
 
 impl Default for StratumServerConfig {
@@ -124,6 +126,7 @@ impl Default for StratumServerConfig {
             minimum_difficulty: 1,
             maximum_difficulty: None,
             solo_address: None,
+            audit_mode: false,
         }
     }
 }
@@ -153,6 +156,7 @@ pub enum StratumResponses {
     SuggestDifficultyResponse {
         suggest_difficulty_resp: SuggestDifficultyResponse,
     },
+    PendingUpstreamResponse,
 }
 /// Response represents a Stratum response message from the server to the client
 /// We use Value in result to allow for different types of responses.
@@ -214,6 +218,8 @@ pub struct DownstreamClient {
     pub monitor_target: Option<bitcoin::Target>,
     /// channel for sending valid block submissions from miners to the block submission handler.
     pub block_submission_tx: Option<mpsc::UnboundedSender<BlockSubmissionRequest>>,
+    /// Indicates whether this downstream client is operating in proxy/audit mode (connected via an upstream pool).
+    pub is_proxy_mode: bool,
 }
 impl DownstreamClient {
     /// A helper function to keep connection_id immutable after assignment
@@ -243,17 +249,32 @@ impl DownstreamClient {
         notification_sender: mpsc::Sender<NotifyCmd>,
         peer_addr: String,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
+        audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
+        upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
+        connection_mapping: Arc<Mutex<ConnectionMapping>>,
+        upstream_configure_tx: Option<mpsc::Sender<(Value, u64, mpsc::Sender<Value>)>>,
     ) -> Result<StratumResponses, StratumErrors> {
         let req_params = client_request.params;
         let method = client_request.method.clone();
         let client_request_id = client_request.id;
         let connection_id_hex = format!("{:x}", self.connection_id());
         let response_or_error = match method.as_ref() {
-            "mining.configure" => self.handle_configure(&req_params, client_request_id).await,
+            "mining.configure" => {
+                self.handle_configure(&req_params, client_request_id, upstream_configure_tx)
+                    .await
+            }
             "mining.subscribe" => {
                 Self::handle_subscribe(self, &req_params, client_request_id).await
             }
-            "mining.authorize" => self.handle_authorize(&req_params, client_request_id).await,
+            "mining.authorize" => {
+                self.handle_authorize(
+                    &req_params,
+                    client_request_id,
+                    connection_mapping.clone(),
+                    peer_addr.clone(),
+                )
+                .await
+            }
             "mining.submit" => {
                 Self::handle_submit(
                     self,
@@ -261,6 +282,8 @@ impl DownstreamClient {
                     mining_job_map,
                     client_request_id,
                     swarm_handler,
+                    audit_dag,
+                    upstream_share_tx,
                 )
                 .await
             }
@@ -271,6 +294,16 @@ impl DownstreamClient {
         };
         match response_or_error {
             Ok(stratum_response) => {
+                match &stratum_response {
+                    StratumResponses::PendingUpstreamResponse => {
+                        info!(
+                            "Share forwarded to upstream, response pending (request_id={})",
+                            client_request_id
+                        );
+                        return Ok(stratum_response);
+                    }
+                    _ => {}
+                }
                 let response_json_string = match stratum_response.clone() {
                     StratumResponses::StandardResponse { std_response } => {
                         serde_json::to_string(&std_response).map_err(|e| {
@@ -282,12 +315,11 @@ impl DownstreamClient {
                     }
                     StratumResponses::SuggestDifficultyResponse {
                         suggest_difficulty_resp,
-                    } => serde_json::to_string(&suggest_difficulty_resp).map_err(|e| {
-                        error!(error = %e, "Failed to serialize suggest difficulty response");
-                        StratumErrors::InvalidMethod {
-                            method: "serialization_error".to_string(),
-                        }
-                    })?,
+                    } => serde_json::to_string(&suggest_difficulty_resp).unwrap(),
+                    StratumResponses::PendingUpstreamResponse => {
+                        // Already handled above, this shouldn't be reached
+                        return Ok(stratum_response);
+                    }
                 };
                 debug!(
                     connection_id = %connection_id_hex,
@@ -310,7 +342,30 @@ impl DownstreamClient {
                         );
                     }
                 };
-                //Sending the initial latest avaialble template to the recently subscribed and authorized
+
+                if method == "mining.subscribe" {
+                    let upstream_diff = {
+                        let mapping = connection_mapping.lock().await;
+                        mapping.upstream_difficulty
+                    }; // Lock is always dropped here
+
+                    if let Some(diff) = upstream_diff {
+                        let set_difficulty_msg = serde_json::json!({
+                            "method": "mining.set_difficulty",
+                            "params": [diff]
+                        });
+
+                        if let Err(e) = response_message_sender
+                            .send(serde_json::to_string(&set_difficulty_msg).unwrap())
+                            .await
+                        {
+                            error!("Failed to send upstream difficulty to miner: {}", e);
+                        } else {
+                            info!("Sent upstream difficulty {} to miner {}", diff, peer_addr);
+                        }
+                    }
+                }
+                //Sending the initial latest available template to the recently subscribed and authorized
                 //downstream connection
                 if self.authorized == true
                     && self.subscribed == true
@@ -385,6 +440,8 @@ impl DownstreamClient {
         mining_job_map: Arc<Mutex<MiningJobMap>>,
         client_request_id: u64,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
+        audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
+        upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
     ) -> Result<StratumResponses, StratumErrors> {
         let connection_id_hex = format!("{:x}", self.connection_id());
         let param_array = match submit_work_params.as_array() {
@@ -420,6 +477,15 @@ impl DownstreamClient {
             worker = %worker_name,
             "Mining worker connected"
         );
+        if !self.authorized {
+            warn!(
+                "Miner {} tried to submit without authorization",
+                worker_name
+            );
+            return Err(StratumErrors::InvalidMethodParams {
+                method: "mining.submit".to_string(),
+            });
+        }
 
         // Parse hex job_id (sent by miner)
         let job_id_str = match param_array.get(1).and_then(|v| v.as_str()) {
@@ -432,17 +498,6 @@ impl DownstreamClient {
             }
         };
 
-        // Parse the job_id string from the miner into a numeric u64 job ID,
-        // If parsing fails, return a descriptive error for invalid job_id.
-        let numeric_job_id = match job_id_str.parse::<u64>() {
-            Ok(id) => id,
-            Err(e) => {
-                return Err(StratumErrors::JobIdCouldNotBeParsed {
-                    method: "mining.submit".to_string(),
-                    error: format!("Invalid job_id: {}", e),
-                });
-            }
-        };
         let extranonce2: &str = match param_array.get(2).and_then(|v| v.as_str()) {
             Some(extra) => extra,
             None => {
@@ -452,6 +507,34 @@ impl DownstreamClient {
                 })
             }
         };
+        let expected_hex_len = self.extranonce2_len * 2;
+        if extranonce2.len() != expected_hex_len {
+            error!(
+                "Miner {} submitted extranonce2 '{}' with wrong length: expected {} hex chars, got {}",
+                worker_name,
+                extranonce2,
+                expected_hex_len,
+                extranonce2.len()
+            );
+            return Err(StratumErrors::InvalidMethodParams {
+                method: format!(
+                    "mining.submit: extranonce2 must be {} hex chars ({} bytes), got {}",
+                    expected_hex_len,
+                    self.extranonce2_len,
+                    extranonce2.len()
+                ),
+            });
+        }
+
+        if hex::decode(extranonce2).is_err() {
+            error!(
+                "Miner {} submitted invalid hex extranonce2: '{}'",
+                worker_name, extranonce2
+            );
+            return Err(StratumErrors::InvalidMethodParams {
+                method: "mining.submit: extranonce2 is not valid hex".to_string(),
+            });
+        }
 
         let ntime: &str = match param_array.get(3).and_then(|v| v.as_str()) {
             Some(nt) => nt,
@@ -473,14 +556,117 @@ impl DownstreamClient {
             }
         };
         //Acquiring lock on the mining map and fetching the submitted job from the memory
-        let job_mapping = mining_job_map.lock().await;
-        let submitted_job = job_mapping.get_by_job_id(numeric_job_id).await?;
-        let template_id = job_mapping
-            .template_id_from_job_id(numeric_job_id)
-            .ok_or_else(|| StratumErrors::MiningJobNotFound {
-                job_id: Some(numeric_job_id),
-                template_id: None,
-            })?;
+        let (submitted_job, template_id) = {
+            let job_mapping = mining_job_map.lock().await;
+
+            // Try string lookup first (upstream jobs)
+            if let Ok((job, tid)) = job_mapping.get_by_string_job_id(job_id_str) {
+                info!(
+                    jobid = job_id_str,
+                    mode = "upstream",
+                    "Found job by string ID"
+                );
+                (job.clone(), tid.clone())
+            } else {
+                // Fall back to numeric parsing (Braidpool jobs)
+                let numeric_job_id = match job_id_str.parse::<u64>() {
+                    Ok(id) => id,
+                    Err(_) => {
+                        match u64::from_str_radix(job_id_str, 16) {
+                            Ok(id) => id,
+                            Err(e) => {
+                                return Err(StratumErrors::JobIdCouldNotBeParsed {
+                                    method: "mining.submit".to_string(),
+                                    error: format!("Invalid job_id (not valid decimal, hex, or upstream): {}, {}", job_id_str, e),
+                                });
+                            }
+                        }
+                    }
+                };
+                info!(
+                    jobid = numeric_job_id,
+                    mode = "braidpool",
+                    "Found job by numeric ID"
+                );
+                let job = job_mapping.get_by_job_id(numeric_job_id)?.clone();
+                let templateid = job_mapping
+                    .template_id_from_job_id(numeric_job_id)
+                    .ok_or_else(|| StratumErrors::MiningJobNotFound {
+                        job_id: Some(numeric_job_id),
+                        template_id: None,
+                    })?;
+                (job, templateid)
+            }
+        };
+
+        if submitted_job.is_upstream_job {
+            info!("Forwarding upstream job share from {}", worker_name);
+
+            let share_id = crate::audit::ShareId::from_share(
+                job_id_str,
+                extranonce2,
+                nonce,
+                ntime,
+                worker_name,
+            );
+            // Record in audit record
+            // Note: For now its only adding entry one-by-one in records without any DAG, this feature does not represent the final audit records, it's just the
+            // initial way of showing things, subsequent changes will use proper DAG based auditing and validation of shares.
+            // TODO: Implement DAG based auditing
+            if let Some(ref audit_dag_arc) = audit_dag {
+                let audit_record = crate::audit::AuditRecord {
+                    share_id: share_id.clone(),
+                    timestamp: std::time::SystemTime::now(),
+                    miner_ip: self.downstream_ip.clone(),
+                    worker_name: worker_name.to_string(),
+                    job_id: job_id_str.to_string(),
+                    share_difficulty: submitted_job.blocktemplate.bits,
+                    extranonce2: extranonce2.to_string(),
+                    nonce: nonce.to_string(),
+                    ntime: ntime.to_string(),
+                    block_hash: None,
+                    valid: true,
+                    upstream_accepted: None,
+                    parent_shares: vec![],
+                };
+
+                let mut dag = audit_dag_arc.lock().await;
+                match dag.add_record(audit_record).await {
+                    Ok(id) => info!("Recorded share {} in audit DAG", id),
+                    Err(e) => warn!("Failed to record audit entry: {}", e),
+                }
+            }
+
+            // Forward to upstream without validation
+            // TODO: Implement validation logic.
+            if let Some(ref upstream_tx) = upstream_share_tx {
+                let upstream_share = crate::upstream_pool::UpstreamShare {
+                    worker_name: worker_name.to_string(),
+                    job_id: job_id_str.to_string(),
+                    extranonce2: extranonce2.to_string(),
+                    ntime: ntime.to_string(),
+                    nonce: nonce.to_string(),
+                    version_bits: param_array
+                        .get(5)
+                        .and_then(|v| v.as_str())
+                        .map(String::from),
+                    original_request_id: client_request_id,
+                };
+                info!(
+                    "Forwarding share to upstream pool (worker: {}, job: {})",
+                    worker_name, job_id_str
+                );
+
+                if let Err(e) = upstream_tx.send(upstream_share).await {
+                    error!("Failed to forward share to upstream: {}", e);
+                    return Err(StratumErrors::UpstreamShareForwardFailed {
+                        error: e.to_string(),
+                    });
+                }
+            }
+            return Ok(StratumResponses::PendingUpstreamResponse);
+        }
+
         //Building the coinbase and then eventually the block and testing for the validation against the
         //mainnet/regtest/cpunet/testnet difficulty or the weakshare local difficulty .
         let extranonce_1_hex = hex::encode(self.extranonce1.clone());
@@ -571,27 +757,29 @@ impl DownstreamClient {
 
             // Mask set during mining.configure
             let mut mask_bytes = [0u8; 4];
-            let version_rolling_mask_str = match self.version_rolling_mask.clone() {
-                Some(mask) => mask,
+            let version_rolling_mask = match self.version_rolling_mask.clone() {
+                Some(mask_str) => match u32::from_str_radix(&mask_str, 16) {
+                    Ok(mask) => mask,
+                    Err(e) => {
+                        error!(
+                            "Failed to parse version_rolling_mask '{}' as hex: {}",
+                            mask_str, e
+                        );
+                        return Err(StratumErrors::ParsingVersionMask {
+                            error: format!("Invalid hex mask '{}': {}", mask_str, e),
+                        });
+                    }
+                },
                 None => {
-                    error!(connection_id = %connection_id_hex, "Version rolling mask not set");
+                    error!("Version rolling submitted but no mask was configured");
                     return Err(StratumErrors::ParsingVersionMask {
-                        error: "Version rolling mask not configured".to_string(),
-                    });
-                }
-            };
-            let version_rolling_mask = match version_rolling_mask_str.parse::<u32>() {
-                Ok(version_mask) => version_mask,
-                Err(error) => {
-                    return Err(StratumErrors::ParsingVersionMask {
-                        error: error.to_string(),
+                        error: "No version rolling mask configured".to_string(),
                     });
                 }
             };
 
             let version_rolling_mask_bytes = version_rolling_mask.to_be_bytes();
             let version_rolling_mask_hex = hex::encode(version_rolling_mask_bytes);
-
             info!(
                 connection_id = %connection_id_hex,
                 version_mask = ?version_rolling_mask_hex,
@@ -612,7 +800,7 @@ impl DownstreamClient {
                     });
                 }
             }
-            let mask_version_bits = i32::from_be_bytes(mask_bytes);
+            let mask_version_bits = version_rolling_mask as i32;
             let precondition = version_bits & !mask_version_bits;
             if precondition != 0 {
                 return Err(StratumErrors::MaskNotValid {
@@ -692,7 +880,7 @@ impl DownstreamClient {
             None => {
                 error!(
                     connection_id = %connection_id_hex,
-                    job_id = %numeric_job_id,
+                    job_id = job_id_str,
                     "Job missing witness commitment"
                 );
                 return Err(StratumErrors::InvalidCoinbase);
@@ -732,7 +920,7 @@ impl DownstreamClient {
                 // If valid block found, send to submission channel
                 if let Some(ref submission_tx) = self.block_submission_tx {
                     let submission = BlockSubmissionRequest {
-                        template_id,
+                        template_id: template_id.clone(),
                         header: header.clone(),
                         coinbase_transaction: coinbase_tx_for_submission.clone(),
                     };
@@ -811,7 +999,7 @@ impl DownstreamClient {
             Ok(_) => {
                 info!(
                     connection_id = %connection_id_hex,
-                    job_id = %numeric_job_id,
+                    job_id = job_id_str,
                     template_id = %template_id,
                     peer = %self.downstream_ip,
                     "Candidate block submitted"
@@ -877,12 +1065,12 @@ impl DownstreamClient {
         &mut self,
         authorize_request_params: &Value,
         client_request_id: u64,
+        connection_mapping: Arc<Mutex<ConnectionMapping>>,
+        peer_addr: String,
     ) -> Result<StratumResponses, StratumErrors> {
-        let connection_id_hex = format!("{:x}", self.connection_id());
-        debug!(
-            connection_id = %connection_id_hex,
-            params = ?authorize_request_params,
-            "Authorization request"
+        info!(
+            "Authorization is taking place -- {:?}",
+            authorize_request_params
         );
         let param_array = match authorize_request_params.as_array() {
             Some(param_array) => param_array,
@@ -913,20 +1101,17 @@ impl DownstreamClient {
                 return Err(error);
             }
         };
-        // Validate password parameter exists (but don't log it)
-        if param_array.get(1).is_none() {
-            return Err(StratumErrors::ParamNotFound {
-                param: "password".to_string(),
-                method: "mining.authorize".to_string(),
-            });
-        }
-
         self.authorized = true;
         info!(
-            connection_id = %connection_id_hex,
+            connection_id = %format!("{:x}", self.connection_id()),
             username = %username,
             "Miner authorized"
         );
+        let mut conn_map = connection_mapping.lock().await;
+        conn_map.register_worker(peer_addr.clone(), username.to_string());
+        drop(conn_map);
+        info!("Registered worker '{}' for peer {}", username, peer_addr);
+
         Ok(StratumResponses::StandardResponse {
             std_response: (StandardResponse {
                 id: Some(client_request_id),
@@ -945,13 +1130,82 @@ impl DownstreamClient {
         &mut self,
         config_req_params: &Value,
         client_request_id: u64,
+        upstream_configure_tx: Option<mpsc::Sender<(Value, u64, mpsc::Sender<Value>)>>,
     ) -> Result<StratumResponses, StratumErrors> {
         let connection_id_hex = format!("{:x}", self.connection_id());
         info!(
-            connection_id = %connection_id_hex,
-            params = ?config_req_params,
-            "Configuration handling is taking place"
+            "{:?} configuration handling is taking place",
+            config_req_params
         );
+        match &upstream_configure_tx {
+            Some(_) => debug!("Audit mode: upstream_configure_tx available"),
+            None => warn!("No upstream_configure_tx, using local handling"),
+        }
+        if let Some(ref upstream_tx) = upstream_configure_tx {
+            debug!("Forwarding mining.configure to upstream pool");
+            let (response_tx, mut response_rx) = mpsc::channel(1);
+
+            // Send configure request to upstream handler
+            if let Err(e) = upstream_tx
+                .send((config_req_params.clone(), client_request_id, response_tx))
+                .await
+            {
+                error!("Failed to forward configure to upstream: {}", e);
+                return Err(StratumErrors::UpstreamShareForwardFailed {
+                    error: e.to_string(),
+                });
+            }
+
+            // Wait for upstream response with some timeout
+            match tokio::time::timeout(std::time::Duration::from_secs(10), response_rx.recv()).await
+            {
+                Ok(Some(response)) => {
+                    info!("Received upstream configure response: {:?}", response);
+
+                    // Store upstream's version rolling mask if present
+                    if let Some(result) = response.get("result").and_then(|r| r.as_object()) {
+                        if let Some(mask) =
+                            result.get("version-rolling.mask").and_then(|m| m.as_str())
+                        {
+                            self.version_rolling_mask = Some(mask.to_string());
+                            info!("Using upstream version_rolling_mask: {}", mask);
+                        }
+                        if let Some(min_bits) = result.get("version-rolling.min-bit-count") {
+                            if let Some(count) = min_bits.as_u64() {
+                                self.version_rolling_min_bit = Some(count as u32);
+                            }
+                        }
+                    }
+
+                    self.channel_configured = true;
+
+                    // Forward upstream response to miner
+                    return Ok(StratumResponses::StandardResponse {
+                        std_response: StandardResponse {
+                            id: Some(client_request_id),
+                            result: response.get("result").cloned(),
+                            error: response
+                                .get("error")
+                                .and_then(|e| e.as_str())
+                                .map(String::from),
+                        },
+                    });
+                }
+                Ok(None) => {
+                    error!("Upstream configure channel closed");
+                    return Err(StratumErrors::UpstreamShareForwardFailed {
+                        error: "Upstream channel closed".to_string(),
+                    });
+                }
+                Err(_) => {
+                    error!("Upstream configure request timed out");
+                    return Err(StratumErrors::UpstreamShareForwardFailed {
+                        error: "Timeout waiting for upstream response".to_string(),
+                    });
+                }
+            }
+        }
+
         let params = match config_req_params.as_array() {
             Some(param_array) => param_array,
             None => {
@@ -1032,28 +1286,34 @@ impl DownstreamClient {
             //Intersecting with the bits provided by the pool and miner's suggested one
             let final_rollable_version_bits = u32::from_be_bytes(mask_bytes) & 0x1FFFE000;
             // `0x1FFFE000` is a reasonable default as it allows all 16 version bits to be used
-            let hex_str = u32::to_string(&final_rollable_version_bits);
-            self.version_rolling_mask = Some(hex_str);
+            self.version_rolling_mask = Some(format!("{:08x}", final_rollable_version_bits));
+            info!(
+                "Set version_rolling_mask: {:08x}",
+                final_rollable_version_bits
+            );
         }
         if let Some(min_bit_count_value) = version_rolling_min_bit_count {
-            let mut mask_bytes: [u8; 4] = [0u8; 4];
-            let version_rolling_min_bit_count_str = match min_bit_count_value.as_str() {
-                Some(s) => s,
-                None => {
-                    return Err(StratumErrors::VersionrollingMinBitCountHexParseError {
-                        error: "version-rolling.min-bit-count is not a string".to_string(),
-                    });
+            if let Some(count) = min_bit_count_value.as_u64() {
+                self.version_rolling_min_bit = Some(count as u32);
+                debug!("Parsed min-bit-count as number: {}", count);
+            } else if let Some(count_str) = min_bit_count_value.as_str() {
+                let mut mask_bytes: [u8; 4] = [0u8; 4];
+                match hex::decode_to_slice(count_str, &mut mask_bytes) {
+                    Ok(_) => {
+                        self.version_rolling_min_bit = Some(u32::from_be_bytes(mask_bytes));
+                        debug!("Parsed min-bit-count as hex string: {}", count_str);
+                    }
+                    Err(error) => {
+                        return Err(StratumErrors::VersionrollingMinBitCountHexParseError {
+                            error: error.to_string(),
+                        });
+                    }
                 }
-            };
-            match hex::decode_to_slice(version_rolling_min_bit_count_str, &mut mask_bytes) {
-                Ok(_) => {}
-                Err(error) => {
-                    return Err(StratumErrors::VersionrollingMinBitCountHexParseError {
-                        error: error.to_string(),
-                    });
-                }
-            };
-            self.version_rolling_min_bit = Some(u32::from_be_bytes(mask_bytes));
+            } else {
+                return Err(StratumErrors::VersionrollingMinBitCountHexParseError {
+                    error: "min-bit-count must be a number or hex string".to_string(),
+                });
+            }
         }
         self.channel_configured = true;
         Ok(StratumResponses::StandardResponse {
@@ -1100,20 +1360,24 @@ impl DownstreamClient {
         subscribe_req_params: &Value,
         client_request_id: u64,
     ) -> Result<StratumResponses, StratumErrors> {
-        info!(
-            connection_id = %format!("{:x}", self.connection_id()),
-            params = ?subscribe_req_params,
-            "Miner subscribing"
-        );
-        //TODO: dummy testing subscription IDs must be unique though can be changed accordingly these are just dummy values
+        info!("Subscribing is taking place -- {:?}", subscribe_req_params);
+
         let subscriptions: Vec<(String, String)> = vec![
             (String::from("mining.set_difficulty"), String::from("34")),
             (String::from("mining.notify"), String::from("12")),
         ];
         self.subscribed = true;
-        /* 16 is the default since that is the only value the
-         * pool supports currently  As per SV2 */
-        let extranonce1_hex_str = hex::encode(self.extranonce1.clone());
+        let extranonce1_hex_str = hex::encode(&self.extranonce1);
+        info!(
+            "Subscribe response: mode={}, extranonce1={}, extranonce2_size={}",
+            if self.is_proxy_mode {
+                "AUDIT"
+            } else {
+                "BRAIDPOOL"
+            },
+            extranonce1_hex_str,
+            self.extranonce2_len
+        );
         Ok(StratumResponses::StandardResponse {
             std_response: StandardResponse::new_ok(
                 Some(client_request_id),
@@ -1151,6 +1415,7 @@ impl Default for DownstreamClient {
             extranonce2_len: EXTRANONCE2_SIZE,
             monitor_target: None,
             block_submission_tx: None,
+            is_proxy_mode: false,
         }
     }
 }
@@ -1181,6 +1446,12 @@ pub enum NotifyCmd {
     SendLatestTemplateToNewDownstream {
         new_downstream_addr: String,
     },
+    SendUpstreamJob {
+        job_notification: crate::stratum::JobNotification,
+    },
+    BroadcastDifficulty {
+        difficulty: f64,
+    },
 }
 /// Represents a `mining.notify` job message in the Stratum protocol.
 ///
@@ -1210,6 +1481,7 @@ pub struct JobNotification {
     pub ntime: String,
     pub clean_jobs: bool,
     pub coinbase_witness_commitment: Option<Witness>,
+    pub parsed_bits: Option<bitcoin::CompactTarget>,
 }
 ///`JobDetails` which are required for tracking of the jobs available to each downstream node
 /// which is required during the job validation during `mining.submit` from the downstream node .
@@ -1222,6 +1494,7 @@ pub struct JobDetails {
     pub coinbase_witness_commitment: Option<Witness>,
     //Unix timestamp at which current job was sent to downstream miner
     pub job_sent_time: u32,
+    pub is_upstream_job: bool,
 }
 ///Struct storing all the jobs mapped accroding to the job id
 /// it will serve the purpose for maintaining the details received from the downstream as well as other
@@ -1236,6 +1509,8 @@ pub struct MiningJobMap {
     job_id_to_template: HashMap<u64, TemplateId>,
     // Generate sequential numeric job IDs for miners
     next_job_id: u64,
+    // Store upstream jobs by their original string ID
+    string_job_id_map: HashMap<String, (TemplateId, JobDetails)>,
 }
 impl MiningJobMap {
     pub fn new() -> Self {
@@ -1243,6 +1518,7 @@ impl MiningJobMap {
             mining_jobs: HashMap::new(),
             job_id_to_template: HashMap::new(),
             next_job_id: 0,
+            string_job_id_map: HashMap::new(),
         }
     }
     ///Inserting a suitable mining job which has been passed to the downstream being constructed from a suitable block template .
@@ -1256,7 +1532,7 @@ impl MiningJobMap {
         debug!(job_id = %numeric_job_id, template_id = %template_id, "Inserting mining job into MiningJobMap");
 
         // Store job by template_id
-        self.mining_jobs.insert(template_id, job_details);
+        self.mining_jobs.insert(template_id.clone(), job_details);
 
         // Map numeric job_id to template_id for reverse lookup
         self.job_id_to_template.insert(numeric_job_id, template_id);
@@ -1264,21 +1540,57 @@ impl MiningJobMap {
         numeric_job_id
     }
 
-    /// Get job by template_id which is used internally by server
-    pub async fn get_by_template_id(
-        &self,
+    pub async fn insert_upstream_job(
+        &mut self,
+        upstream_job_id: String,
         template_id: TemplateId,
+        jobdetails: JobDetails,
+    ) -> String {
+        debug!(
+            upstream_job_id = %upstream_job_id,
+            templateid = %template_id,
+            "Inserting upstream job into MiningJobMap"
+        );
+
+        // Store by original string ID
+        self.string_job_id_map.insert(
+            upstream_job_id.clone(),
+            (template_id.clone(), jobdetails.clone()),
+        );
+
+        // Also store in main map for consistency
+        self.mining_jobs.insert(template_id, jobdetails);
+        upstream_job_id
+    }
+
+    pub fn get_by_string_job_id(
+        &self,
+        job_id_str: &str,
+    ) -> Result<(&JobDetails, &TemplateId), StratumErrors> {
+        if let Some((template_id, jobdetails)) = self.string_job_id_map.get(job_id_str) {
+            return Ok((jobdetails, template_id));
+        }
+
+        Err(StratumErrors::MiningJobNotFound {
+            job_id: None,
+            template_id: None,
+        })
+    }
+    /// Get job by template_id which is used internally by server
+    pub fn get_by_template_id(
+        &self,
+        template_id: &TemplateId,
     ) -> Result<&JobDetails, StratumErrors> {
         self.mining_jobs
             .get(&template_id)
             .ok_or_else(|| StratumErrors::MiningJobNotFound {
                 job_id: None,
-                template_id: Some(template_id),
+                template_id: Some(template_id.clone()),
             })
     }
 
     /// Get job by numeric job_id which is used by miners in mining.submit
-    pub async fn get_by_job_id(&self, job_id: u64) -> Result<&JobDetails, StratumErrors> {
+    pub fn get_by_job_id(&self, job_id: u64) -> Result<&JobDetails, StratumErrors> {
         let template_id = self.job_id_to_template.get(&job_id).ok_or_else(|| {
             StratumErrors::MiningJobNotFound {
                 job_id: Some(job_id),
@@ -1286,12 +1598,12 @@ impl MiningJobMap {
             }
         })?;
 
-        self.get_by_template_id(*template_id).await
+        self.get_by_template_id(template_id)
     }
 
     /// Get template_id from numeric job_id for mining.submit validation
     pub fn template_id_from_job_id(&self, job_id: u64) -> Option<TemplateId> {
-        self.job_id_to_template.get(&job_id).copied()
+        self.job_id_to_template.get(&job_id).cloned()
     }
 }
 ///`Notifier` that will serve the purpose of notifying the downstream nodes with the lates available jobs
@@ -1459,6 +1771,7 @@ impl Notifier {
             ntime: hex::encode(time.to_be_bytes()),
             clean_jobs: clean_job,
             coinbase_witness_commitment: Some(coinbase_witness_commitment),
+            parsed_bits: None,
         })
     }
     /// Runs the Stratum notifier task that handles broadcasting mining jobs to downstream miners.
@@ -1530,7 +1843,7 @@ impl Notifier {
                         let job_notification = match Self::construct_job_notification(
                             clean_job,
                             template.clone(),
-                            template_id,
+                            template_id.clone(),
                             merkle_branch_coinbase.clone(),
                         )
                         .await
@@ -1575,10 +1888,11 @@ impl Notifier {
                             coinbase_witness_commitment: job_notification
                                 .coinbase_witness_commitment,
                             job_sent_time: unix_timestamp,
+                            is_upstream_job: false,
                         };
 
                         let numeric_job_id = curr_peer_mining_job_map
-                            .insert_mining_job(template_id, job_details)
+                            .insert_mining_job(template_id.clone(), job_details)
                             .await;
 
                         let job_notification_response = JobNotificationResponse {
@@ -1625,7 +1939,7 @@ impl Notifier {
                 NotifyCmd::SendLatestTemplateToNewDownstream {
                     new_downstream_addr,
                 } => {
-                    let current_template_id = *latest_template_id.lock().await;
+                    let current_template_id = latest_template_id.lock().await.clone();
                     let connection_entry = {
                         let current_downstream_mapping = downstream_connection_map.lock().await;
                         current_downstream_mapping
@@ -1644,13 +1958,31 @@ impl Notifier {
                     };
                     let connection_id_hex = format!("{:x}", connection_entry.connection_id);
 
-                    if current_template_id == 0 {
+                    let is_empty_template = match current_template_id {
+                        TemplateId::Braidpool(0) => true,
+                        TemplateId::Upstream(ref s) if s == "0" => true,
+                        _ => false,
+                    };
+
+                    if is_empty_template {
                         warn!(
                             connection_id = %connection_id_hex,
                             "No templates generated yet for new miner"
                         );
                         continue; // Skip but keep notifier running
                     }
+                    let latest_template = latest_template_arc.lock().await.to_owned();
+                    if latest_template.transactions.is_empty() {
+                        warn!(
+                            "Empty template for {}, will receive next upstream job",
+                            new_downstream_addr
+                        );
+                        continue;
+                    }
+                    info!(
+                        "Sending template {} to new miner {}",
+                        current_template_id, new_downstream_addr
+                    );
 
                     let latest_template = latest_template_arc.lock().await.to_owned();
                     let latest_template_merkle_branch =
@@ -1677,7 +2009,7 @@ impl Notifier {
                     let job_notification = Self::construct_job_notification(
                         clean_job,
                         latest_template.clone(),
-                        current_template_id,
+                        current_template_id.clone(),
                         latest_template_merkle_branch,
                     )
                     .await;
@@ -1714,9 +2046,10 @@ impl Notifier {
                                     coinbase_merkle_path: job.merkle_branches.clone(),
                                     coinbase_witness_commitment: job.coinbase_witness_commitment,
                                     job_sent_time: unix_timestamp,
+                                    is_upstream_job: false,
                                 };
                                 let numeric_job_id = curr_peer_mining_job_map
-                                    .insert_mining_job(current_template_id, job_details)
+                                    .insert_mining_job(current_template_id.clone(), job_details)
                                     .await;
                                 let job_notification_response = JobNotificationResponse {
                                     method: "mining.notify".to_string(),
@@ -1759,10 +2092,153 @@ impl Notifier {
                                 msg_type: "LatestTemplateSent".to_string(),
                             })
                         }
+                    }
+                }
+
+                NotifyCmd::SendUpstreamJob { job_notification } => {
+                    let compact_bits = match job_notification.parsed_bits {
+                        Some(bits) => bits,
+                        None => {
+                            error!(
+                                "Upstream job {} has no parsed bits, this would cause share spam, skipping...", 
+                                job_notification.job_id
+                            );
+                            error!("   Raw nbits from upstream: '{}'", job_notification.nbits);
+                            // Don't broadcast invalid jobs, miners would submit unpayable shares
+                            continue;
+                        }
                     };
+
+                    let downstream_channel_mapping = downstream_connection_map
+                        .lock()
+                        .await
+                        .downstream_channel_mapping
+                        .clone();
+
+                    let miner_count = downstream_channel_mapping.len();
+                    if miner_count == 0 {
+                        // TODO: Implement the job caching logic
+                        info!(
+                            "No miners connected, caching job {} for future connections",
+                            job_notification.job_id
+                        );
+                        continue;
+                    }
+                    let unix_timestamp = std::time::SystemTime::now()
+                        .duration_since(std::time::UNIX_EPOCH)
+                        .map(|d| d.as_secs() as u32)
+                        .unwrap_or_else(|e| {
+                            error!("System time is before Unix epoch: {}", e);
+                            0u32
+                        });
+
+                    // Broadcast to all connected miners
+                    for (peer_addr, mining_job_arc) in self.job_map_arc.lock().await.iter() {
+                        let mut curr_peer_mining_job_map = mining_job_arc.lock().await;
+                        let mut template = crate::stratum::BlockTemplate::default();
+                        template.bits = compact_bits;
+                        if let Ok(version_u32) = u32::from_str_radix(&job_notification.version, 16)
+                        {
+                            template.version =
+                                bitcoin::block::Version::from_consensus(version_u32 as i32);
+                        }
+                        if let Ok(prevhash_bytes) = hex::decode(&job_notification.prevhash) {
+                            if prevhash_bytes.len() == 32 {
+                                let mut reversed = [0u8; 32];
+                                for i in 0..32 {
+                                    reversed[i] = prevhash_bytes[31 - i];
+                                }
+                                let hash = bitcoin::BlockHash::from_byte_array(reversed);
+                                template.previousblockhash = hash;
+                            }
+                        }
+                        let template_id =
+                            TemplateId::from_upstream_string(&job_notification.job_id);
+
+                        // Store job details
+                        let job_details = crate::stratum::JobDetails {
+                            blocktemplate: template,
+                            coinbase1: job_notification.coinbase1.clone(),
+                            coinbase2: job_notification.coinbase2.clone(),
+                            coinbase_merkle_path: job_notification.merkle_branches.clone(),
+                            coinbase_witness_commitment: job_notification
+                                .coinbase_witness_commitment
+                                .clone(),
+                            job_sent_time: unix_timestamp,
+                            is_upstream_job: true,
+                        };
+
+                        let upstream_job_id = curr_peer_mining_job_map
+                            .insert_upstream_job(
+                                job_notification.job_id.clone(),
+                                template_id.clone(),
+                                job_details,
+                            )
+                            .await;
+
+                        let job_notification_response = serde_json::json!({
+                            "method": "mining.notify",
+                            "params": [
+                                upstream_job_id,
+                                job_notification.prevhash,
+                                job_notification.coinbase1,
+                                job_notification.coinbase2,
+                                job_notification.merkle_branches,
+                                job_notification.version,
+                                job_notification.nbits,
+                                job_notification.ntime,
+                                job_notification.clean_jobs
+                            ]
+                        });
+
+                        // Send this to miner
+                        if let Some(downstream_channel) = downstream_channel_mapping.get(peer_addr)
+                        {
+                            if let Err(e) = downstream_channel
+                                .sender
+                                .send(serde_json::to_string(&job_notification_response).unwrap())
+                                .await
+                            {
+                                error!("Failed to send upstream job to {}: {}", peer_addr, e);
+                            } else {
+                                info!(
+                                    "Sent upstream job {} to {} (bits: {})",
+                                    upstream_job_id, peer_addr, job_notification.nbits
+                                );
+                            }
+                        }
+                    }
+                }
+                NotifyCmd::BroadcastDifficulty { difficulty } => {
+                    info!("Broadcasting difficulty {} to all miners", difficulty);
+
+                    let set_difficulty_msg = serde_json::json!({
+                        "method": "mining.set_difficulty",
+                        "params": [difficulty]
+                    });
+
+                    let downstream_channel_mapping = downstream_connection_map
+                        .lock()
+                        .await
+                        .downstream_channel_mapping
+                        .clone();
+
+                    for (peer_addr, channel) in downstream_channel_mapping.iter() {
+                        if let Err(e) = channel
+                            .sender
+                            .send(serde_json::to_string(&set_difficulty_msg).unwrap())
+                            .await
+                        {
+                            error!("Failed to send difficulty to {}: {}", peer_addr, e);
+                        } else {
+                            info!("Sent difficulty {} to {}", difficulty, peer_addr);
+                        }
+                    }
                 }
             }
         }
+
+        warn!("Notifier channel closed, exiting...");
         Ok(())
     }
 }
@@ -1776,14 +2252,77 @@ pub struct ConnectionInfo {
 #[derive(Debug, Clone)]
 pub struct ConnectionMapping {
     downstream_channel_mapping: HashMap<String, ConnectionInfo>,
+    pub upstream_extranonce1: Option<String>,
+    pub upstream_extranonce2_size: Option<usize>,
+    pub upstream_difficulty: Option<f64>,
+    worker_to_peer: HashMap<String, String>,
+    pub upstream_connected: bool,
 }
+
 impl ConnectionMapping {
     pub fn new() -> Self {
         ConnectionMapping {
             downstream_channel_mapping: HashMap::new(),
+            upstream_extranonce1: None,
+            upstream_extranonce2_size: None,
+            upstream_difficulty: None,
+            worker_to_peer: HashMap::new(),
+            upstream_connected: false,
         }
     }
-    ///Inserting new connction along with its `peer_socket_address`, `connection_id`, and `Sender_channel`.
+
+    pub fn set_upstream_connected(&mut self, connected: bool) {
+        self.upstream_connected = connected;
+        if connected {
+            info!("Upstream marked as connected");
+        } else {
+            warn!("Upstream marked as disconnected");
+        }
+    }
+
+    pub fn remove_peer(&mut self, peer_addr: &str) {
+        // Remove from channel mapping
+        self.downstream_channel_mapping.remove(peer_addr);
+
+        // Remove all workers associated with this peer
+        self.worker_to_peer
+            .retain(|_worker_name, mapped_peer| mapped_peer != peer_addr);
+
+        debug!("Removed peer {} and associated workers", peer_addr);
+    }
+
+    pub fn set_upstream_extranonce(&mut self, extranonce1: String, extranonce2_size: usize) {
+        self.upstream_extranonce1 = Some(extranonce1);
+        self.upstream_extranonce2_size = Some(extranonce2_size);
+        info!("ConnectionMapping updated with upstream extranonce");
+    }
+
+    pub fn set_upstream_difficulty(&mut self, difficulty: f64) {
+        self.upstream_difficulty = Some(difficulty);
+        info!(
+            "ConnectionMapping updated with upstream difficulty: {}",
+            difficulty
+        );
+    }
+
+    pub fn get_channels(&self) -> &HashMap<String, ConnectionInfo> {
+        &self.downstream_channel_mapping
+    }
+
+    pub fn register_worker(&mut self, peer_addr: String, worker_name: String) {
+        self.worker_to_peer.insert(worker_name, peer_addr);
+    }
+
+    pub fn get_peer_for_worker(&self, worker_name: &str) -> Option<&String> {
+        self.worker_to_peer.get(worker_name)
+    }
+
+    pub fn get_channel_for_worker(&self, worker_name: &str) -> Option<&mpsc::Sender<String>> {
+        self.get_peer_for_worker(worker_name)
+            .and_then(|peer| self.downstream_channel_mapping.get(peer))
+            .map(|info| &info.sender)
+    }
+
     pub fn new_connection(
         &mut self,
         peer_addr: String,
@@ -1830,6 +2369,9 @@ impl Server {
         notification_sender: mpsc::Sender<NotifyCmd>,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
         ibd_or_not: Arc<AtomicBool>,
+        audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
+        upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
+        upstream_configure_tx: Option<mpsc::Sender<(Value, u64, mpsc::Sender<Value>)>>,
     ) -> Result<(), Box<std::io::Error>> {
         debug!("Starting stratum server");
         let bind_address = format!(
@@ -1884,6 +2426,56 @@ impl Server {
                  match event{
                      Ok((stream,peer_addr))=>{
                          let (reader, writer) = stream.into_split();
+
+                            // This will determine extranonce before creating client
+                            let (assigned_extranonce1, assigned_extranonce2_size, is_proxy) = {
+                                let mapping = self.downstream_connection_mapping.lock().await;
+
+                                if self.stratum_config.audit_mode {
+                                    // This must have upstream connection
+                                    if let (Some(ref upstream_ext1), Some(upstream_ext2_size)) =
+                                        (&mapping.upstream_extranonce1, mapping.upstream_extranonce2_size)
+                                    {
+                                        info!("New audit mode connection using upstream extranonce: {}", upstream_ext1);
+
+                                        match hex::decode(upstream_ext1) {
+                                            Ok(bytes) => (bytes, upstream_ext2_size, true),
+                                            Err(e) => {
+                                                error!("Failed to decode upstream extranonce: {}", e);
+                                                continue; // Skip this connection
+                                            }
+                                        }
+                                    } else {
+                                        // That means audit mode enabled but upstream not ready
+                                        error!("Miner {} tried to connect in audit mode, but upstream pool is not ready yet", peer_addr);
+                                        error!("Rejecting connection to prevent mining on wrong chain");
+                                        continue; // Reject the connection
+                                    }
+                                } else {
+                                    // Normal Braidpool mode, generate local extranonce
+                                    let mut bytes = [0u8; 4];
+                                    rand::thread_rng().fill_bytes(&mut bytes);
+                                    info!("New Braidpool connection using local extranonce: {}", hex::encode(&bytes));
+                                    (bytes.to_vec(), EXTRANONCE2_SIZE, false)
+                                }
+                            };
+                            // Create client with correct state
+                            let downstream_client = Arc::new(Mutex::new(DownstreamClient {
+                                authorized: false,
+                                downstream_ip: peer_addr.to_string(),
+                                subscribed: false,
+                                suggest_difficulty_done: false,
+                                channel_configured: false,
+                                connection_id: rand::thread_rng().next_u32(),
+                                extranonce1: assigned_extranonce1,
+                                version_rolling_mask: None,
+                                version_rolling_min_bit: None,
+                                extranonce2_len: assigned_extranonce2_size,
+                                monitor_target: None,
+                                block_submission_tx: self.block_submission_tx.clone(),
+                                is_proxy_mode: is_proxy,
+                            }));
+
                          //Notification sender to the `Notifier` task
                          let notification_sender = notification_sender.clone();
                          //Communication bridge between swarm and stratum service
@@ -1908,21 +2500,21 @@ impl Server {
                          let mining_job_map_clone = Arc::clone(&mining_job_map);
                          let peer_addr_string = peer_addr.to_string();
 
-                         // catering each new connection as seperate process
-                         tokio::spawn(async move{
-                             let _=  Self::handle_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref).await;
-                             debug!(
-                                        connection_id = %connection_id_hex,
-                                        peer = %peer_addr_string,
-                                        "Cleaning up disconnected miner"
-                                    );
+                            let connection_mapping_for_cleanup = Arc::clone(&self.downstream_connection_mapping);
+                            let audit_dag_clone = audit_dag.clone();
+                            let upstream_share_tx_clone = upstream_share_tx.clone();
+                            let upstream_configure_tx_clone = upstream_configure_tx.clone();
 
-                             // cleanup after connection closes, remove from connection mapping
-                             connection_mapping_clone
-                                     .lock()
-                                     .await
-                                     .downstream_channel_mapping
-                                     .remove(&peer_addr_string);
+                            // catering each new connection as seperate process
+                            tokio::spawn(async move{
+                                let _=  Self::handle_connection(downstream_client.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref,audit_dag_clone,upstream_share_tx_clone,connection_mapping_clone,upstream_configure_tx_clone,).await;
+                                debug!("Cleaning up disconnected miner: {}", peer_addr_string);
+
+                                // cleanup after connection closes, remove from connection mapping
+                                connection_mapping_for_cleanup
+                                        .lock()
+                                        .await
+                                        .remove_peer(&peer_addr_string);
 
                              // Remove from job mapping
                                  mining_job_map_clone
@@ -1979,6 +2571,10 @@ impl Server {
         downstream_message_sender: mpsc::Sender<String>,
         notification_sender: mpsc::Sender<NotifyCmd>,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
+        audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
+        upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
+        connection_mapping: Arc<Mutex<ConnectionMapping>>,
+        upstream_configure_tx: Option<mpsc::Sender<(Value, u64, mpsc::Sender<Value>)>>,
     ) -> Result<(), Box<StratumErrors>> {
         const MAX_LINE_LENGTH: usize = 2_usize.pow(16);
         //It can be excessively inefficient to work directly with a AsyncRead instance. A BufReader performs large, infrequent reads on the underlying AsyncRead and maintains an in-memory buffer of the results.
@@ -1997,34 +2593,23 @@ impl Server {
 
         loop {
             tokio::select! {
-                Some(message) = downstream_receiver.recv()=>{
-                    trace!(
-                        connection_id = %connection_id_hex,
-                        message = ?message,
-                        peer = %peer_addr,
-                        "Sending message to miner"
-                    );
-                    //Sending the notifications of new job to the downstream
-                    let write_or_not = stream_writer.write_all(format!("{}\n",message).as_bytes()).await;
-                    match write_or_not{
-                        Ok(_)=>{
-                            trace!(
-                                connection_id = %connection_id_hex,
-                                peer = %peer_addr,
-                                "Response written to stream"
-                            );
+                Some(message) = downstream_receiver.recv() => {
+                    debug!("Message to send to {}: {}", peer_addr, message);
 
-                        },
-                        Err(error)=>{
-                            error!(
-                                connection_id = %connection_id_hex,
-                                error = %error,
-                                peer = %peer_addr,
-                                "Failed to write to stream"
-                            );
-                        }
+                    if let Err(e) = stream_writer.write_all(format!("{}\n", message).as_bytes()).await {
+                        error!("Failed to write to {}: {}", peer_addr, e);
+                        break;
                     }
+
+                    if let Err(e) = stream_writer.flush().await {
+                        error!("Failed to flush to {}: {}", peer_addr, e);
+                        break;
+                    }
+
+                    info!("Response has been written to the TcpStream successfully");
                 }
+
+                // Process incoming requests from miner
                 line = framed.next().fuse() => {
                     match line {
                         Some(Ok(line)) => {
@@ -2037,19 +2622,42 @@ impl Server {
                                 peer = %peer_addr,
                                 "Read line from miner"
                             );
-                        //Parsing the lines read from buffer to find out whether they are valid JSON request type to be server as per
-                        //stratum or not .
-                        match serde_json::from_str::<StandardRequest>(&line) {
+                            match serde_json::from_str::<StandardRequest>(&line) {
                                 Ok(request) => {
-                         let server_request_res:Result<StratumResponses, StratumErrors> = downstream_client.lock().await.handle_client_to_server_request(request,mining_job_map.clone(),downstream_message_sender.clone(),notification_sender.clone(),peer_addr.to_string(),swarm_handler.clone()).await;
-                         match server_request_res{
-                            Ok(_)=>{
+                                    let server_request_res = downstream_client.lock().await
+                                        .handle_client_to_server_request(
+                                            request,
+                                            mining_job_map.clone(),
+                                            downstream_message_sender.clone(),
+                                            notification_sender.clone(),
+                                            peer_addr.to_string(),
+                                            swarm_handler.clone(),
+                                            audit_dag.clone(),
+                                            upstream_share_tx.clone(),
+                                            connection_mapping.clone(),
+                                            upstream_configure_tx.clone(),
+                                        )
+                                        .await;
 
-                            },
-                            Err(error)=>{
-                                return Err(Box::new(error))
-                            }
-                         }
+                                    if let Err(error) = server_request_res {
+                                        error!("Error handling request from {}: {:?}", peer_addr, error);
+                                        let error_response = serde_json::json!({
+                                            "id": line.parse::<serde_json::Value>()
+                                                .ok()
+                                                .and_then(|v| v.get("id").cloned())
+                                                .unwrap_or(serde_json::json!(null)),
+                                            "result": null,
+                                            "error": format!("{:?}", error)
+                                        });
+
+                                        if let Err(e) = downstream_message_sender
+                                            .send(error_response.to_string())
+                                            .await
+                                        {
+                                            error!("Failed to send error response: {}", e);
+                                            break;
+                                        }
+                                    }
                                 }
                                 Err(e) => {
                                     error!(
@@ -2062,8 +2670,6 @@ impl Server {
                                     );
                                 }
                             }
-
-
                         }
                         Some(Err(e)) => {
                             error!(
@@ -2082,11 +2688,9 @@ impl Server {
                                 "Connection closed by client"
                             );
                             break;
-
                         }
                     }
                 }
-
             }
         }
         Ok(())
@@ -2139,11 +2743,14 @@ mod test {
 
         let server_task = tokio::spawn(async move {
             let _ = server
-                .run_stratum_service(
+                .run_stratum_service(    
                     mining_job_map,
                     notify_tx,
                     swarm_handler_arc,
                     test_ibd_spinlock.clone(),
+                    None,
+                    None,
+                    None,
                 )
                 .await;
         });
@@ -2210,6 +2817,9 @@ mod test {
                     notify_tx,
                     swarm_handler_arc,
                     test_ibd_spinlock,
+                    None,
+                    None,
+                    None,
                 )
                 .await;
         });
@@ -2259,6 +2869,9 @@ mod test {
                     notify_tx,
                     swarm_handler_arc,
                     ibd_spinlock.clone(),
+                    None,
+                    None,
+                    None,
                 )
                 .await;
         });
@@ -2309,6 +2922,9 @@ mod test {
                     notify_tx,
                     swarm_handler_arc,
                     ibd_spinlock.clone(),
+                    None,
+                    None,
+                    None,
                 )
                 .await;
         });
@@ -2355,6 +2971,9 @@ mod test {
                     notify_tx_clone,
                     swarm_handler_arc,
                     ibd_spinlock,
+                    None,
+                    None,
+                    None,
                 )
                 .await
                 .unwrap();
@@ -2467,10 +3086,14 @@ mod test {
             bits: test_template_header.bits,
             ..Default::default()
         };
-        let mut constructed_test_notification =
-            Notifier::construct_job_notification(false, test_template.clone(), 1, vec![])
-                .await
-                .unwrap();
+        let mut constructed_test_notification = Notifier::construct_job_notification(
+            false,
+            test_template.clone(),
+            TemplateId::Braidpool(1),
+            vec![],
+        )
+        .await
+        .unwrap();
         println!(
             "Constructed test notification: {:?}",
             constructed_test_notification
@@ -2480,6 +3103,7 @@ mod test {
         let duration_since_epoch = current_system_time.duration_since(UNIX_EPOCH).unwrap();
         let unix_timestamp = duration_since_epoch.as_secs().to_u32().unwrap();
         let mut mock_downstream_handler = DownstreamClient::default();
+        mock_downstream_handler.authorized = true;
         let mock_mining_job_map: Arc<Mutex<MiningJobMap>> =
             Arc::new(Mutex::new(MiningJobMap::new()));
         test_template.transactions.remove(0);
@@ -2490,11 +3114,12 @@ mod test {
             coinbase_merkle_path: vec![],
             coinbase_witness_commitment: Some(test_witness),
             job_sent_time: unix_timestamp,
+            is_upstream_job: false,
         };
         let numeric_job_id = mock_mining_job_map
             .lock()
             .await
-            .insert_mining_job(1, job_details.clone())
+            .insert_mining_job(TemplateId::Braidpool(1), job_details.clone())
             .await;
         let test_submit_request_params = json!([
             "bitaxe",
@@ -2514,7 +3139,7 @@ mod test {
         let test_extranonce_1 = hex::decode("9495ac08").unwrap();
         mock_downstream_handler.extranonce1 = test_extranonce_1;
         let configure_response = mock_downstream_handler
-            .handle_configure(&configure_test_request, 1)
+            .handle_configure(&configure_test_request, 1, None)
             .await;
         let submit_response: StratumResponses = mock_downstream_handler
             .handle_submit(
@@ -2522,6 +3147,8 @@ mod test {
                 mock_mining_job_map.clone(),
                 2,
                 swarm_handler_arc,
+                None,
+                None,
             )
             .await
             .unwrap();

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -287,7 +287,41 @@ impl DownstreamClient {
                 )
                 .await
             }
-            "mining.suggest_difficulty" => self.suggest_difficulty(&req_params).await,
+            "mining.suggest_difficulty" => {
+                // In audit mode, ignore Braidpool's suggested difficulty and use the upstream pool's difficulty instead
+                if self.is_proxy_mode {
+                    let upstream_diff = {
+                        let mapping = connection_mapping.lock().await;
+                        mapping.upstream_difficulty
+                    };
+                    if let Some(diff) = upstream_diff {
+                        info!(
+                            connection_id = %connection_id_hex,
+                            suggested = ?req_params,
+                            upstream_diff = %diff,
+                            "Audit mode, suggest_difficulty is taking place using upstream difficulty"
+                        );
+                        // Return the upstream difficulty
+                        Ok(StratumResponses::SuggestDifficultyResponse {
+                            suggest_difficulty_resp: SuggestDifficultyResponse {
+                                method: "mining.set_difficulty".to_string(),
+                                params: vec![diff as u64],
+                            },
+                        })
+                    } else {
+                        error!(
+                            connection_id = %connection_id_hex,
+                            "Audit mode: no upstream difficulty available, rejecting suggest_difficulty"
+                        );
+                        Err(StratumErrors::UpstreamNotReady {
+                            error: "Upstream pool difficulty not available yet".to_string(),
+                        })
+                    }
+                } else {
+                    // For normal Braidpool interactions
+                    self.suggest_difficulty(&req_params).await
+                }
+            }
             method => Err(StratumErrors::InvalidMethod {
                 method: method.to_string(),
             }),

--- a/node/src/upstream_pool.rs
+++ b/node/src/upstream_pool.rs
@@ -1,4 +1,3 @@
-// src/upstream_pool.rs
 use serde_json::{json, Value};
 use std::collections::HashMap;
 use tokio::{
@@ -272,6 +271,7 @@ pub struct UpstreamShare {
     pub nonce: String,
     pub version_bits: Option<String>,
     pub original_request_id: u64,
+    pub share_id: crate::audit::ShareId,
 }
 
 /// Upstream pool client that acts as a miner to the upstream pool
@@ -294,8 +294,8 @@ pub struct UpstreamPoolClient {
     upstream_difficulty: Option<f64>,
     /// Next request ID to use for upstream requests
     next_request_id: u64,
-    /// Tracks pending share submissions: request_id -> (worker_name, original_request_id, sent_at)
-    pending_shares: HashMap<u64, (String, u64, std::time::Instant)>,
+    /// Tracks pending share submissions: request_id -> (worker_name, original_request_id, sent_at, share_id)
+    pending_shares: HashMap<u64, (String, u64, std::time::Instant, crate::audit::ShareId)>,
     /// Tracks pending configure requests: request_id -> response channel
     pending_requests: HashMap<u64, mpsc::Sender<Value>>,
     /// Sends updated extranonce values to the stratum server
@@ -306,6 +306,14 @@ pub struct UpstreamPoolClient {
     configure_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>>>,
     /// Shared cache for upstream responses and state
     upstream_cache: Arc<RwLock<UpstreamCache>>,
+    /// Shared reference to the Braid structure for bead/audit operations
+    braid_arc: Arc<tokio::sync::RwLock<crate::braid::Braid>>,
+    /// Channel for sending upstream share responses and events with ShareId to the audit log
+    audit_log_tx: mpsc::Sender<(crate::audit::ShareId, Value)>,
+    // Track subscribe handshake request ID
+    subscribe_req_id: Option<u64>,
+    // Track authorize handshake requet ID
+    authorize_req_id: Option<u64>,
 }
 
 impl UpstreamPoolClient {
@@ -319,6 +327,8 @@ impl UpstreamPoolClient {
         difficulty_tx: Option<mpsc::Sender<f64>>,
         configure_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>>>,
         upstream_cache: Arc<RwLock<UpstreamCache>>,
+        braid_arc: Arc<tokio::sync::RwLock<crate::braid::Braid>>,
+        audit_log_tx: mpsc::Sender<(crate::audit::ShareId, Value)>,
     ) -> Self {
         Self {
             config,
@@ -336,6 +346,10 @@ impl UpstreamPoolClient {
             difficulty_tx,
             configure_rx,
             upstream_cache,
+            braid_arc,
+            audit_log_tx,
+            subscribe_req_id: None,
+            authorize_req_id: None,
         }
     }
 
@@ -378,7 +392,7 @@ impl UpstreamPoolClient {
         {
             use std::time::Duration as StdDuration;
             let keepalive = socket2::TcpKeepalive::new()
-                .with_time(StdDuration::from_secs(30))
+                .with_time(StdDuration::from_secs(300))
                 .with_interval(StdDuration::from_secs(2))
                 .with_retries(3);
 
@@ -389,14 +403,14 @@ impl UpstreamPoolClient {
                     error: format!("Keepalive config failed: {}", e),
                 });
             }
-            info!("TCP keepalive enabled: idle=30s, interval=2s, retries=3 (dead connection detected in ~36s)");
+            info!("TCP keepalive enabled: idle=300s, interval=2s, retries=3 (dead connection detected in ~306s)");
         }
 
         #[cfg(not(target_os = "linux"))]
         {
             use std::time::Duration as StdDuration;
             let keepalive = socket2::TcpKeepalive::new()
-                .with_time(StdDuration::from_secs(30))
+                .with_time(StdDuration::from_secs(300))
                 .with_interval(StdDuration::from_secs(2));
 
             let sockref = socket2::SockRef::from(&stream);
@@ -404,10 +418,10 @@ impl UpstreamPoolClient {
                 warn!("Failed to set TCP keepalive: {}", e);
             } else {
                 #[cfg(any(target_os = "macos", target_os = "windows"))]
-                info!("TCP keepalive enabled: idle=30s, interval=2s (dead connection detected in ~60-90s, system default retries)");
+                info!("TCP keepalive enabled: idle=30s, interval=2s (dead connection detected in ~310-330s, system default retries)");
 
                 #[cfg(not(any(target_os = "macos", target_os = "windows")))]
-                info!("TCP keepalive enabled: idle=30s, interval=2s (platform-specific detection time)");
+                info!("TCP keepalive enabled: idle=300s, interval=2s (platform-specific detection time)");
             }
         }
 
@@ -421,6 +435,8 @@ impl UpstreamPoolClient {
         self.pending_requests.clear();
         self.next_request_id = 1;
         self.upstream_cache.write().await.clear();
+        self.subscribe_req_id = None;
+        self.authorize_req_id = None;
 
         // Send initial handshake
         self.send_subscribe(&mut writer).await?;
@@ -690,7 +706,7 @@ impl UpstreamPoolClient {
                     let now = std::time::Instant::now();
                     let timeout = Duration::from_secs(60);
                     let before_shares = self.pending_shares.len();
-                    self.pending_shares.retain(|request_id, (worker_name, _original_id, sent_at)| {
+                    self.pending_shares.retain(|request_id, (worker_name, _original_id, sent_at, _share_id)| {
                         let age = now.duration_since(*sent_at);
                         if age > timeout {
                             warn!(
@@ -748,6 +764,9 @@ impl UpstreamPoolClient {
         &mut self,
         writer: &mut tokio::net::tcp::OwnedWriteHalf,
     ) -> Result<(), StratumErrors> {
+        let request_id = self.next_request_id;
+        self.subscribe_req_id = Some(request_id);
+
         let subscribe_req = json!({
             "id": self.next_request_id,
             "method": "mining.subscribe",
@@ -775,6 +794,9 @@ impl UpstreamPoolClient {
         &mut self,
         writer: &mut tokio::net::tcp::OwnedWriteHalf,
     ) -> Result<(), StratumErrors> {
+        let request_id = self.next_request_id;
+        self.authorize_req_id = Some(request_id);
+
         let authorize_req = json!({
             "id": self.next_request_id,
             "method": "mining.authorize",
@@ -831,87 +853,52 @@ impl UpstreamPoolClient {
                     }
 
                     // Check if this is a pending share response
-                    if let Some((worker_name, original_request_id, _sent_at)) =
+                    if let Some((worker_name, original_request_id, _sent_at, share_id)) =
                         self.pending_shares.remove(&request_id)
                     {
                         info!(
                             "Received share response for {} (upstream_id={}, miner_id={})",
                             worker_name, request_id, original_request_id
                         );
-
-                        // Check if share was accepted or rejected
-                        if let Some(result) = msg.get("result") {
+                        let accepted = if let Some(result) = msg.get("result") {
                             if result.is_null() {
-                                // Result is null, check error field
-                                if let Some(error) = msg.get("error") {
-                                    if error.is_null() {
-                                        // Both result and error are null, but treat as success
-                                        warn!(
-                                            "Share response has null result and null error for {}",
-                                            worker_name
-                                        );
-                                    } else {
-                                        // Error is not null, share rejected
-                                        error!(
-                                            "SHARE REJECTED by upstream pool for worker: {}",
-                                            worker_name
-                                        );
-                                        error!("Error code: {:?}", error);
-                                        // Parse error details
-                                        if let Some(error_arr) = error.as_array() {
-                                            let error_code = error_arr
-                                                .get(0)
-                                                .and_then(|v| v.as_i64())
-                                                .unwrap_or(-1);
-                                            let error_msg = error_arr
-                                                .get(1)
-                                                .and_then(|v| v.as_str())
-                                                .unwrap_or("unknown");
-                                            error!("Error [{}]: {}", error_code, error_msg);
-                                        } else {
-                                            error!("Error details: {:?}", error);
-                                        }
-                                    }
-                                } else {
-                                    // Result is null but no error field
-                                    warn!(
-                                        "Share response for {} has null result and no error field",
-                                        worker_name
-                                    );
-                                }
+                                msg.get("error").map_or(false, |e| e.is_null())
                             } else {
-                                // Result is not null, check if true
-                                if result == &json!(true) {
-                                    info!(
-                                        "SHARE ACCEPTED!!! by upstream pool for worker: {}",
-                                        worker_name
-                                    );
-                                    info!("Share successfully submitted to Ocean!");
-                                } else {
-                                    warn!(
-                                        "Share response for {} has unexpected result: {:?}",
-                                        worker_name, result
-                                    );
-                                }
+                                result == &json!(true)
                             }
                         } else {
-                            // No result field at all
-                            error!("Share response for {} missing 'result' field", worker_name);
+                            false
+                        };
+                        if accepted {
+                            info!("SHARE ACCEPTED by upstream pool for {}", worker_name);
+                        } else {
+                            error!("SHARE REJECTED by upstream pool for {}", worker_name);
+                            if let Some(error) = msg.get("error") {
+                                if let Some(error_arr) = error.as_array() {
+                                    let error_code =
+                                        error_arr.get(0).and_then(|v| v.as_i64()).unwrap_or(-1);
+                                    let error_msg = error_arr
+                                        .get(1)
+                                        .and_then(|v| v.as_str())
+                                        .unwrap_or("unknown");
+                                    error!("Rejection details [{}]: {}", error_code, error_msg);
+                                } else {
+                                    error!("Rejection reason: {:?}", error);
+                                }
+                            }
                         }
-
-                        // Forward the response back to main.rs
                         if let Err(e) = self
-                            .response_tx
-                            .send((worker_name.clone(), msg.clone(), original_request_id))
+                            .audit_log_tx
+                            .send((share_id.clone(), msg.clone()))
                             .await
                         {
-                            error!("Failed to forward share response to main: {}", e);
+                            error!("Failed to send to audit log: {}", e);
                         }
                         return Ok(());
                     }
 
                     // Handle subscribe response
-                    if request_id == 1
+                    if Some(request_id) == self.subscribe_req_id
                         && msg.get("result").is_some()
                         && msg.get("error").map_or(true, |e| e.is_null())
                     {
@@ -1006,8 +993,8 @@ impl UpstreamPoolClient {
                         return Ok(());
                     }
 
-                    // Handle authorize response (id=2 typically)
-                    if request_id == 2 && msg.get("result").is_some() {
+                    // Handle authorize response
+                    if Some(request_id) == self.authorize_req_id && msg.get("result").is_some() {
                         if let Some(result) = msg.get("result") {
                             if result == &json!(true) {
                                 info!("Upstream authorize successful!");
@@ -1045,7 +1032,38 @@ impl UpstreamPoolClient {
                         job.job_id, job.clean_jobs
                     );
                     debug!("Upstream parsed job: {:?}", job);
-                    let should_log_stats = self.next_request_id % 10 == 0;
+
+                    let bead_hash = {
+                        let braid = self.braid_arc.read().await;
+
+                        if let Some(&latest_tip_idx) = braid.tips.iter().next() {
+                            if let Some(bead) = braid.beads.get(latest_tip_idx) {
+                                crate::audit::compute_audit_bead_hash(bead)
+                            } else {
+                                bitcoin::BlockHash::from_byte_array([0u8; 32])
+                            }
+                        } else {
+                            bitcoin::BlockHash::from_byte_array([0u8; 32])
+                        }
+                    };
+                    if let Err(e) = self
+                        .notification_tx
+                        .send(NotifyCmd::UpdateExtranonce {
+                            new_bead_hash: bead_hash,
+                        })
+                        .await
+                    {
+                        error!(
+                            bead_hash = %bead_hash,
+                            error = %e,
+                            "Failed to send extranonce update command to notifier"
+                        );
+                    } else {
+                        debug!(
+                            bead_hash = %bead_hash,
+                            "Sent extranonce update command to notifier"
+                        );
+                    }
 
                     // cache the job
                     {
@@ -1053,6 +1071,7 @@ impl UpstreamPoolClient {
                         cache.set_latest_job(job.clone());
                     }
 
+                    let should_log_stats = self.next_request_id % 10 == 0;
                     // Log cache stats every 10 jobs
                     if should_log_stats {
                         let cache = self.upstream_cache.read().await;
@@ -1407,6 +1426,7 @@ impl UpstreamPoolClient {
                 share.worker_name.clone(),
                 share.original_request_id,
                 std::time::Instant::now(),
+                share.share_id.clone(),
             ),
         );
         let msg = format!("{}\n", submit_req);

--- a/node/src/upstream_pool.rs
+++ b/node/src/upstream_pool.rs
@@ -12,6 +12,246 @@ use tracing::{debug, error, info, warn};
 
 use crate::error::StratumErrors;
 use crate::stratum::{JobNotification, NotifyCmd};
+use std::sync::Arc;
+use tokio::sync::RwLock;
+use tokio::time::Duration;
+
+const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
+
+/// Unified cache for all upstream pool data
+#[derive(Debug, Clone)]
+pub struct UpstreamCache {
+    /// Cached mining.configure response (version rolling mask, etc.)
+    pub configure_response: Option<CachedItem<Value>>,
+
+    /// Cached mining.subscribe response (extranonce1, extranonce2_size)
+    pub subscribe_response: Option<CachedItem<UpstreamSubscribeResponse>>,
+
+    /// Current difficulty from upstream
+    pub current_difficulty: Option<CachedItem<f64>>,
+
+    /// Most recent job notification
+    pub latest_job: Option<CachedItem<JobNotification>>,
+}
+
+/// Individual cache item with its own timestamp and TTL
+#[derive(Debug, Clone)]
+pub struct CachedItem<T> {
+    /// The cached value
+    pub value: T,
+
+    /// When this item was cached
+    pub cached_at: std::time::SystemTime,
+
+    /// TTL in seconds, how long this item stays valid
+    pub ttl_seconds: u64,
+}
+
+impl<T: Clone> CachedItem<T> {
+    /// Create a new cached item with default TTL
+    pub fn new(value: T, ttl_seconds: u64) -> Self {
+        Self {
+            value,
+            cached_at: std::time::SystemTime::now(),
+            ttl_seconds,
+        }
+    }
+
+    /// Check if this cached item is still valid
+    pub fn is_valid(&self) -> bool {
+        match self.cached_at.elapsed() {
+            Ok(duration) => duration.as_secs() < self.ttl_seconds,
+            Err(_) => false,
+        }
+    }
+
+    /// Get age in seconds
+    pub fn age_seconds(&self) -> u64 {
+        self.cached_at.elapsed().map(|d| d.as_secs()).unwrap_or(0)
+    }
+
+    /// Update value and reset timestamp
+    pub fn update(&mut self, new_value: T) {
+        self.value = new_value;
+        self.cached_at = std::time::SystemTime::now();
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct UpstreamSubscribeResponse {
+    pub extranonce1: String,
+    pub extranonce2_size: usize,
+    pub subscriptions: Vec<(String, String)>,
+}
+
+impl Default for UpstreamCache {
+    fn default() -> Self {
+        Self {
+            configure_response: None,
+            subscribe_response: None,
+            current_difficulty: None,
+            latest_job: None,
+        }
+    }
+}
+
+impl UpstreamCache {
+    pub fn new() -> Arc<RwLock<Self>> {
+        Arc::new(RwLock::new(Self::default()))
+    }
+
+    pub fn clear(&mut self) {
+        info!("Clearing upstream cache due to new connection");
+        self.configure_response = None;
+        self.subscribe_response = None;
+        self.current_difficulty = None;
+        self.latest_job = None;
+    }
+
+    /// Cache mining.configure response
+    pub fn set_configure(&mut self, response: Value) {
+        self.configure_response = Some(CachedItem::new(response, u64::MAX));
+        info!("Cached upstream mining.configure response");
+    }
+
+    /// Get cached configure response if valid
+    pub fn get_configure(&self) -> Option<&Value> {
+        self.configure_response
+            .as_ref()
+            .filter(|item| item.is_valid())
+            .map(|item| &item.value)
+    }
+
+    pub fn set_subscribe(
+        &mut self,
+        extranonce1: String,
+        extranonce2_size: usize,
+        subscriptions: &[(String, String)],
+    ) {
+        self.subscribe_response = Some(CachedItem::new(
+            UpstreamSubscribeResponse {
+                extranonce1,
+                extranonce2_size,
+                subscriptions: subscriptions.to_vec(),
+            },
+            u64::MAX,
+        ));
+        info!(
+            "Cached upstream mining.subscribe response with {} subscriptions",
+            self.subscribe_response
+                .as_ref()
+                .unwrap()
+                .value
+                .subscriptions
+                .len()
+        );
+    }
+
+    /// Get cached subscribe response if valid
+    pub fn get_subscribe(&self) -> Option<&UpstreamSubscribeResponse> {
+        self.subscribe_response
+            .as_ref()
+            .filter(|item| item.is_valid())
+            .map(|item| &item.value)
+    }
+
+    /// Cache difficulty
+    pub fn set_difficulty(&mut self, difficulty: f64) {
+        self.current_difficulty = Some(CachedItem::new(difficulty, u64::MAX));
+        info!("Cached upstream difficulty: {}", difficulty);
+    }
+
+    /// Get cached difficulty if valid
+    pub fn get_difficulty(&self) -> Option<f64> {
+        self.current_difficulty
+            .as_ref()
+            .filter(|item| item.is_valid())
+            .map(|item| item.value)
+    }
+
+    /// Cache latest job notification, 1 hour TTL, but respects clean_jobs
+    pub fn set_latest_job(&mut self, job: JobNotification) {
+        // If clean_jobs=true, invalidate old job first
+        if job.clean_jobs {
+            info!("Job has clean_jobs=true, invalidating old cache");
+            self.latest_job = None;
+        }
+
+        self.latest_job = Some(CachedItem::new(job.clone(), 3600)); // 1 hour
+
+        info!(
+            job_id = %job.job_id,
+            clean_jobs = %job.clean_jobs,
+            "Cached upstream job"
+        );
+    }
+
+    /// Get cached job if valid
+    pub fn get_latest_job(&self) -> Option<&JobNotification> {
+        self.latest_job
+            .as_ref()
+            .filter(|item| item.is_valid())
+            .map(|item| &item.value)
+    }
+
+    /// Force invalidate job cache (e.g., on upstream disconnect)
+    pub fn invalidate_job(&mut self) {
+        info!("Manually invalidating job cache");
+        self.latest_job = None;
+    }
+
+    /// cache statistics
+    pub fn stats(&self) -> CacheStats {
+        CacheStats {
+            configure_cached: self.configure_response.is_some(),
+            configure_valid: self.get_configure().is_some(),
+
+            subscribe_cached: self.subscribe_response.is_some(),
+            subscribe_valid: self.get_subscribe().is_some(),
+
+            difficulty_cached: self.current_difficulty.is_some(),
+            difficulty_valid: self.get_difficulty().is_some(),
+            difficulty_value: self.get_difficulty(),
+
+            job_cached: self.latest_job.is_some(),
+            job_valid: self.get_latest_job().is_some(),
+            job_id: self.get_latest_job().map(|j| j.job_id.clone()),
+            job_age_seconds: self.latest_job.as_ref().map(|item| item.age_seconds()),
+        }
+    }
+
+    /// Log current cache state, mainly useful for debugging
+    pub fn log_stats(&self) {
+        let stats = self.stats();
+        info!(
+            "Cache stats [Cached/Valid]: configure={}/{}, subscribe={}/{}, difficulty={}/{}, job={}/{} (age={}s, id={:?})",
+            stats.configure_cached, stats.configure_valid,
+            stats.subscribe_cached, stats.subscribe_valid,
+            stats.difficulty_cached, stats.difficulty_valid,
+            stats.job_cached, stats.job_valid,
+            stats.job_age_seconds.unwrap_or(0),
+            stats.job_id
+        );
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CacheStats {
+    pub configure_cached: bool,
+    pub configure_valid: bool,
+
+    pub subscribe_cached: bool,
+    pub subscribe_valid: bool,
+
+    pub difficulty_cached: bool,
+    pub difficulty_valid: bool,
+    pub difficulty_value: Option<f64>,
+
+    pub job_cached: bool,
+    pub job_valid: bool,
+    pub job_id: Option<String>,
+    pub job_age_seconds: Option<u64>,
+}
 
 /// Configuration for upstream pool connection
 #[derive(Debug, Clone)]
@@ -36,41 +276,49 @@ pub struct UpstreamShare {
 
 /// Upstream pool client that acts as a miner to the upstream pool
 pub struct UpstreamPoolClient {
+    /// Upstream pool connection configuration (hostname, port, credentials)
     config: UpstreamPoolConfig,
     /// Receive shares from miners to forward upstream
-    share_rx: mpsc::Receiver<UpstreamShare>,
+    share_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<UpstreamShare>>>,
     /// Send jobs from upstream to notifier
     job_tx: mpsc::Sender<JobNotification>,
+    /// Sends protocol notifications to local handlers
     notification_tx: mpsc::Sender<NotifyCmd>,
-    /// Send share responses back
-    response_tx: mpsc::Sender<(String, Value, u64)>, //  (worker_name, response, original_request_id)
-
-    /// Upstream connection state
+    /// Send share responses back (worker_name, response, original_request_id)
+    response_tx: mpsc::Sender<(String, Value, u64)>,
+    /// Cached extranonce1 value received from upstream
     extranonce1: Option<String>,
+    /// Cached extranonce2 size received from upstream
     extranonce2_size: Option<usize>,
+    /// Current difficulty as set by upstream
     upstream_difficulty: Option<f64>,
+    /// Next request ID to use for upstream requests
     next_request_id: u64,
-
-    pending_shares: HashMap<u64, (String, u64)>,
+    /// Tracks pending share submissions: request_id -> (worker_name, original_request_id, sent_at)
+    pending_shares: HashMap<u64, (String, u64, std::time::Instant)>,
+    /// Tracks pending configure requests: request_id -> response channel
     pending_requests: HashMap<u64, mpsc::Sender<Value>>,
-
+    /// Sends updated extranonce values to the stratum server
     extranonce_tx: Option<mpsc::Sender<(String, usize)>>,
-
+    /// Sends updated difficulty values to the stratum server
     difficulty_tx: Option<mpsc::Sender<f64>>,
-
-    configure_rx: mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>,
+    /// Receives mining.configure requests from miners to be forwarded upstream
+    configure_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>>>,
+    /// Shared cache for upstream responses and state
+    upstream_cache: Arc<RwLock<UpstreamCache>>,
 }
 
 impl UpstreamPoolClient {
     pub fn new(
         config: UpstreamPoolConfig,
-        share_rx: mpsc::Receiver<UpstreamShare>,
+        share_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<UpstreamShare>>>,
         job_tx: mpsc::Sender<JobNotification>,
         notification_tx: mpsc::Sender<NotifyCmd>,
         response_tx: mpsc::Sender<(String, Value, u64)>,
         extranonce_tx: Option<mpsc::Sender<(String, usize)>>,
         difficulty_tx: Option<mpsc::Sender<f64>>,
-        configure_rx: mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>,
+        configure_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>>>,
+        upstream_cache: Arc<RwLock<UpstreamCache>>,
     ) -> Self {
         Self {
             config,
@@ -87,98 +335,410 @@ impl UpstreamPoolClient {
             extranonce_tx,
             difficulty_tx,
             configure_rx,
+            upstream_cache,
         }
     }
 
     /// Connect to upstream pool and handle bidirectional communication
     pub async fn run(mut self) -> Result<(), StratumErrors> {
-        let mut retry_delay = std::time::Duration::from_secs(5);
-        let max_retry_delay = std::time::Duration::from_secs(60);
+        info!(
+            "Connecting to upstream pool at {}:{}",
+            self.config.hostname, self.config.port
+        );
 
-        loop {
-            info!(
-                "Connecting to upstream pool at {}:{}",
-                self.config.hostname, self.config.port
-            );
-
-            match self.connect_and_run().await {
-                Ok(_) => {
-                    info!("Upstream pool client disconnected gracefully");
-                    // Graceful disconnect, don't reconnect
-                    return Ok(());
-                }
-                Err(e) => {
-                    error!("Upstream connection error: {:?}", e);
-                    info!("Reconnecting in {:?}...", retry_delay);
-                    tokio::time::sleep(retry_delay).await;
-                    // Exponential backoff with max cap
-                    retry_delay = std::cmp::min(retry_delay * 2, max_retry_delay);
-                }
-            }
-        }
+        self.connect_and_run().await
     }
 
     /// Single connection attempt, handles all communication until disconnect
     async fn connect_and_run(&mut self) -> Result<(), StratumErrors> {
         let addr = format!("{}:{}", self.config.hostname, self.config.port);
-        let stream = TcpStream::connect(&addr).await.map_err(|e| {
-            StratumErrors::UpstreamConnectionFailed {
-                error: e.to_string(),
+
+        // Connection with timeout
+        let stream =
+            match tokio::time::timeout(Duration::from_secs(30), TcpStream::connect(&addr)).await {
+                Ok(Ok(stream)) => stream,
+                Ok(Err(e)) => {
+                    return Err(StratumErrors::UpstreamConnectionFailed {
+                        error: format!("Connection failed: {}", e),
+                    });
+                }
+                Err(_) => {
+                    return Err(StratumErrors::UpstreamConnectionFailed {
+                        error: "Connection timeout".to_string(),
+                    });
+                }
+            };
+
+        // Set TCP keepalive
+        if let Err(e) = stream.set_nodelay(true) {
+            warn!("Failed to set TCP_NODELAY: {}", e);
+        }
+
+        #[cfg(target_os = "linux")]
+        {
+            use std::time::Duration as StdDuration;
+            let keepalive = socket2::TcpKeepalive::new()
+                .with_time(StdDuration::from_secs(30))
+                .with_interval(StdDuration::from_secs(2))
+                .with_retries(3);
+
+            let sockref = socket2::SockRef::from(&stream);
+            if let Err(e) = sockref.set_tcp_keepalive(&keepalive) {
+                error!("Failed to set TCP keepalive: {}", e);
+                return Err(StratumErrors::UpstreamConnectionFailed {
+                    error: format!("Keepalive config failed: {}", e),
+                });
             }
-        })?;
+            info!("TCP keepalive enabled: idle=30s, interval=2s, retries=3 (dead connection detected in ~36s)");
+        }
+
+        #[cfg(not(target_os = "linux"))]
+        {
+            use std::time::Duration as StdDuration;
+            let keepalive = socket2::TcpKeepalive::new()
+                .with_time(StdDuration::from_secs(30))
+                .with_interval(StdDuration::from_secs(2));
+
+            let sockref = socket2::SockRef::from(&stream);
+            if let Err(e) = sockref.set_tcp_keepalive(&keepalive) {
+                warn!("Failed to set TCP keepalive: {}", e);
+            } else {
+                #[cfg(any(target_os = "macos", target_os = "windows"))]
+                info!("TCP keepalive enabled: idle=30s, interval=2s (dead connection detected in ~60-90s, system default retries)");
+
+                #[cfg(not(any(target_os = "macos", target_os = "windows")))]
+                info!("TCP keepalive enabled: idle=30s, interval=2s (platform-specific detection time)");
+            }
+        }
 
         let (reader, mut writer) = stream.into_split();
         let reader = BufReader::new(reader);
-        let mut framed = FramedRead::new(reader, LinesCodec::new());
-
+        let mut framed = FramedRead::new(reader, LinesCodec::new_with_max_length(64 * 1024));
         // Reset state for new connection
         self.extranonce1 = None;
         self.extranonce2_size = None;
         self.pending_shares.clear();
         self.pending_requests.clear();
         self.next_request_id = 1;
+        self.upstream_cache.write().await.clear();
+
+        // Send initial handshake
         self.send_subscribe(&mut writer).await?;
         self.send_authorize(&mut writer).await?;
-        info!("Connected to upstream pool");
+        info!("Connected to upstream pool at {}", addr);
+
+        let mut cleanup_interval = tokio::time::interval(Duration::from_secs(30));
+        let mut last_activity = std::time::Instant::now();
+        let activity_timeout = Duration::from_secs(120);
+        let read_timeout = Duration::from_secs(30);
 
         // Main event loop
         loop {
             tokio::select! {
                 // Handle incoming messages from upstream
-                result = framed.next() => {
+               result = tokio::time::timeout(read_timeout, framed.next()) => {
                     match result {
-                        Some(Ok(line)) => {
-                            self.handle_upstream_message(&line).await?;
+                        Ok(Some(Ok(line))) => {
+                            last_activity = std::time::Instant::now();
+                            if let Err(e) = self.handle_upstream_message(&line).await {
+                                error!("Error handling upstream message: {:?}", e);
+                            }
                         }
-                        Some(Err(e)) => {
+                        Ok(Some(Err(e))) => {
                             error!("Error reading from upstream: {}", e);
                             return Err(StratumErrors::UpstreamConnectionFailed {
-                                error: e.to_string(),
+                                error: format!("Read error: {}", e),
                             });
                         }
-                        None => {
-                            warn!("Upstream connection closed");
+                        Ok(None) => {
+                            warn!("Upstream connection closed by server");
                             return Err(StratumErrors::UpstreamConnectionFailed {
                                 error: "Connection closed by upstream".to_string(),
                             });
                         }
+                        Err(_elapsed) => {
+                            // Read timeout, check if connection is dead
+                            let elapsed_since_activity = last_activity.elapsed();
+                            if elapsed_since_activity > activity_timeout {
+                                error!(
+                                    "No upstream activity for {:?} - connection dead",
+                                    elapsed_since_activity
+                                );
+                                return Err(StratumErrors::UpstreamConnectionFailed {
+                                    error: format!(
+                                        "No activity for {:?}",
+                                        elapsed_since_activity
+                                    ),
+                                });
+                            } else {
+                                debug!(
+                                    "Read timeout after {:?}, last activity {:?} ago - continuing",
+                                    read_timeout,
+                                    elapsed_since_activity
+                                );
+                                // Continue the loop, not a dead connection yet
+                                continue;
+                            }
+                        }
                     }
                 }
+
                 // Forward shares from miners to upstream
-                Some(share) = self.share_rx.recv() => {
-                    if let Err(e) = self.forward_share(&mut writer, share).await {
-                        error!("Failed to forward share: {:?}", e);
+                share = async {
+                    let mut rx = self.share_rx.lock().await;
+                    rx.recv().await
+                } => {
+                    match share {
+                        Some(share) => {
+                            // Check queue depth after every Nth (100) share
+                            let check_frequency = 100;
+                            if self.next_request_id % check_frequency == 0 {
+                                let pending_count = {
+                                    let rx = self.share_rx.lock().await;
+                                    rx.len()
+                                };
+
+                                if pending_count > 5000 {
+                                    error!(
+                                        "Upstream share queue critically high: {} shares pending",
+                                        pending_count
+                                    );
+                                    error!("Upstream pool may be slow or disconnected");
+                                } else if pending_count > 1000 {
+                                    warn!(
+                                        "Upstream share queue growing: {} shares pending",
+                                        pending_count
+                                    );
+                                } else if pending_count > 0 && pending_count % 100 == 0 {
+                                    debug!("Upstream share queue: {} shares pending", pending_count);
+                                }
+                            }
+
+                            if self.extranonce1.is_none() {
+                                warn!(
+                                    "Cannot forward share for {} - upstream extranonce not set yet",
+                                    share.worker_name
+                                );
+                                // Send error response back to miner
+                                if let Err(e) = self.response_tx.send((
+                                    share.worker_name.clone(),
+                                    serde_json::json!({
+                                        "id": share.original_request_id,
+                                        "result": null,
+                                        "error": [21, "Upstream not ready", null]
+                                    }),
+                                    share.original_request_id
+                                )).await {
+                                    error!("Failed to send error response: {}", e);
+                                }
+                                continue;
+                            }
+
+                            match tokio::time::timeout(
+                                WRITE_TIMEOUT,
+                                self.forward_share(&mut writer, share.clone())
+                            ).await {
+                                Ok(Ok(())) => {
+                                    // Share forwarded successfully
+                                    last_activity = std::time::Instant::now();
+                                }
+                                Ok(Err(e)) => {
+                                    error!("Failed to forward share: {:?}", e);
+                                    // Connection might be broken, return to trigger reconnect
+                                    return Err(e);
+                                }
+                                Err(_elapsed) => {
+                                    error!(
+                                        "Share write timed out after {:?} for worker {}",
+                                        WRITE_TIMEOUT,
+                                        share.worker_name
+                                    );
+                                    // Send error back to miner
+                                    let _ = self.response_tx.send((
+                                        share.worker_name.clone(),
+                                        serde_json::json!({
+                                            "id": share.original_request_id,
+                                            "result": null,
+                                            "error": [23, "Share write timeout", null]
+                                        }),
+                                        share.original_request_id
+                                    )).await;
+
+                                    // Connection is likely dead, trigger reconnect
+                                    return Err(StratumErrors::UpstreamConnectionFailed {
+                                        error: format!(
+                                            "Share write timeout after {:?}",
+                                            WRITE_TIMEOUT
+                                        ),
+                                    });
+                                }
+                            }
+                        }
+                        None => {
+                            // All share senders dropped, very unlikely
+                            warn!("Share channel closed unexpectedly");
+                        }
                     }
                 }
+
                 // Handle mining.configure requests from miners
-                Some((params, request_id, response_tx)) = self.configure_rx.recv() => {
-                    if let Err(e) = self.forward_configure(&mut writer, &params, request_id, response_tx).await {
-                        error!("Failed to forward configure: {:?}", e);
+                configure = async {
+                    let mut rx = self.configure_rx.lock().await;
+                    rx.recv().await
+                } => {
+                    match configure {
+                        Some((params, request_id, response_tx)) => {
+                            // Check cache first
+                            let cache = self.upstream_cache.read().await;
+
+                            if let Some(cached_response) = &cache.configure_response {
+                                if cached_response.is_valid() {
+                                    info!("Serving mining.configure from cache");
+
+                                    let response = serde_json::json!({
+                                        "id": request_id,
+                                        "result": cached_response.value.get("result").cloned().unwrap_or(serde_json::json!({})),
+                                        "error": null
+                                    });
+
+                                    if let Err(e) = response_tx.send(response).await {
+                                        error!("Failed to send cached configure response: {}", e);
+                                    }
+
+                                    drop(cache);
+                                    continue;
+                                }
+                            }
+
+                            drop(cache);
+
+                            // If cache miss or expired, forward to upstream
+                            info!("Cache miss for mining.configure - forwarding to upstream pool");
+
+                           match tokio::time::timeout(
+                                WRITE_TIMEOUT,
+                                self.forward_configure(&mut writer, &params, request_id, response_tx.clone())
+                            ).await {
+                                Ok(Ok(())) => {
+                                    // Configure forwarded successfully
+                                    last_activity = std::time::Instant::now();
+                                    info!("Configure forwarded successfully");
+                                }
+                                Ok(Err(e)) => {
+                                    error!("Failed to forward configure: {:?}", e);
+                                    // Send error back to miner
+                                    let _ = response_tx.send(serde_json::json!({
+                                        "id": request_id,
+                                        "result": null,
+                                        "error": [24, "Configure forward failed", null]
+                                    })).await;
+
+                                    return Err(StratumErrors::UpstreamConnectionFailed {
+                                        error: "Configure forward failed".to_string(),
+                                    });
+                                }
+                                Err(_elapsed) => {
+                                    error!(
+                                        "Configure write timed out after {:?}",
+                                        WRITE_TIMEOUT
+                                    );
+                                    // Send error back to miner
+                                    let _ = response_tx.send(serde_json::json!({
+                                        "id": request_id,
+                                        "result": null,
+                                        "error": [23, "Configure write timeout", null]
+                                    })).await;
+
+                                    // kill connection for configure timeouts
+                                    return Err(StratumErrors::UpstreamConnectionFailed {
+                                        error: format!("Configure write timeout after {:?}", WRITE_TIMEOUT),
+                                    });
+                                }
+                            }
+                        }
+                        None => {
+                            warn!("Configure channel closed unexpectedly");
+                        }
                     }
                 }
-                else => {
-                    warn!("All channels closed, exiting upstream pool client");
-                    return Ok(()); // Graceful exit
+
+                // Periodic cleanup of stale requests
+                _ = cleanup_interval.tick() => {
+                    if last_activity.elapsed() > activity_timeout {
+                        error!(
+                            "No upstream activity in {:?}, assuming dead connection",
+                            activity_timeout
+                        );
+                        return Err(StratumErrors::UpstreamConnectionFailed {
+                            error: "Connection timeout - no activity".to_string(),
+                        });
+                    }
+
+                    // Clean up stale pending requests
+                    let before = self.pending_requests.len();
+                    self.pending_requests.retain(|_, tx| !tx.is_closed());
+                    let cleaned = before - self.pending_requests.len();
+                    if cleaned > 0 {
+                        debug!(
+                            cleaned_requests = cleaned,
+                            remaining = self.pending_requests.len(),
+                            "Cleaned up stale configure requests"
+                        );
+                    }
+
+                    // Clean up stale pending shares (older than 60 seconds)
+                    let now = std::time::Instant::now();
+                    let timeout = Duration::from_secs(60);
+                    let before_shares = self.pending_shares.len();
+                    self.pending_shares.retain(|request_id, (worker_name, _original_id, sent_at)| {
+                        let age = now.duration_since(*sent_at);
+                        if age > timeout {
+                            warn!(
+                                "Share from {} (request_id={}) timed out after {:?} - upstream never responded",
+                                worker_name,
+                                request_id,
+                                age
+                            );
+                            false  // Remove this entry
+                        } else {
+                            true  // Keep this entry
+                        }
+                    });
+                    let cleaned_shares = before_shares - self.pending_shares.len();
+                    if cleaned_shares > 0 {
+                        warn!(
+                            cleaned_shares = cleaned_shares,
+                            remaining = self.pending_shares.len(),
+                            "Cleaned up {} stale pending shares that upstream never responded to",
+                            cleaned_shares
+                        );
+                    }
+                    if self.pending_shares.len() > 100 || self.pending_requests.len() > 10 {
+                        warn!(
+                            "High pending counts - shares: {}, requests: {}",
+                            self.pending_shares.len(),
+                            self.pending_requests.len()
+                        );
+                    }
+
+                    {
+                        let mut cache = self.upstream_cache.write().await;
+
+                        if let Some(ref job_item) = cache.latest_job {
+                            if !job_item.is_valid() {
+                                warn!(
+                                    "Removing expired job from cache (age={}s, job_id={:?})",
+                                    job_item.age_seconds(),
+                                    job_item.value.job_id
+                                );
+                                cache.latest_job = None;
+                            }
+                        }
+                    }
+
+                    // Log cache stats periodically
+                    let cache = self.upstream_cache.read().await;
+                    cache.log_stats();
                 }
             }
         }
@@ -195,17 +755,17 @@ impl UpstreamPoolClient {
         });
         self.next_request_id += 1;
         let msg = format!("{}\n", subscribe_req);
-        writer.write_all(msg.as_bytes()).await.map_err(|e| {
-            StratumErrors::UpstreamConnectionFailed {
-                error: e.to_string(),
-            }
+        tokio::time::timeout(WRITE_TIMEOUT, async {
+            writer.write_all(msg.as_bytes()).await?;
+            writer.flush().await
+        })
+        .await
+        .map_err(|_| StratumErrors::UpstreamConnectionFailed {
+            error: format!("Subscribe write timeout after {:?}", WRITE_TIMEOUT),
+        })?
+        .map_err(|e| StratumErrors::UpstreamConnectionFailed {
+            error: e.to_string(),
         })?;
-        writer
-            .flush()
-            .await
-            .map_err(|e| StratumErrors::UpstreamConnectionFailed {
-                error: e.to_string(),
-            })?;
 
         info!("Sent subscribe to upstream pool");
         Ok(())
@@ -222,17 +782,18 @@ impl UpstreamPoolClient {
         });
         self.next_request_id += 1;
         let msg = format!("{}\n", authorize_req);
-        writer.write_all(msg.as_bytes()).await.map_err(|e| {
-            StratumErrors::UpstreamConnectionFailed {
-                error: e.to_string(),
-            }
+        tokio::time::timeout(WRITE_TIMEOUT, async {
+            writer.write_all(msg.as_bytes()).await?;
+            writer.flush().await
+        })
+        .await
+        .map_err(|_| StratumErrors::UpstreamConnectionFailed {
+            error: format!("Authorize write timeout after {:?}", WRITE_TIMEOUT),
+        })?
+        .map_err(|e| StratumErrors::UpstreamConnectionFailed {
+            error: e.to_string(),
         })?;
-        writer
-            .flush()
-            .await
-            .map_err(|e| StratumErrors::UpstreamConnectionFailed {
-                error: e.to_string(),
-            })?;
+
         info!("Sent authorize to upstream pool");
         Ok(())
     }
@@ -247,15 +808,6 @@ impl UpstreamPoolClient {
             }
         })?;
 
-        debug!(
-            "Pending requests: {:?}",
-            self.pending_requests.keys().collect::<Vec<_>>()
-        );
-        debug!(
-            "Pending shares: {:?}",
-            self.pending_shares.keys().collect::<Vec<_>>()
-        );
-
         // Check if this is a response (has "id" field that's not null)
         if let Some(id) = msg.get("id") {
             // Skip if id is null (notifications don't have numeric IDs)
@@ -263,7 +815,15 @@ impl UpstreamPoolClient {
                 if let Some(request_id) = id.as_u64() {
                     // Check if this is a pending configure request
                     if let Some(response_tx) = self.pending_requests.remove(&request_id) {
-                        info!("Received response for pending request {}", request_id);
+                        info!("Received configure response from upstream, caching it");
+                        let msg_clone = msg.clone();
+
+                        // Cache the response for future use
+                        {
+                            let mut cache = self.upstream_cache.write().await;
+                            cache.set_configure(msg_clone);
+                        }
+
                         if let Err(e) = response_tx.send(msg.clone()).await {
                             error!("Failed to forward response to miner: {}", e);
                         }
@@ -271,7 +831,7 @@ impl UpstreamPoolClient {
                     }
 
                     // Check if this is a pending share response
-                    if let Some((worker_name, original_request_id)) =
+                    if let Some((worker_name, original_request_id, _sent_at)) =
                         self.pending_shares.remove(&request_id)
                     {
                         info!(
@@ -359,6 +919,28 @@ impl UpstreamPoolClient {
                         if let Some(result) = msg.get("result").and_then(|r| r.as_array()) {
                             // result = [[subscriptions], extranonce1, extranonce2_size]
                             if result.len() >= 3 {
+                                // Parse subscriptions array
+                                let subscriptions: Vec<(String, String)> = result
+                                    .get(0)
+                                    .and_then(|v| v.as_array())
+                                    .map(|subs| {
+                                        subs.iter()
+                                            .filter_map(|sub| {
+                                                if let Some(arr) = sub.as_array() {
+                                                    if arr.len() >= 2 {
+                                                        let method = arr[0].as_str()?.to_string();
+                                                        let id = arr[1].as_str()?.to_string();
+                                                        return Some((method, id));
+                                                    }
+                                                }
+                                                None
+                                            })
+                                            .collect()
+                                    })
+                                    .unwrap_or_default();
+
+                                info!("Upstream subscriptions: {:?}", subscriptions);
+
                                 // Handle nested array for subscriptions, extranonce1 might be at index 1
                                 // Check if result[0] is an array (subscriptions) or string (some pools format differently)
                                 let (ext1_idx, ext2_idx) =
@@ -386,6 +968,24 @@ impl UpstreamPoolClient {
                                         "Upstream extranonce2 size: {} bytes = {} hex characters",
                                         ext2_size,
                                         ext2_size * 2
+                                    );
+                                }
+                                // Cache subscribe response
+                                if let (Some(extranonce1), Some(extranonce2_size)) =
+                                    (&self.extranonce1, self.extranonce2_size)
+                                {
+                                    let ext1_clone = extranonce1.clone();
+                                    {
+                                        let mut cache = self.upstream_cache.write().await;
+                                        cache.set_subscribe(
+                                            ext1_clone,
+                                            extranonce2_size,
+                                            &subscriptions,
+                                        );
+                                    }
+                                    info!(
+                                        "Cached upstream subscribe response with {} subscriptions",
+                                        subscriptions.len()
                                     );
                                 }
 
@@ -445,6 +1045,20 @@ impl UpstreamPoolClient {
                         job.job_id, job.clean_jobs
                     );
                     debug!("Upstream parsed job: {:?}", job);
+                    let should_log_stats = self.next_request_id % 10 == 0;
+
+                    // cache the job
+                    {
+                        let mut cache = self.upstream_cache.write().await;
+                        cache.set_latest_job(job.clone());
+                    }
+
+                    // Log cache stats every 10 jobs
+                    if should_log_stats {
+                        let cache = self.upstream_cache.read().await;
+                        cache.log_stats();
+                    }
+
                     // Also send to job_tx for main.rs
                     if let Err(e) = self.job_tx.send(job).await {
                         error!("Failed to send job to main: {}", e);
@@ -472,6 +1086,12 @@ impl UpstreamPoolClient {
 
                         self.upstream_difficulty = Some(difficulty);
                         info!("Upstream difficulty changed to: {}", difficulty);
+
+                        // Cache difficulty
+                        {
+                            let mut cache = self.upstream_cache.write().await;
+                            cache.set_difficulty(difficulty);
+                        }
 
                         // Broadcast to all miners via notification_tx
                         if let Err(e) = self
@@ -509,6 +1129,26 @@ impl UpstreamPoolClient {
                             "Upstream extranonce updated: {:?}, size={:?}",
                             self.extranonce1, self.extranonce2_size
                         );
+
+                        // cache extranonce
+                        if let (Some(ref extranonce1), Some(extranonce2_size)) =
+                            (&self.extranonce1, self.extranonce2_size)
+                        {
+                            let ext1_clone = extranonce1.clone();
+                            let existing_subs = {
+                                let cache = self.upstream_cache.read().await;
+                                cache
+                                    .get_subscribe()
+                                    .map(|sub_resp| sub_resp.subscriptions.clone())
+                                    .unwrap_or_default()
+                            };
+                            {
+                                let mut cache = self.upstream_cache.write().await;
+                                cache.set_subscribe(ext1_clone, extranonce2_size, &existing_subs);
+                            }
+                            info!("Updated cached extranonce from mining.set_extranonce (preserved {} subscriptions)", 
+                                existing_subs.len());
+                        }
 
                         // Send updated extranonce to stratum server
                         if let Some(ref tx) = self.extranonce_tx {
@@ -752,7 +1392,11 @@ impl UpstreamPoolClient {
         // Track request_id -> worker_name mapping
         self.pending_shares.insert(
             request_id,
-            (share.worker_name.clone(), share.original_request_id),
+            (
+                share.worker_name.clone(),
+                share.original_request_id,
+                std::time::Instant::now(),
+            ),
         );
         let msg = format!("{}\n", submit_req);
         writer.write_all(msg.as_bytes()).await.map_err(|e| {
@@ -768,7 +1412,7 @@ impl UpstreamPoolClient {
                 error: e.to_string(),
             })?;
 
-        info!(
+        debug!(
             "Forwarded share from {} to upstream (request_id={})",
             share.worker_name, request_id
         );
@@ -782,6 +1426,7 @@ impl UpstreamPoolClient {
         _request_id: u64,
         response_tx: mpsc::Sender<Value>,
     ) -> Result<(), StratumErrors> {
+        self.pending_requests.retain(|_, tx| !tx.is_closed());
         let configure_req = json!({
             "id": self.next_request_id,
             "method": "mining.configure",

--- a/node/src/upstream_pool.rs
+++ b/node/src/upstream_pool.rs
@@ -1,0 +1,815 @@
+// src/upstream_pool.rs
+use serde_json::{json, Value};
+use std::collections::HashMap;
+use tokio::{
+    io::{AsyncWriteExt, BufReader},
+    net::TcpStream,
+    sync::mpsc,
+};
+use tokio_stream::StreamExt;
+use tokio_util::codec::{FramedRead, LinesCodec};
+use tracing::{debug, error, info, warn};
+
+use crate::error::StratumErrors;
+use crate::stratum::{JobNotification, NotifyCmd};
+
+/// Configuration for upstream pool connection
+#[derive(Debug, Clone)]
+pub struct UpstreamPoolConfig {
+    pub hostname: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+/// Share to be forwarded to upstream pool
+#[derive(Debug, Clone)]
+pub struct UpstreamShare {
+    pub worker_name: String,
+    pub job_id: String,
+    pub extranonce2: String,
+    pub ntime: String,
+    pub nonce: String,
+    pub version_bits: Option<String>,
+    pub original_request_id: u64,
+}
+
+/// Upstream pool client that acts as a miner to the upstream pool
+pub struct UpstreamPoolClient {
+    config: UpstreamPoolConfig,
+    /// Receive shares from miners to forward upstream
+    share_rx: mpsc::Receiver<UpstreamShare>,
+    /// Send jobs from upstream to notifier
+    job_tx: mpsc::Sender<JobNotification>,
+    notification_tx: mpsc::Sender<NotifyCmd>,
+    /// Send share responses back
+    response_tx: mpsc::Sender<(String, Value, u64)>, //  (worker_name, response, original_request_id)
+
+    /// Upstream connection state
+    extranonce1: Option<String>,
+    extranonce2_size: Option<usize>,
+    upstream_difficulty: Option<f64>,
+    next_request_id: u64,
+
+    pending_shares: HashMap<u64, (String, u64)>,
+    pending_requests: HashMap<u64, mpsc::Sender<Value>>,
+
+    extranonce_tx: Option<mpsc::Sender<(String, usize)>>,
+
+    difficulty_tx: Option<mpsc::Sender<f64>>,
+
+    configure_rx: mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>,
+}
+
+impl UpstreamPoolClient {
+    pub fn new(
+        config: UpstreamPoolConfig,
+        share_rx: mpsc::Receiver<UpstreamShare>,
+        job_tx: mpsc::Sender<JobNotification>,
+        notification_tx: mpsc::Sender<NotifyCmd>,
+        response_tx: mpsc::Sender<(String, Value, u64)>,
+        extranonce_tx: Option<mpsc::Sender<(String, usize)>>,
+        difficulty_tx: Option<mpsc::Sender<f64>>,
+        configure_rx: mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>,
+    ) -> Self {
+        Self {
+            config,
+            share_rx,
+            job_tx,
+            notification_tx,
+            response_tx,
+            extranonce1: None,
+            extranonce2_size: None,
+            upstream_difficulty: None,
+            next_request_id: 1,
+            pending_shares: HashMap::new(),
+            pending_requests: HashMap::new(),
+            extranonce_tx,
+            difficulty_tx,
+            configure_rx,
+        }
+    }
+
+    /// Connect to upstream pool and handle bidirectional communication
+    pub async fn run(mut self) -> Result<(), StratumErrors> {
+        let mut retry_delay = std::time::Duration::from_secs(5);
+        let max_retry_delay = std::time::Duration::from_secs(60);
+
+        loop {
+            info!(
+                "Connecting to upstream pool at {}:{}",
+                self.config.hostname, self.config.port
+            );
+
+            match self.connect_and_run().await {
+                Ok(_) => {
+                    info!("Upstream pool client disconnected gracefully");
+                    // Graceful disconnect, don't reconnect
+                    return Ok(());
+                }
+                Err(e) => {
+                    error!("Upstream connection error: {:?}", e);
+                    info!("Reconnecting in {:?}...", retry_delay);
+                    tokio::time::sleep(retry_delay).await;
+                    // Exponential backoff with max cap
+                    retry_delay = std::cmp::min(retry_delay * 2, max_retry_delay);
+                }
+            }
+        }
+    }
+
+    /// Single connection attempt, handles all communication until disconnect
+    async fn connect_and_run(&mut self) -> Result<(), StratumErrors> {
+        let addr = format!("{}:{}", self.config.hostname, self.config.port);
+        let stream = TcpStream::connect(&addr).await.map_err(|e| {
+            StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            }
+        })?;
+
+        let (reader, mut writer) = stream.into_split();
+        let reader = BufReader::new(reader);
+        let mut framed = FramedRead::new(reader, LinesCodec::new());
+
+        // Reset state for new connection
+        self.extranonce1 = None;
+        self.extranonce2_size = None;
+        self.pending_shares.clear();
+        self.pending_requests.clear();
+        self.next_request_id = 1;
+        self.send_subscribe(&mut writer).await?;
+        self.send_authorize(&mut writer).await?;
+        info!("Connected to upstream pool");
+
+        // Main event loop
+        loop {
+            tokio::select! {
+                // Handle incoming messages from upstream
+                result = framed.next() => {
+                    match result {
+                        Some(Ok(line)) => {
+                            self.handle_upstream_message(&line).await?;
+                        }
+                        Some(Err(e)) => {
+                            error!("Error reading from upstream: {}", e);
+                            return Err(StratumErrors::UpstreamConnectionFailed {
+                                error: e.to_string(),
+                            });
+                        }
+                        None => {
+                            warn!("Upstream connection closed");
+                            return Err(StratumErrors::UpstreamConnectionFailed {
+                                error: "Connection closed by upstream".to_string(),
+                            });
+                        }
+                    }
+                }
+                // Forward shares from miners to upstream
+                Some(share) = self.share_rx.recv() => {
+                    if let Err(e) = self.forward_share(&mut writer, share).await {
+                        error!("Failed to forward share: {:?}", e);
+                    }
+                }
+                // Handle mining.configure requests from miners
+                Some((params, request_id, response_tx)) = self.configure_rx.recv() => {
+                    if let Err(e) = self.forward_configure(&mut writer, &params, request_id, response_tx).await {
+                        error!("Failed to forward configure: {:?}", e);
+                    }
+                }
+                else => {
+                    warn!("All channels closed, exiting upstream pool client");
+                    return Ok(()); // Graceful exit
+                }
+            }
+        }
+    }
+
+    async fn send_subscribe(
+        &mut self,
+        writer: &mut tokio::net::tcp::OwnedWriteHalf,
+    ) -> Result<(), StratumErrors> {
+        let subscribe_req = json!({
+            "id": self.next_request_id,
+            "method": "mining.subscribe",
+            "params": ["Braidpool/1.0.0"]
+        });
+        self.next_request_id += 1;
+        let msg = format!("{}\n", subscribe_req);
+        writer.write_all(msg.as_bytes()).await.map_err(|e| {
+            StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            }
+        })?;
+        writer
+            .flush()
+            .await
+            .map_err(|e| StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            })?;
+
+        info!("Sent subscribe to upstream pool");
+        Ok(())
+    }
+
+    async fn send_authorize(
+        &mut self,
+        writer: &mut tokio::net::tcp::OwnedWriteHalf,
+    ) -> Result<(), StratumErrors> {
+        let authorize_req = json!({
+            "id": self.next_request_id,
+            "method": "mining.authorize",
+            "params": [self.config.username, self.config.password]
+        });
+        self.next_request_id += 1;
+        let msg = format!("{}\n", authorize_req);
+        writer.write_all(msg.as_bytes()).await.map_err(|e| {
+            StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            }
+        })?;
+        writer
+            .flush()
+            .await
+            .map_err(|e| StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            })?;
+        info!("Sent authorize to upstream pool");
+        Ok(())
+    }
+
+    async fn handle_upstream_message(&mut self, line: &str) -> Result<(), StratumErrors> {
+        debug!("Raw upstream message: {}", line);
+
+        let msg: Value = serde_json::from_str(line).map_err(|e| {
+            error!("Failed to parse upstream message: {}", e);
+            StratumErrors::InvalidMethodParams {
+                method: "upstream_parse".to_string(),
+            }
+        })?;
+
+        debug!(
+            "Pending requests: {:?}",
+            self.pending_requests.keys().collect::<Vec<_>>()
+        );
+        debug!(
+            "Pending shares: {:?}",
+            self.pending_shares.keys().collect::<Vec<_>>()
+        );
+
+        // Check if this is a response (has "id" field that's not null)
+        if let Some(id) = msg.get("id") {
+            // Skip if id is null (notifications don't have numeric IDs)
+            if !id.is_null() {
+                if let Some(request_id) = id.as_u64() {
+                    // Check if this is a pending configure request
+                    if let Some(response_tx) = self.pending_requests.remove(&request_id) {
+                        info!("Received response for pending request {}", request_id);
+                        if let Err(e) = response_tx.send(msg.clone()).await {
+                            error!("Failed to forward response to miner: {}", e);
+                        }
+                        return Ok(()); // return early, don't process further
+                    }
+
+                    // Check if this is a pending share response
+                    if let Some((worker_name, original_request_id)) =
+                        self.pending_shares.remove(&request_id)
+                    {
+                        info!(
+                            "Received share response for {} (upstream_id={}, miner_id={})",
+                            worker_name, request_id, original_request_id
+                        );
+
+                        // Check if share was accepted or rejected
+                        if let Some(result) = msg.get("result") {
+                            if result.is_null() {
+                                // Result is null, check error field
+                                if let Some(error) = msg.get("error") {
+                                    if error.is_null() {
+                                        // Both result and error are null, but treat as success
+                                        warn!(
+                                            "Share response has null result and null error for {}",
+                                            worker_name
+                                        );
+                                    } else {
+                                        // Error is not null, share rejected
+                                        error!(
+                                            "SHARE REJECTED by upstream pool for worker: {}",
+                                            worker_name
+                                        );
+                                        error!("Error code: {:?}", error);
+                                        // Parse error details
+                                        if let Some(error_arr) = error.as_array() {
+                                            let error_code = error_arr
+                                                .get(0)
+                                                .and_then(|v| v.as_i64())
+                                                .unwrap_or(-1);
+                                            let error_msg = error_arr
+                                                .get(1)
+                                                .and_then(|v| v.as_str())
+                                                .unwrap_or("unknown");
+                                            error!("Error [{}]: {}", error_code, error_msg);
+                                        } else {
+                                            error!("Error details: {:?}", error);
+                                        }
+                                    }
+                                } else {
+                                    // Result is null but no error field
+                                    warn!(
+                                        "Share response for {} has null result and no error field",
+                                        worker_name
+                                    );
+                                }
+                            } else {
+                                // Result is not null, check if true
+                                if result == &json!(true) {
+                                    info!(
+                                        "SHARE ACCEPTED!!! by upstream pool for worker: {}",
+                                        worker_name
+                                    );
+                                    info!("Share successfully submitted to Ocean!");
+                                } else {
+                                    warn!(
+                                        "Share response for {} has unexpected result: {:?}",
+                                        worker_name, result
+                                    );
+                                }
+                            }
+                        } else {
+                            // No result field at all
+                            error!("Share response for {} missing 'result' field", worker_name);
+                        }
+
+                        // Forward the response back to main.rs
+                        if let Err(e) = self
+                            .response_tx
+                            .send((worker_name.clone(), msg.clone(), original_request_id))
+                            .await
+                        {
+                            error!("Failed to forward share response to main: {}", e);
+                        }
+                        return Ok(());
+                    }
+
+                    // Handle subscribe response
+                    if request_id == 1
+                        && msg.get("result").is_some()
+                        && msg.get("error").map_or(true, |e| e.is_null())
+                    {
+                        // Subscribe response, parse extranonce
+                        if let Some(result) = msg.get("result").and_then(|r| r.as_array()) {
+                            // result = [[subscriptions], extranonce1, extranonce2_size]
+                            if result.len() >= 3 {
+                                // Handle nested array for subscriptions, extranonce1 might be at index 1
+                                // Check if result[0] is an array (subscriptions) or string (some pools format differently)
+                                let (ext1_idx, ext2_idx) =
+                                    if result.get(0).map_or(false, |v| v.is_array()) {
+                                        (1, 2) // Standard format: [[subs], extranonce1, extranonce2_size]
+                                    } else {
+                                        (1, 2) // Same indices, just verify
+                                    };
+
+                                self.extranonce1 = result
+                                    .get(ext1_idx)
+                                    .and_then(|v| v.as_str())
+                                    .map(String::from);
+                                self.extranonce2_size = result
+                                    .get(ext2_idx)
+                                    .and_then(|v| v.as_u64())
+                                    .map(|v| v as usize);
+
+                                info!("Upstream subscribe successful!");
+                                info!("Extranonce1: {:?}", self.extranonce1);
+                                info!("Extranonce2 size: {:?}", self.extranonce2_size);
+
+                                if let Some(ext2_size) = self.extranonce2_size {
+                                    info!(
+                                        "Upstream extranonce2 size: {} bytes = {} hex characters",
+                                        ext2_size,
+                                        ext2_size * 2
+                                    );
+                                }
+
+                                // Send extranonce to stratum server
+                                if let Some(ref tx) = self.extranonce_tx {
+                                    if let (Some(ref ext1), Some(ext2_size)) =
+                                        (&self.extranonce1, self.extranonce2_size)
+                                    {
+                                        if let Err(e) = tx.send((ext1.clone(), ext2_size)).await {
+                                            error!("Failed to send extranonce to stratum: {}", e);
+                                        } else {
+                                            info!("Sent upstream extranonce to stratum server");
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        return Ok(());
+                    }
+
+                    // Handle authorize response (id=2 typically)
+                    if request_id == 2 && msg.get("result").is_some() {
+                        if let Some(result) = msg.get("result") {
+                            if result == &json!(true) {
+                                info!("Upstream authorize successful!");
+                            } else {
+                                error!("Upstream authorize failed: {:?}", msg.get("error"));
+                            }
+                        }
+                        return Ok(());
+                    }
+
+                    // Unknown response with numeric id
+                    warn!(
+                        "Received response for unknown request_id={}: {:?}",
+                        request_id, msg
+                    );
+                }
+            }
+        }
+
+        // Handle notifications (no id, or id is null) - mining.notify, mining.set_difficulty
+        if let Some(method) = msg.get("method").and_then(|m| m.as_str()) {
+            match method {
+                "mining.notify" => {
+                    let params =
+                        msg["params"]
+                            .as_array()
+                            .ok_or(StratumErrors::InvalidMethodParams {
+                                method: "mining.notify".to_string(),
+                            })?;
+
+                    // Parse job notification from upstream
+                    let job = self.parse_upstream_job(params)?;
+                    info!(
+                        "Received upstream job: {} (clean={})",
+                        job.job_id, job.clean_jobs
+                    );
+                    debug!("Upstream parsed job: {:?}", job);
+                    // Also send to job_tx for main.rs
+                    if let Err(e) = self.job_tx.send(job).await {
+                        error!("Failed to send job to main: {}", e);
+                    }
+                }
+
+                "mining.set_difficulty" => {
+                    let params =
+                        msg["params"]
+                            .as_array()
+                            .ok_or(StratumErrors::InvalidMethodParams {
+                                method: "mining.set_difficulty".to_string(),
+                            })?;
+
+                    if let Some(diff_value) = params.get(0) {
+                        // Parse difficulty (can be float or integer)
+                        let difficulty = if let Some(d) = diff_value.as_f64() {
+                            d
+                        } else if let Some(d) = diff_value.as_u64() {
+                            d as f64
+                        } else {
+                            error!("Invalid difficulty type from upstream: {:?}", diff_value);
+                            return Ok(());
+                        };
+
+                        self.upstream_difficulty = Some(difficulty);
+                        info!("Upstream difficulty changed to: {}", difficulty);
+
+                        // Broadcast to all miners via notification_tx
+                        if let Err(e) = self
+                            .notification_tx
+                            .send(NotifyCmd::BroadcastDifficulty { difficulty })
+                            .await
+                        {
+                            error!("Failed to send difficulty broadcast: {}", e);
+                        }
+
+                        // Also update ConnectionMapping for new subscribers
+                        if let Some(ref tx) = self.difficulty_tx {
+                            if let Err(e) = tx.send(difficulty).await {
+                                error!("Failed to update ConnectionMapping with difficulty: {}", e);
+                            }
+                        }
+                    }
+                }
+
+                "mining.set_extranonce" => {
+                    // Some pools send this to update extranonce mid-session
+                    let params =
+                        msg["params"]
+                            .as_array()
+                            .ok_or(StratumErrors::InvalidMethodParams {
+                                method: "mining.set_extranonce".to_string(),
+                            })?;
+
+                    if params.len() >= 2 {
+                        self.extranonce1 = params.get(0).and_then(|v| v.as_str()).map(String::from);
+                        self.extranonce2_size =
+                            params.get(1).and_then(|v| v.as_u64()).map(|v| v as usize);
+
+                        info!(
+                            "Upstream extranonce updated: {:?}, size={:?}",
+                            self.extranonce1, self.extranonce2_size
+                        );
+
+                        // Send updated extranonce to stratum server
+                        if let Some(ref tx) = self.extranonce_tx {
+                            if let (Some(ref ext1), Some(ext2_size)) =
+                                (&self.extranonce1, self.extranonce2_size)
+                            {
+                                if let Err(e) = tx.send((ext1.clone(), ext2_size)).await {
+                                    error!("Failed to send updated extranonce to stratum: {}", e);
+                                }
+                            }
+                        }
+                    }
+                }
+
+                _ => {
+                    debug!("Unhandled upstream method: {}", method);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    fn parse_upstream_job(&self, params: &[Value]) -> Result<JobNotification, StratumErrors> {
+        let job_id = params
+            .get(0)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                error!("Upstream job missing or empty job_id");
+                StratumErrors::ParamNotFound {
+                    param: "job_id".to_string(),
+                    method: "mining.notify".to_string(),
+                }
+            })?
+            .to_string();
+
+        let prevhash = params
+            .get(1)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                error!("Upstream job {} missing or empty prevhash", job_id);
+                StratumErrors::ParamNotFound {
+                    param: "prevhash".to_string(),
+                    method: "mining.notify".to_string(),
+                }
+            })?
+            .to_string();
+
+        let coinbase1 = params
+            .get(2)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                error!("Upstream job {} missing or empty coinbase1", job_id);
+                StratumErrors::ParamNotFound {
+                    param: "coinbase1".to_string(),
+                    method: "mining.notify".to_string(),
+                }
+            })?
+            .to_string();
+
+        let coinbase2 = params
+            .get(3)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                error!("Upstream job {} missing or empty coinbase2", job_id);
+                StratumErrors::ParamNotFound {
+                    param: "coinbase2".to_string(),
+                    method: "mining.notify".to_string(),
+                }
+            })?
+            .to_string();
+
+        let merkle_branches: Vec<String> = params
+            .get(4)
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+
+        let version = params
+            .get(5)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                error!("Upstream job {} missing or empty version", job_id);
+                StratumErrors::ParamNotFound {
+                    param: "version".to_string(),
+                    method: "mining.notify".to_string(),
+                }
+            })?
+            .to_string();
+
+        let nbits_str = params
+            .get(6)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                error!("Upstream job {} missing or empty nbits", job_id);
+                StratumErrors::ParamNotFound {
+                    param: "nbits".to_string(),
+                    method: "mining.notify".to_string(),
+                }
+            })?
+            .to_string();
+
+        let parsed_bits = match u32::from_str_radix(&nbits_str, 16) {
+            Ok(bits_u32) => {
+                if bits_u32 == 0 {
+                    error!("Upstream job {} has zero nbits", job_id);
+                    return Err(StratumErrors::InvalidMethodParams {
+                        method: "mining.notify: nbits cannot be zero".to_string(),
+                    });
+                }
+                Some(bitcoin::CompactTarget::from_consensus(bits_u32))
+            }
+            Err(e) => {
+                error!(
+                    "Upstream job {} has invalid nbits '{}': {}",
+                    job_id, nbits_str, e
+                );
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: format!(
+                        "mining.notify: nbits '{}' is not valid hex: {}",
+                        nbits_str, e
+                    ),
+                });
+            }
+        };
+
+        let ntime = params
+            .get(7)
+            .and_then(|v| v.as_str())
+            .filter(|s| !s.is_empty())
+            .ok_or_else(|| {
+                error!("Upstream job {} missing or empty ntime", job_id);
+                StratumErrors::ParamNotFound {
+                    param: "ntime".to_string(),
+                    method: "mining.notify".to_string(),
+                }
+            })?
+            .to_string();
+
+        // clean_jobs is optional, defaults to false
+        let clean_jobs = params.get(8).and_then(|v| v.as_bool()).unwrap_or(false);
+
+        // Parse upstream mining.notify params
+        Ok(JobNotification {
+            job_id,
+            prevhash,
+            coinbase1,
+            coinbase2,
+            merkle_branches,
+            version,
+            nbits: nbits_str,
+            ntime,
+            clean_jobs,
+            coinbase_witness_commitment: None,
+            parsed_bits,
+        })
+    }
+
+    async fn forward_share(
+        &mut self,
+        writer: &mut tokio::net::tcp::OwnedWriteHalf,
+        share: UpstreamShare,
+    ) -> Result<(), StratumErrors> {
+        if self.extranonce1.is_none() {
+            error!(
+                "Cannot forward share for {}, upstream extranonce1 not set!",
+                share.worker_name
+            );
+            return Err(StratumErrors::UpstreamShareForwardFailed {
+                error: "Upstream extranonce1 not configured, share cannot be forwarded".to_string(),
+            });
+        }
+
+        if let Some(expected_size) = self.extranonce2_size {
+            let expected_hex_len = expected_size * 2; // where each byte = 2 hex chars
+            let actual_hex_len = share.extranonce2.len();
+
+            if actual_hex_len != expected_hex_len {
+                error!(
+                    "Invalid extranonce2 length for worker {}: expected {} hex chars ({} bytes), got {} hex chars",
+                    share.worker_name,
+                    expected_hex_len,
+                    expected_size,
+                    actual_hex_len
+                );
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: format!(
+                        "mining.submit: extranonce2 '{}' has wrong length (expected {} hex chars)",
+                        share.extranonce2, expected_hex_len
+                    ),
+                });
+            }
+
+            // validate it's valid hex
+            if hex::decode(&share.extranonce2).is_err() {
+                error!(
+                    "Invalid extranonce2 hex for worker {}: '{}'",
+                    share.worker_name, share.extranonce2
+                );
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: format!(
+                        "mining.submit: extranonce2 '{}' is not valid hex",
+                        share.extranonce2
+                    ),
+                });
+            }
+        } else {
+            warn!("Cannot validate extranonce2 length, upstream extranonce2_size not set");
+        }
+
+        let mut params = vec![
+            json!(self.config.username),
+            json!(share.job_id),
+            json!(share.extranonce2),
+            json!(share.ntime),
+            json!(share.nonce),
+        ];
+
+        if let Some(version_bits) = share.version_bits {
+            params.push(json!(version_bits));
+        }
+
+        let request_id = self.next_request_id;
+        let submit_req = json!({
+            "id": request_id,
+            "method": "mining.submit",
+            "params": params
+        });
+        self.next_request_id += 1;
+
+        // Track request_id -> worker_name mapping
+        self.pending_shares.insert(
+            request_id,
+            (share.worker_name.clone(), share.original_request_id),
+        );
+        let msg = format!("{}\n", submit_req);
+        writer.write_all(msg.as_bytes()).await.map_err(|e| {
+            StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            }
+        })?;
+
+        writer
+            .flush()
+            .await
+            .map_err(|e| StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            })?;
+
+        info!(
+            "Forwarded share from {} to upstream (request_id={})",
+            share.worker_name, request_id
+        );
+        Ok(())
+    }
+
+    pub async fn forward_configure(
+        &mut self,
+        writer: &mut tokio::net::tcp::OwnedWriteHalf,
+        params: &Value,
+        _request_id: u64,
+        response_tx: mpsc::Sender<Value>,
+    ) -> Result<(), StratumErrors> {
+        let configure_req = json!({
+            "id": self.next_request_id,
+            "method": "mining.configure",
+            "params": params
+        });
+
+        let upstream_request_id = self.next_request_id;
+        self.next_request_id += 1;
+
+        // Store response channel for this request
+        self.pending_requests
+            .insert(upstream_request_id, response_tx);
+
+        let msg = format!("{}\n", configure_req);
+        writer.write_all(msg.as_bytes()).await.map_err(|e| {
+            StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            }
+        })?;
+
+        writer
+            .flush()
+            .await
+            .map_err(|e| StratumErrors::UpstreamConnectionFailed {
+                error: e.to_string(),
+            })?;
+
+        info!("Forwarded mining.configure to upstream pool");
+        Ok(())
+    }
+}

--- a/node/src/upstream_pool.rs
+++ b/node/src/upstream_pool.rs
@@ -1377,10 +1377,21 @@ impl UpstreamPoolClient {
             json!(share.nonce),
         ];
 
+        let version_bits_for_log = share.version_bits.clone();
         if let Some(version_bits) = share.version_bits {
             params.push(json!(version_bits));
         }
-
+        debug!(
+            worker = %share.worker_name,
+            job_id = %share.job_id,
+            extranonce2 = %share.extranonce2,
+            extranonce2_len = %share.extranonce2.len(),
+            ntime = %share.ntime,
+            nonce = %share.nonce,
+            version_bits = ?version_bits_for_log,
+            upstream_username = %self.config.username,
+            "Forwarding share to upstream with params"
+        );
         let request_id = self.next_request_id;
         let submit_req = json!({
             "id": request_id,


### PR DESCRIPTION
### Background
The problem with today's mining pool is there is no way to independently verify the pool’s internal data by miners; share logs are private to the pool, which leaves the question of whether miners are paid fairly according to their contribution and hashing power and whether pools are fairly keeping track of their submitted shares. For now all is done under an opaque system where no miner knows about their statistics transparently. 

This is the first PR in the path of enabling [audit](https://github.com/braidpool/braidpool/blob/main/docs/derivatives.md) mode in Braidpool. Using this PR, one can easily connect through the upstream pool and mine on that using Braidpool as an intermediate node. For now you can mine on "Ocean" which is supported by this PR, but in the future there will be more upstream pool options to choose from. A user needs to connect to Braidpool while passing some CLI args (e.g payout_address, port, username and password), and all the connection with the upstream pool is done by Braidpool internally.  This will allow you to audit your work transparently, using the Directed Acyclic Graph (DAG) which is the Braidpool internal cryptographically attested system to keep track of each miner's work. To know more about this, one can refer to [braid consensus](https://github.com/braidpool/braidpool/blob/main/docs/braid_consensus.md) and [specification](https://github.com/braidpool/braidpool/blob/main/docs/braidpool_spec.md) docs. In the future one can also download their contribution records in a triple accounting fashion to keep track of each and all of his shares. This will help users in accounting, risk management and miner monitoring.

### Actual

This PR introduces two new files, `upstream_pool.rs` and `audit.rs` where `upstream_pool.rs` is mainly used to communicate with the upstream pool and `audit.rs` is used to track the miner's valid shares. Apart from that, the PR also changes some parts of `stratum.rs` where it integrates the audit mode functionality in a way that both features are self-isolated and independent from each other, meaning running audit mode will not affect the normal Braidpool operations and vice versa. This is also fixed and strengthens some existing parts of the code in `stratum.rs`, where there were some inconsistencies in the stratum.rs still exist in the existing codebase. I don't feel right making those changes in the same PR, so that will be done in some other one. Here is the basic list of what I fixed in the existing `stratum.rs` code:
- Previously in `handle_connection` connections could stay registered after TCP write failures, leaving stale entries in `ConnectionMapping` and consuming resources, but now it does immediate connection teardown on write failures.
- The most critical/significant fix is that previously in the handle_submit the lock was held for more than 200+ lines, which was somewhat time-consuming and inefficient, which is now done under 41 lines of code, without any expensive operation. This way `handle_submit` was split into two separations: lock-protected and lock-free computation.
- Adds extranonce2 validation and explicit authorization check in `handle_submit`.

Apart from that, these are changes focused on new features for audit mode:
- `TemplateId` Bifurcation: This will distinguish between Braidpool and upstream jobs.
- Bifurcated Job Lookup in `handle_submit`: this will try to look for jobs by string first and fall back to numeric parsing. Allowing both hex (for upstream) and numeric (for Braidpool) job IDs.
- In `run_notifier` added `NotifyCmd::SendUpstreamJob` this forwards upstream pool jobs to miners transparently.
- `handle_configure` now can relay mining configuration to upstream pool and use its settings.
- New CLI flags `--audit` plus required `--upstream-host`, `--upstream-port`, `--upstream-username`, `--upstream-password`.
- Inside `upstream_pool.rs` introduced `UpstreamPoolConfig`, `UpstreamShare`, and `UpstreamPoolClient` which behaves like a miner towards the upstream pool: it sends `mining.subscribe`, `mining.authorize`, `mining.submit`, `mining.configure`, and parses `mining.notify` / `difficulty` / `extranonce` messages.
- Implemented full DAG construction in Audit Mode. Since we cannot modify the upstream Coinbase to insert OP_RETURN commitments, we now use a Composite Hash `(hash(header || metadata))` to uniquely identify beads and insert them into the local Braidpool DAG.
- This now embeds a 5 byte commitment to the local parent bead inside the `extranonce1` sent to the miner (we embed this into extranonce2 while sending to the upstream pool to be compatible with pool consensus). This creates a cryptographically verifiable link between the miner's work and the DAG tip.
- Introduced the `UpdateExtranonce` enum variant of `NotifyCmd`, which sends the updated extranonce commitment to all the connected miners at variable intervals upon receiving the new job from the upstream pool, which is later used as the verifiable audit commitment.
- The `audit.rs` introduces some major structs like `MinerAuditState`, `AuditDAG`, `MinerStats` and `AuditRecord`, which is used to verify the individual shares, adding them into the existing DAG, provides a link between shares and detailed audit records, managing miner statistics and commitment tracking.
### How to run?

Running the Braidpool with audit mode is easy you just need to pass some CLI flags relevant to audit mode. Here is a simple structure:

```
cargo run  -- \
  --audit \
  --upstream-host example.pool.xyz \
  --upstream-port 3334 \
  --upstream-username your_pool_username \
  --upstream-password your_pool_password \
  --miner-difficulty 1000.0
```
Here is the example CLI command:
```
cargo run -- \
  --audit \
  --upstream-host mine.ocean.xyz \
  --upstream-port 3334 \
  --upstream-username bc1qse6fmltgm39k9976eghu787cap5atgrg0yrhtv.mine \
  --upstream-password x
  --miner-difficulty 1000.0
```
Note: The implementation of the difficulty adjustment algorithm is not yet developed for the main Braidpool operation (without audit mode) and its out of scope for this PR and this project of audit mode to create such algorithm. That's why I included a new CLI argument (`--miner-difficulty`) for the user to set the miner difficulty using CLI until we come up with the difficulty adjustment algorithm.

Note: This PR only enables mining on the upstream pool (Ocean) using Braidpool as an intermediate node its not tested with any other pool but as long as some upstream pool communicates with the 4 bytes for `extranonce1` and 8 bytes for `extranonce2`, this will work fine any other sizes of extranonces will not work according to the current Braidpool audit rules and consensus. Please don't treat this PR as the final version of audit mode.


