### PR TITLE
Change IPC listener block size heuristic to transaction count

### DIFF
--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -401,7 +401,7 @@ async fn get_template(
     block_height: u32,
     network: Network,
 ) -> Result<client::BlockTemplate, Box<dyn std::error::Error>> {
-    const MIN_TEMPLATE_SIZE: usize = 256;
+    const MIN_TRANSACTION_COUNT: u64 = 1;
     const NONCE: u32 = 0;
     let config = CoinbaseConfig::for_network(network);
 
@@ -412,17 +412,19 @@ async fn get_template(
     let final_template =
         create_braidpool_template(&components.components, &config, block_height, NONCE)?;
 
+    let template_transaction_count = final_template.block_transaction_count();
+
     let complete_block_bytes = final_template.complete_block_hex;
     if complete_block_bytes.is_empty() {
         return Err("Received empty template (0 bytes)".into());
     }
 
-    if complete_block_bytes.len() < MIN_TEMPLATE_SIZE {
+    if template_transaction_count < MIN_TRANSACTION_COUNT {
         warn!(
             context = %context,
-            size_bytes = %complete_block_bytes.len(),
-            min_template_size = %MIN_TEMPLATE_SIZE,
-            "Template smaller than minimum template size - using anyway"
+            transaction_count = %template_transaction_count,
+            min_transaction_count = %MIN_TRANSACTION_COUNT,
+            "Template tx count smaller than minimum - using anyway"
         );
     }
 

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -56,9 +56,11 @@ pub struct FinalTemplate {
 }
 
 impl FinalTemplate {
+    const BLOCK_HEADER_LENGTH: usize = 80;
+
     pub fn block_hash(&self) -> Vec<u8> {
-        if self.complete_block_hex.len() >= 80 {
-            let header = &self.complete_block_hex[0..80];
+        if self.complete_block_hex.len() >= Self::BLOCK_HEADER_LENGTH {
+            let header = &self.complete_block_hex[0..Self::BLOCK_HEADER_LENGTH];
             let hash = sha256d::Hash::hash(header).to_byte_array();
             let mut reversed_hash = hash;
             reversed_hash.reverse();
@@ -69,8 +71,8 @@ impl FinalTemplate {
     }
 
     pub fn get_nonce(&self) -> u32 {
-        if self.complete_block_hex.len() >= 80 {
-            let nonce_bytes = &self.complete_block_hex[76..80];
+        if self.complete_block_hex.len() >= Self::BLOCK_HEADER_LENGTH {
+            let nonce_bytes = &self.complete_block_hex[76..Self::BLOCK_HEADER_LENGTH];
             u32::from_le_bytes([
                 nonce_bytes[0],
                 nonce_bytes[1],
@@ -89,8 +91,8 @@ impl FinalTemplate {
 
     /// Returns just the block header as bytes
     pub fn block_header(&self) -> Vec<u8> {
-        if self.complete_block_hex.len() >= 80 {
-            self.complete_block_hex[0..80].to_vec()
+        if self.complete_block_hex.len() >= Self::BLOCK_HEADER_LENGTH {
+            self.complete_block_hex[0..Self::BLOCK_HEADER_LENGTH].to_vec()
         } else {
             Vec::new()
         }
@@ -105,8 +107,8 @@ impl FinalTemplate {
     ///
     /// The number of transactions is the first `varint` field after the block header.
     pub fn block_transaction_count(&self) -> u64 {
-        if self.complete_block_hex.len() >= 80 {
-            let body = &self.complete_block_hex[80..];
+        if self.complete_block_hex.len() >= Self::BLOCK_HEADER_LENGTH {
+            let body = &self.complete_block_hex[Self::BLOCK_HEADER_LENGTH..];
             match decode_varint(body) {
                 Ok((count, _)) => count,
                 Err(_) => 0,

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -81,6 +81,7 @@ impl FinalTemplate {
             0
         }
     }
+
     /// Returns the block hash as hex string
     pub fn block_hash_hex(&self) -> String {
         hex::encode(self.block_hash())
@@ -98,6 +99,21 @@ impl FinalTemplate {
     /// Returns the size of the complete block in bytes
     pub fn block_size(&self) -> usize {
         self.complete_block_hex.len()
+    }
+
+    /// Returns the number of transactions in the block
+    ///
+    /// The number of transactions is the first `varint` field after the block header.
+    pub fn block_transaction_count(&self) -> u64 {
+        if self.complete_block_hex.len() >= 80 {
+            let body = &self.complete_block_hex[80..];
+            match decode_varint(body) {
+                Ok((count, _)) => count,
+                Err(_) => 0,
+            }
+        } else {
+            0
+        }
     }
 }
 


### PR DESCRIPTION
This PR is a follow up to #312 to change the block size heuristic from `256` bytes to number (`1`) of transactions.
- Introduces a new accessor method named `block_transaction_count()` in `FinalTemplate` which peeks at the first `varint` after the block header to return the number of transactions in the block template.
- Checks the transaction count against `MIN_TRANSACTION_COUNT=2` instead of the old `MIN_TEMPLATE_SIZE`.
- Refactors `FinalTemplate` accessors to use a constant `BLOCK_HEADER_LENGTH` instead of hardcoding `80` everywhere for better readability.

Questions:
- Contributor guidelines read like there should only be one commit per PR. Including the refactor commit along with this PR felt right to me - let me know if you prefer a separate PR for that.
- I didn't see existing unit tests for the `FinalTemplate` accessors or I would have included one for `block_transaction_count()`. If there is somewhere else to look for tests, please LMK. Can also work on adding one if required.

Closes #314 