### PR TITLE
Enable Graph Download Feature

### DIFF
--- a/dashboard/src/components/BeadsTab/AdvancedChart.tsx
+++ b/dashboard/src/components/BeadsTab/AdvancedChart.tsx
@@ -7,66 +7,117 @@ import {
   CartesianGrid,
   ResponsiveContainer,
 } from 'recharts';
+import { useRef } from 'react';
+import ActionIconButton from '../common/ActionIconButton';
+import { downloadSvgFromContainer } from '../../utils/downloadSvg';
 
 import { AdvancedchartProps } from './lib/Types';
+
+const CHART_HEIGHT = 350;
 
 export default function AdvancedChart({
   data,
   yLabel,
   unit,
   lineColor = '#3b82f6',
+  title,
+  description,
+  headerRight,
+  downloadFileName = 'advanced-chart',
 }: AdvancedchartProps) {
+  const chartContainerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleDownload = () => {
+    if (!chartContainerRef.current) return;
+    downloadSvgFromContainer(chartContainerRef.current, downloadFileName);
+  };
+
   return (
-    <div className=" relative border border-gray-800/50 rounded-xl p-4 h-auto backdrop-blur-md overflow-hidden  ">
-      <ResponsiveContainer width="100%" height={350}>
-        <LineChart data={data}>
-          <CartesianGrid stroke="#444" />
-          <XAxis
-            className="text-sm"
-            dataKey="timestamp"
-            domain={['auto', 'auto']}
-            type="number"
-            scale="time"
-            tickFormatter={(ts) =>
-              new Date(ts).toLocaleTimeString([], {
-                hour: '2-digit',
-                minute: '2-digit',
-                second: '2-digit',
-              })
-            }
-            tick={{ fill: '#aaa' }}
-          />
-          <YAxis
-            className="text-sm"
-            tick={{ fill: '#aaa' }}
-            unit={` ${unit}`}
-          />
-          <Tooltip
-            contentStyle={{
-              backgroundColor: '#2d2d2d',
-              borderColor: '#555',
-            }}
-            labelFormatter={(ts) =>
-              new Date(ts).toLocaleTimeString([], {
-                hour: '2-digit',
-                minute: '2-digit',
-                second: '2-digit',
-              })
-            }
-            formatter={(value: number) => [
-              `${value.toFixed(2)} ${unit}`,
-              yLabel,
-            ]}
-          />
-          <Line
-            type="monotone"
-            dataKey="value"
-            stroke={lineColor}
-            strokeWidth={2}
-            dot={false}
-          />
-        </LineChart>
-      </ResponsiveContainer>
+    <div
+      className="relative border border-gray-800/50 rounded-xl p-4 w-full backdrop-blur-md overflow-hidden"
+      style={{ minHeight: title ? CHART_HEIGHT + 48 : CHART_HEIGHT }}
+    >
+      {title && (
+        <div className="flex items-start justify-between mb-4">
+          <div className="flex flex-col">
+            <div className="flex items-center gap-2">
+              <h3 className="text-xl font-bold text-blue-300">{title}</h3>
+              <ActionIconButton
+                onClick={handleDownload}
+                ariaLabel="Download chart"
+                icon={
+                  <svg
+                    xmlns="http://www.w3.org/2000/svg"
+                    viewBox="0 0 20 20"
+                    fill="currentColor"
+                  >
+                    <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
+                    <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
+                  </svg>
+                }
+              />
+            </div>
+            {description && (
+              <div className="text-sm text-gray-400 mt-1">{description}</div>
+            )}
+          </div>
+          {headerRight && <div>{headerRight}</div>}
+        </div>
+      )}
+      <div
+        ref={chartContainerRef}
+        style={{ width: '100%', height: CHART_HEIGHT }}
+      >
+        <ResponsiveContainer width="100%" height="100%">
+          <LineChart data={data}>
+            <CartesianGrid stroke="#444" />
+            <XAxis
+              className="text-sm"
+              dataKey="timestamp"
+              domain={['auto', 'auto']}
+              type="number"
+              scale="time"
+              tickFormatter={(ts) =>
+                new Date(ts).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  second: '2-digit',
+                })
+              }
+              tick={{ fill: '#aaa' }}
+            />
+            <YAxis
+              className="text-sm"
+              tick={{ fill: '#aaa' }}
+              unit={` ${unit}`}
+            />
+            <Tooltip
+              contentStyle={{
+                backgroundColor: '#2d2d2d',
+                borderColor: '#555',
+              }}
+              labelFormatter={(ts) =>
+                new Date(ts).toLocaleTimeString([], {
+                  hour: '2-digit',
+                  minute: '2-digit',
+                  second: '2-digit',
+                })
+              }
+              formatter={(value: number) => [
+                `${value.toFixed(2)} ${unit}`,
+                yLabel,
+              ]}
+            />
+            <Line
+              type="monotone"
+              dataKey="value"
+              stroke={lineColor}
+              strokeWidth={2}
+              dot={false}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 }

--- a/dashboard/src/components/BeadsTab/Reward/RewardsDashboard.tsx
+++ b/dashboard/src/components/BeadsTab/Reward/RewardsDashboard.tsx
@@ -13,10 +13,18 @@ import { calculateRewardAnalytics } from '../lib/Utils';
 import { RewardPoint } from '../lib/Types';
 import { StatCard } from './RewardStats';
 import { WEBSOCKET_URLS } from '@/URLs';
+import ActionIconButton from '../../common/ActionIconButton';
+import { downloadSvgFromContainer } from '../../../utils/downloadSvg';
 
 export function RewardsDashboard() {
   const [rewardHistory, setRewardHistory] = useState<RewardPoint[]>([]);
   const wsRef = useRef<WebSocket | null>(null);
+  const rewardsChartRef = useRef<HTMLDivElement | null>(null);
+
+  const handleDownloadRewardsChart = () => {
+    if (!rewardsChartRef.current) return;
+    downloadSvgFromContainer(rewardsChartRef.current, 'block-rewards-chart');
+  };
 
   useEffect(() => {
     const ws = new WebSocket(WEBSOCKET_URLS.MAIN_WEBSOCKET);
@@ -124,10 +132,25 @@ export function RewardsDashboard() {
       </div>
 
       {/* Chart */}
-      <div className="w-full h-[400px]  p-6 rounded-xl border border-gray-700">
+      <div className="w-full h-[400px] p-6 rounded-xl border border-gray-700 relative">
         <div className="flex justify-between items-center mb-4">
-          <h2 className="text-white text-lg font-semibold">Block Rewards</h2>
-          <span className="text-gray-400 text-sm">
+          <div className="flex items-center gap-2">
+            <h2 className="text-white text-lg font-semibold">Block Rewards</h2>
+            <ActionIconButton
+              onClick={handleDownloadRewardsChart}
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
+                  <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
+                </svg>
+              }
+            />
+          </div>
+          <span className="text-gray-400 pt-2 text-sm">
             ({rewardHistory.length} blocks)
           </span>
         </div>
@@ -137,70 +160,72 @@ export function RewardsDashboard() {
             <div className="text-gray-400">Waiting for block data...</div>
           </div>
         ) : (
-          <ResponsiveContainer width="100%" height="90%">
-            <LineChart data={rewardHistory}>
-              <CartesianGrid strokeDasharray="3 3" stroke="#333" />
-              <XAxis dataKey="height" stroke="#aaa" />
-              <YAxis
-                yAxisId="left"
-                stroke="#fbbf24"
-                domain={['auto', 'auto']}
-              />
-              <YAxis
-                yAxisId="right"
-                orientation="right"
-                stroke="#60a5fa"
-                domain={['auto', 'auto']}
-              />
-              <Tooltip
-                content={({ active, payload, label }) => {
-                  if (active && payload && payload.length) {
-                    const timestamp = payload[0]?.payload?.timestamp;
-                    const formattedTime = timestamp
-                      ? new Date(timestamp).toLocaleTimeString()
-                      : 'N/A';
+          <div ref={rewardsChartRef} className="w-full h-[90%]">
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={rewardHistory}>
+                <CartesianGrid strokeDasharray="3 3" stroke="#333" />
+                <XAxis dataKey="height" stroke="#aaa" />
+                <YAxis
+                  yAxisId="left"
+                  stroke="#fbbf24"
+                  domain={['auto', 'auto']}
+                />
+                <YAxis
+                  yAxisId="right"
+                  orientation="right"
+                  stroke="#60a5fa"
+                  domain={['auto', 'auto']}
+                />
+                <Tooltip
+                  content={({ active, payload, label }) => {
+                    if (active && payload && payload.length) {
+                      const timestamp = payload[0]?.payload?.timestamp;
+                      const formattedTime = timestamp
+                        ? new Date(timestamp).toLocaleTimeString()
+                        : 'N/A';
 
-                    return (
-                      <div className=" bg-[#1a1a1a] text-gray-400 sm:text-xs md:text-base border border-xl border-gray-500 p-2 rounded-sm">
-                        <p>Height: {label}</p>
-                        <p>Time: {formattedTime}</p>
-                        {payload.map((item, index) => {
-                          const value =
-                            typeof item.value === 'number'
-                              ? item.value.toFixed(2)
-                              : item.value;
-                          return (
-                            <p key={index}>
-                              {item.name}: {value}
-                            </p>
-                          );
-                        })}
-                      </div>
-                    );
-                  }
-                  return null;
-                }}
-              />
+                      return (
+                        <div className=" bg-[#1a1a1a] text-gray-400 sm:text-xs md:text-base border border-xl border-gray-500 p-2 rounded-sm">
+                          <p>Height: {label}</p>
+                          <p>Time: {formattedTime}</p>
+                          {payload.map((item, index) => {
+                            const value =
+                              typeof item.value === 'number'
+                                ? item.value.toFixed(2)
+                                : item.value;
+                            return (
+                              <p key={index}>
+                                {item.name}: {value}
+                              </p>
+                            );
+                          })}
+                        </div>
+                      );
+                    }
+                    return null;
+                  }}
+                />
 
-              <Legend />
-              <Line
-                yAxisId="left"
-                type="monotone"
-                dataKey="rewardBTC"
-                stroke="#fbbf24"
-                name="BTC Reward"
-                dot={false}
-              />
-              <Line
-                yAxisId="right"
-                type="monotone"
-                dataKey="rewardUSD"
-                stroke="#60a5fa"
-                name="USD Reward"
-                dot={false}
-              />
-            </LineChart>
-          </ResponsiveContainer>
+                <Legend />
+                <Line
+                  yAxisId="left"
+                  type="monotone"
+                  dataKey="rewardBTC"
+                  stroke="#fbbf24"
+                  name="BTC Reward"
+                  dot={false}
+                />
+                <Line
+                  yAxisId="right"
+                  type="monotone"
+                  dataKey="rewardUSD"
+                  stroke="#60a5fa"
+                  name="USD Reward"
+                  dot={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
         )}
       </div>
     </div>

--- a/dashboard/src/components/BeadsTab/Trends/Difficulty.tsx
+++ b/dashboard/src/components/BeadsTab/Trends/Difficulty.tsx
@@ -66,28 +66,25 @@ export const Difficulty = () => {
 
   return (
     <div className="space-y-6 ">
-      <div className="flex justify-between items-center">
-        <div>
-          <h3 className="text-xl font-bold text-blue-300">
-            Network Difficulty
-          </h3>
-        </div>
-        <div className="bg-purple-900/30 px-3 py-1 rounded-md">
-          <span className="text-purple-300 font-mono">
-            Current Difficulty :{' '}
-            {chartData.length > 0
-              ? `${chartData[chartData.length - 1].value} T`
-              : 'Loading...'}
-          </span>
-        </div>
-      </div>
-
       <div>
         <AdvancedChart
           data={chartData}
           yLabel="Difficulty"
           unit="T"
           lineColor="#8884d8"
+          title="Network Difficulty"
+          description="Bitcoin network difficulty over time (in Trillions)"
+          headerRight={
+            <div className="bg-purple-900/30 px-3 py-1 rounded-md">
+              <span className="text-purple-300 font-mono">
+                Current Difficulty :{' '}
+                {chartData.length > 0
+                  ? `${chartData[chartData.length - 1].value} T`
+                  : 'Loading...'}
+              </span>
+            </div>
+          }
+          downloadFileName="network-difficulty"
         />
       </div>
     </div>

--- a/dashboard/src/components/BeadsTab/Trends/HashrateTab.tsx
+++ b/dashboard/src/components/BeadsTab/Trends/HashrateTab.tsx
@@ -132,26 +132,22 @@ export default function HashrateTab({ timeRange }: { timeRange: string }) {
 
   return (
     <div className="space-y-4  ">
-      <div className="flex justify-between items-center">
-        <div>
-          <h3 className="text-xl font-bold text-blue-300">Pool Hashrate</h3>
-          <p className="text-sm text-gray-400 mt-1">
-            Live hashrate of the Braidpool
-          </p>
-        </div>
-        <div className="bg-purple-900/30 px-3 py-1 rounded-md">
-          <span className="text-purple-300 font-mono">
-            {hashrateData.current}
-          </span>
-        </div>
-      </div>
-
       <div>
         <AdvancedChart
           data={chartData}
           yLabel="Hashrate"
           unit="EH/s"
           lineColor="#8884d8"
+          title="Pool Hashrate"
+          description="Live hashrate of the Braidpool"
+          headerRight={
+            <div className="bg-purple-900/30 px-3 py-1 rounded-md">
+              <span className="text-purple-300 font-mono">
+                {hashrateData.current}
+              </span>
+            </div>
+          }
+          downloadFileName="pool-hashrate"
         />
       </div>
 

--- a/dashboard/src/components/BeadsTab/Trends/LatencyTab.tsx
+++ b/dashboard/src/components/BeadsTab/Trends/LatencyTab.tsx
@@ -142,27 +142,23 @@ export default function LatencyTab({ timeRange }: { timeRange: string }) {
   // ✅ Render UI
   return (
     <div className="space-y-4 ">
-      <div className="flex justify-between items-center">
-        <div>
-          <h3 className="text-xl font-bold text-blue-300">Network Latency</h3>
-          <p className="text-sm text-gray-400 mt-1">
-            Real-time latency measurements from peer nodes
-          </p>
-        </div>
-        <div className="bg-purple-900/30 px-3 py-1 rounded-md">
-          <span className="text-purple-300 font-mono">
-            Avg: {latencyData.averageLatency} | {latencyData.validPings}/
-            {latencyData.peerCount} peers
-          </span>
-        </div>
-      </div>
-
       <div>
         <AdvancedChart
           data={chartData}
           yLabel="Latency"
           unit="ms"
           lineColor="#8884d8"
+          title="Network Latency"
+          description="Real-time latency measurements from peer nodes"
+          headerRight={
+            <div className="bg-purple-900/30 px-3 py-1 rounded-md">
+              <span className="text-purple-300 font-mono">
+                Avg: {latencyData.averageLatency} | {latencyData.validPings}/
+                {latencyData.peerCount} peers
+              </span>
+            </div>
+          }
+          downloadFileName="network-latency"
         />
       </div>
 

--- a/dashboard/src/components/BeadsTab/Trends/TransactionsTab.tsx
+++ b/dashboard/src/components/BeadsTab/Trends/TransactionsTab.tsx
@@ -121,43 +121,43 @@ export default function TransactionsTab({ timeRange }: TransactionTabProps) {
 
   return (
     <div className="space-y-4 ">
-      <div className="flex justify-between items-center">
-        <div>
-          <h3 className="text-xl font-bold text-blue-300">
-            Transaction Activity
-          </h3>
-          <p className="text-sm text-gray-400 mt-1">
-            Real-time transaction statistics
-          </p>
-          {error && <p className="text-sm text-red-400 mt-1">Error: {error}</p>}
-          {!isConnected && !error && (
-            <p className="text-sm text-yellow-400 mt-1">Disconnected</p>
-          )}
-        </div>
-        <div className="flex items-center gap-4">
-          <div className="bg-purple-900/30 px-3 py-1 rounded-md">
-            <div className="text-center">
-              <span className="text-purple-300 font-mono text-lg">
-                {getCurrentRate()
-                  ? `${getCurrentRate().toFixed(1)} tx/min`
-                  : isLoading
-                    ? 'Loading...'
-                    : 'No data'}
-              </span>
-              <div className="text-xs text-purple-400 mt-1">
-                {getRateLabel()}
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-
       <div>
         <AdvancedChart
           data={chartData.slice(-10)}
           yLabel="Transactions per Block"
           unit="tx"
           lineColor="#8884d8"
+          title="Transaction Activity"
+          description={
+            <>
+              Real-time transaction statistics
+              {error && (
+                <div className="text-sm text-red-400 mt-1">Error: {error}</div>
+              )}
+              {!isConnected && !error && (
+                <div className="text-sm text-yellow-400 mt-1">Disconnected</div>
+              )}
+            </>
+          }
+          headerRight={
+            <div className="flex items-center gap-4">
+              <div className="bg-purple-900/30 px-3 py-1 rounded-md">
+                <div className="text-center">
+                  <span className="text-purple-300 font-mono text-lg">
+                    {getCurrentRate()
+                      ? `${getCurrentRate().toFixed(1)} tx/min`
+                      : isLoading
+                        ? 'Loading...'
+                        : 'No data'}
+                  </span>
+                  <div className="text-xs text-purple-400 mt-1">
+                    {getRateLabel()}
+                  </div>
+                </div>
+              </div>
+            </div>
+          }
+          downloadFileName="transaction-activity"
         />
       </div>
 

--- a/dashboard/src/components/BeadsTab/Trends/__tests__/HashrateTab.test.tsx
+++ b/dashboard/src/components/BeadsTab/Trends/__tests__/HashrateTab.test.tsx
@@ -4,9 +4,26 @@ import { beforeEach, describe, it } from '@jest/globals';
 import '@testing-library/jest-dom';
 global.WebSocket = require('ws');
 
-jest.mock('../../AdvancedChart', () => () => (
-  <div data-testid="advanced-chart" />
-));
+jest.mock(
+  '../../AdvancedChart',
+  () =>
+    ({
+      title,
+      description,
+      headerRight,
+    }: {
+      title?: string;
+      description?: React.ReactNode;
+      headerRight?: React.ReactNode;
+    }) => (
+      <div data-testid="advanced-chart">
+        {title && <h3>{title}</h3>}
+        {description && <div>{description}</div>}
+        {headerRight && <div>{headerRight}</div>}
+        Chart
+      </div>
+    )
+);
 jest.mock('../../AnimatedStatCard', () => ({ title, value }: any) => (
   <div data-testid="animated-stat">{`${title}: ${value}`}</div>
 ));

--- a/dashboard/src/components/BeadsTab/Trends/__tests__/LatencyTab.test.tsx
+++ b/dashboard/src/components/BeadsTab/Trends/__tests__/LatencyTab.test.tsx
@@ -6,9 +6,26 @@ global.WebSocket = require('ws');
 
 import '@testing-library/jest-dom';
 
-jest.mock('../../AdvancedChart', () => () => (
-  <div data-testid="advanced-chart">Chart</div>
-));
+jest.mock(
+  '../../AdvancedChart',
+  () =>
+    ({
+      title,
+      description,
+      headerRight,
+    }: {
+      title?: string;
+      description?: React.ReactNode;
+      headerRight?: React.ReactNode;
+    }) => (
+      <div data-testid="advanced-chart">
+        {title && <h3>{title}</h3>}
+        {description && <div>{description}</div>}
+        {headerRight && <div>{headerRight}</div>}
+        Chart
+      </div>
+    )
+);
 
 jest.mock('../../AnimatedStatCard', () => ({ title, value }: any) => (
   <div data-testid="animated-stat">{`${title}: ${value}`}</div>

--- a/dashboard/src/components/BeadsTab/Trends/__tests__/TransactionsTab.test.tsx
+++ b/dashboard/src/components/BeadsTab/Trends/__tests__/TransactionsTab.test.tsx
@@ -2,9 +2,26 @@ import { render, screen, act, cleanup } from '@testing-library/react';
 import TransactionsTab from '../TransactionsTab';
 import '@testing-library/jest-dom';
 
-jest.mock('../../AdvancedChart', () => () => (
-  <div data-testid="advanced-chart">Chart</div>
-));
+jest.mock(
+  '../../AdvancedChart',
+  () =>
+    ({
+      title,
+      description,
+      headerRight,
+    }: {
+      title?: string;
+      description?: React.ReactNode;
+      headerRight?: React.ReactNode;
+    }) => (
+      <div data-testid="advanced-chart">
+        {title && <h3>{title}</h3>}
+        {description && <div>{description}</div>}
+        {headerRight && <div>{headerRight}</div>}
+        Chart
+      </div>
+    )
+);
 jest.mock('../../AnimatedStatCard', () => ({ title, value }: any) => (
   <div data-testid="animated-stat">{`${title}: ${value}`}</div>
 ));

--- a/dashboard/src/components/BeadsTab/lib/Types.ts
+++ b/dashboard/src/components/BeadsTab/lib/Types.ts
@@ -142,6 +142,10 @@ export interface AdvancedchartProps {
   yLabel: string;
   unit: string;
   lineColor?: string;
+  title?: string;
+  description?: React.ReactNode;
+  headerRight?: React.ReactNode;
+  downloadFileName?: string;
 }
 //Reward section
 

--- a/dashboard/src/components/BitcoinStats/Prices.tsx
+++ b/dashboard/src/components/BitcoinStats/Prices.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import {
   BarChart,
   Bar,
@@ -21,9 +21,10 @@ import {
 } from './Utils';
 import TransactionTable from './TransactionTable';
 import RBFTransactionTable from './RBFTransactionTable';
-import { useRef } from 'react';
 import { WEBSOCKET_URLS } from '../../URLs';
 import { MAX_HISTORY_ITEMS } from './Constants';
+import ActionIconButton from '../common/ActionIconButton';
+import { downloadSvgFromContainer } from '../../utils/downloadSvg';
 
 const CURRENCIES = ['USD', 'EUR', 'GBP', 'JPY'] as const;
 
@@ -47,6 +48,21 @@ const BitcoinPriceTracker: React.FC = () => {
   // MAX_HISTORY_ITEMS is imported from BeadsTab/Constants
   const showSkeletons = loading || !isConnected || (!priceData && !globalStats);
   const currencyRef = useRef(currency);
+  const priceRangeChartRef = useRef<HTMLDivElement | null>(null);
+  const priceHistoryChartRef = useRef<HTMLDivElement | null>(null);
+
+  const handleDownloadPriceRange = () => {
+    if (!priceRangeChartRef.current) return;
+    downloadSvgFromContainer(priceRangeChartRef.current, 'bitcoin-price-range');
+  };
+
+  const handleDownloadPriceHistory = () => {
+    if (!priceHistoryChartRef.current) return;
+    downloadSvgFromContainer(
+      priceHistoryChartRef.current,
+      'bitcoin-price-history'
+    );
+  };
 
   useEffect(() => {
     currencyRef.current = currency;
@@ -326,108 +342,142 @@ const BitcoinPriceTracker: React.FC = () => {
       {/* Charts Section */}
       <div className="w-full flex flex-wrap justify-center items-center gap-4 md:gap-20 p-4 mt-4 md:p-6 rounded-lg mb-6">
         {/* Price Range Bar Chart */}
-        <div className="flex flex-col w-full h-80 -mx-6 sm:mx-0 px-6 sm:px-0">
-          <p className="font-semibold text-base">Bitcoin Price Range (24h)</p>
+        <div className="flex flex-col w-full h-80 -mx-6 sm:mx-0 px-6 sm:px-0 relative">
+          <div className="flex items-center gap-2 mb-2">
+            <p className="font-semibold text-base">Bitcoin Price Range (24h)</p>
+            <ActionIconButton
+              onClick={handleDownloadPriceRange}
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
+                  <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
+                </svg>
+              }
+            />
+          </div>
           <span className="text-sm text-gray-500 mb-2">
             Displays the 24-hour low, current, and 24-hour high prices in{' '}
             {currency}
           </span>
-          <ResponsiveContainer width="100%" height="100%">
-            <BarChart
-              data={[
-                { label: '24h Low', value: priceData?.low24h ?? 0 },
-                { label: 'Current', value: priceData?.current ?? 0 },
-                { label: '24h High', value: priceData?.high24h ?? 0 },
-              ]}
-              margin={{
-                left: -5,
-                right: -5,
-                top: 20,
-                bottom: 20,
-              }}
-            >
-              <XAxis dataKey="label" tick={{ fontSize: 12 }} />
-              <YAxis
-                width={50}
-                tick={{ fontSize: 10 }}
-                domain={[
-                  (dataMin: number) =>
-                    Math.floor(
-                      dataMin -
-                        (priceData
-                          ? (priceData.high24h - priceData.low24h) * 0.1
-                          : 0)
-                    ),
-                  (dataMax: number) =>
-                    Math.ceil(
-                      dataMax +
-                        (priceData
-                          ? (priceData.high24h - priceData.low24h) * 0.1
-                          : 0)
-                    ),
+          <div ref={priceRangeChartRef} className="flex-1">
+            <ResponsiveContainer width="100%" height="100%">
+              <BarChart
+                data={[
+                  { label: '24h Low', value: priceData?.low24h ?? 0 },
+                  { label: 'Current', value: priceData?.current ?? 0 },
+                  { label: '24h High', value: priceData?.high24h ?? 0 },
                 ]}
-                tickFormatter={(value) =>
-                  `${getCurrencySymbol(currency)}${formatPrice(value)}`
-                }
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: 'black',
-                  border: '1px solid #ccc',
-                  fontSize: '12px',
+                margin={{
+                  left: -5,
+                  right: -5,
+                  top: 20,
+                  bottom: 20,
                 }}
-                formatter={(value) => [
-                  `${getCurrencySymbol(currency)}${formatPrice(Number(value))}`,
-                  'Price',
-                ]}
-              />
-              <Legend wrapperStyle={{ fontSize: '12px' }} />
-              <Bar dataKey="value" fill="#8884d8" />
-            </BarChart>
-          </ResponsiveContainer>
+              >
+                <XAxis dataKey="label" tick={{ fontSize: 12 }} />
+                <YAxis
+                  width={50}
+                  tick={{ fontSize: 10 }}
+                  domain={[
+                    (dataMin: number) =>
+                      Math.floor(
+                        dataMin -
+                          (priceData
+                            ? (priceData.high24h - priceData.low24h) * 0.1
+                            : 0)
+                      ),
+                    (dataMax: number) =>
+                      Math.ceil(
+                        dataMax +
+                          (priceData
+                            ? (priceData.high24h - priceData.low24h) * 0.1
+                            : 0)
+                      ),
+                  ]}
+                  tickFormatter={(value) =>
+                    `${getCurrencySymbol(currency)}${formatPrice(value)}`
+                  }
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'black',
+                    border: '1px solid #ccc',
+                    fontSize: '12px',
+                  }}
+                  formatter={(value) => [
+                    `${getCurrencySymbol(currency)}${formatPrice(Number(value))}`,
+                    'Price',
+                  ]}
+                />
+                <Legend wrapperStyle={{ fontSize: '12px' }} />
+                <Bar dataKey="value" fill="#8884d8" />
+              </BarChart>
+            </ResponsiveContainer>
+          </div>
         </div>
 
         {/* Price History Line Chart */}
-        <div className="flex flex-col w-full h-80">
-          <p className="font-semibold text-base">
-            Bitcoin Price History (Live)
-          </p>
+        <div className="flex flex-col w-full h-80 relative">
+          <div className="flex items-center gap-2 mb-2">
+            <p className="font-semibold text-base">
+              Bitcoin Price History (Live)
+            </p>
+            <ActionIconButton
+              onClick={handleDownloadPriceHistory}
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
+                  <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
+                </svg>
+              }
+            />
+          </div>
           <span className="text-sm text-gray-500 mb-2">
             Live updates in {currency}
           </span>
-          <ResponsiveContainer width="99%" height="100%">
-            <LineChart
-              data={priceHistory}
-              margin={{ left: 60, right: 40, top: 20, bottom: 20 }}
-            >
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="time" tick={{ fontSize: 10 }} interval={0} />
-              <YAxis
-                domain={['auto', 'auto']}
-                tickFormatter={(value) =>
-                  `${getCurrencySymbol(currency)}${formatPrice(value)}`
-                }
-              />
-              <Tooltip
-                contentStyle={{
-                  backgroundColor: 'black',
-                  border: '1px solid #ccc',
-                }}
-                formatter={(value) => [
-                  `${getCurrencySymbol(currency)}${formatPrice(Number(value))}`,
-                  'Price',
-                ]}
-                labelFormatter={(label) => `Time: ${label}`}
-              />
-              <Line
-                type="monotone"
-                dataKey="price"
-                stroke="#8884d8"
-                dot={false}
-                isAnimationActive={false}
-              />
-            </LineChart>
-          </ResponsiveContainer>
+          <div ref={priceHistoryChartRef} className="flex-1">
+            <ResponsiveContainer width="99%" height="100%">
+              <LineChart
+                data={priceHistory}
+                margin={{ left: 60, right: 40, top: 20, bottom: 20 }}
+              >
+                <CartesianGrid strokeDasharray="3 3" />
+                <XAxis dataKey="time" tick={{ fontSize: 10 }} interval={0} />
+                <YAxis
+                  domain={['auto', 'auto']}
+                  tickFormatter={(value) =>
+                    `${getCurrencySymbol(currency)}${formatPrice(value)}`
+                  }
+                />
+                <Tooltip
+                  contentStyle={{
+                    backgroundColor: 'black',
+                    border: '1px solid #ccc',
+                  }}
+                  formatter={(value) => [
+                    `${getCurrencySymbol(currency)}${formatPrice(Number(value))}`,
+                    'Price',
+                  ]}
+                  labelFormatter={(label) => `Time: ${label}`}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="price"
+                  stroke="#8884d8"
+                  dot={false}
+                  isAnimationActive={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          </div>
         </div>
       </div>
 

--- a/dashboard/src/components/Mempool/MempoolLatencyStats.tsx
+++ b/dashboard/src/components/Mempool/MempoolLatencyStats.tsx
@@ -22,6 +22,8 @@ import {
 import { currencyLabels, currencyColors } from './Constants';
 import { WEBSOCKET_URLS } from '@/URLs';
 import { Loader } from 'lucide-react';
+import ActionIconButton from '../common/ActionIconButton';
+import { downloadSvgFromContainer } from '../../utils/downloadSvg';
 
 const MempoolLatencyStats = () => {
   const wsRef = useRef<WebSocket | null>(null);
@@ -34,6 +36,21 @@ const MempoolLatencyStats = () => {
     []
   );
   const [wsConnected, setWsConnected] = useState(false);
+  const feeDistChartRef = useRef<HTMLDivElement | null>(null);
+  const blockFeeChartRef = useRef<HTMLDivElement | null>(null);
+
+  const handleDownloadFeeDist = () => {
+    if (!feeDistChartRef.current) return;
+    downloadSvgFromContainer(
+      feeDistChartRef.current,
+      'mempool-fee-distribution'
+    );
+  };
+
+  const handleDownloadBlockFees = () => {
+    if (!blockFeeChartRef.current) return;
+    downloadSvgFromContainer(blockFeeChartRef.current, 'mempool-block-fees');
+  };
 
   useEffect(() => {
     const ws = new WebSocket(WEBSOCKET_URLS.MAIN_WEBSOCKET);
@@ -190,11 +207,26 @@ const MempoolLatencyStats = () => {
         </div>
 
         {/* --- Fee Rate Distribution --- */}
-        <div className="shadow p-6">
+        <div className="shadow p-6 relative">
+          <div className="absolute right-3 top-3 z-10">
+            <ActionIconButton
+              onClick={handleDownloadFeeDist}
+              icon={
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  viewBox="0 0 20 20"
+                  fill="currentColor"
+                >
+                  <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
+                  <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
+                </svg>
+              }
+            />
+          </div>
           <h3 className="text-lg font-semibold text-center mb-4">
             Live Fee Rate Distribution
           </h3>
-          <div className="h-64">
+          <div className="h-64" ref={feeDistChartRef}>
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={feeDistChartData}>
                 <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
@@ -218,8 +250,23 @@ const MempoolLatencyStats = () => {
       </section>
 
       {/* --- Block Fee Chart --- */}
-      <section className="shadow p-6">
-        <div className="flex justify-between items-center mb-4 flex-wrap">
+      <section className="shadow p-6 relative">
+        <div className="absolute right-3 top-0 z-10">
+          <ActionIconButton
+            onClick={handleDownloadBlockFees}
+            icon={
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
+                <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
+              </svg>
+            }
+          />
+        </div>
+        <div className="flex justify-between items-center mb-4 flex-wrap pt-4">
           <h2 className="text-lg font-semibold">Live Block Fees</h2>
 
           <select
@@ -242,77 +289,79 @@ const MempoolLatencyStats = () => {
           </select>
         </div>
 
-        <ResponsiveContainer width="100%" height={400}>
-          <LineChart data={blockFeeChartData}>
-            <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
-            <XAxis dataKey="time" stroke="#9ca3af" />
-            <YAxis stroke="#9ca3af" />
-            <Tooltip
-              contentStyle={{
-                backgroundColor: '#1f2937',
-                borderRadius: '8px',
-                border: 'none',
-                color: '#ffffff',
-                padding: '15px',
-                fontSize: '14px',
-              }}
-              formatter={(value: number, name: string) => [
-                name === 'btc'
-                  ? `${Number(value).toFixed(6)} BTC`
-                  : name === 'jpy'
-                    ? `¥${Number(value).toFixed(0)}`
-                    : name === 'eur'
-                      ? `€${Number(value).toFixed(2)}`
-                      : name === 'usd'
-                        ? `${Number(value).toFixed(2)}`
-                        : `${Number(value).toFixed(2)}`,
-                currencyLabels[name] || name,
-              ]}
-            />
-            <Legend />
+        <div ref={blockFeeChartRef}>
+          <ResponsiveContainer width="100%" height={400}>
+            <LineChart data={blockFeeChartData}>
+              <CartesianGrid strokeDasharray="3 3" stroke="#374151" />
+              <XAxis dataKey="time" stroke="#9ca3af" />
+              <YAxis stroke="#9ca3af" />
+              <Tooltip
+                contentStyle={{
+                  backgroundColor: '#1f2937',
+                  borderRadius: '8px',
+                  border: 'none',
+                  color: '#ffffff',
+                  padding: '15px',
+                  fontSize: '14px',
+                }}
+                formatter={(value: number, name: string) => [
+                  name === 'btc'
+                    ? `${Number(value).toFixed(6)} BTC`
+                    : name === 'jpy'
+                      ? `¥${Number(value).toFixed(0)}`
+                      : name === 'eur'
+                        ? `€${Number(value).toFixed(2)}`
+                        : name === 'usd'
+                          ? `${Number(value).toFixed(2)}`
+                          : `${Number(value).toFixed(2)}`,
+                  currencyLabels[name] || name,
+                ]}
+              />
+              <Legend />
 
-            {(selectedView === 'btc' || selectedView === 'all') && (
-              <Line
-                type="monotone"
-                dataKey="btc"
-                stroke={currencyColors.btc}
-                strokeWidth={2}
-                dot={{ r: 4 }}
-                name="BTC"
-              />
-            )}
-            {(selectedView === 'usd' || selectedView === 'all') && (
-              <Line
-                type="monotone"
-                dataKey="usd"
-                stroke={currencyColors.usd}
-                strokeWidth={2}
-                dot={{ r: 4 }}
-                name="USD"
-              />
-            )}
-            {(selectedView === 'eur' || selectedView === 'all') && (
-              <Line
-                type="monotone"
-                dataKey="eur"
-                stroke={currencyColors.eur}
-                strokeWidth={2}
-                dot={{ r: 4 }}
-                name="EUR"
-              />
-            )}
-            {(selectedView === 'jpy' || selectedView === 'all') && (
-              <Line
-                type="monotone"
-                dataKey="jpy"
-                stroke={currencyColors.jpy}
-                strokeWidth={2}
-                dot={{ r: 4 }}
-                name="JPY"
-              />
-            )}
-          </LineChart>
-        </ResponsiveContainer>
+              {(selectedView === 'btc' || selectedView === 'all') && (
+                <Line
+                  type="monotone"
+                  dataKey="btc"
+                  stroke={currencyColors.btc}
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  name="BTC"
+                />
+              )}
+              {(selectedView === 'usd' || selectedView === 'all') && (
+                <Line
+                  type="monotone"
+                  dataKey="usd"
+                  stroke={currencyColors.usd}
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  name="USD"
+                />
+              )}
+              {(selectedView === 'eur' || selectedView === 'all') && (
+                <Line
+                  type="monotone"
+                  dataKey="eur"
+                  stroke={currencyColors.eur}
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  name="EUR"
+                />
+              )}
+              {(selectedView === 'jpy' || selectedView === 'all') && (
+                <Line
+                  type="monotone"
+                  dataKey="jpy"
+                  stroke={currencyColors.jpy}
+                  strokeWidth={2}
+                  dot={{ r: 4 }}
+                  name="JPY"
+                />
+              )}
+            </LineChart>
+          </ResponsiveContainer>
+        </div>
       </section>
     </div>
   );

--- a/dashboard/src/components/NodeHealth/Bandwidth.tsx
+++ b/dashboard/src/components/NodeHealth/Bandwidth.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useRef } from 'react';
 import {
   LineChart,
   Line,
@@ -11,10 +11,19 @@ import {
 
 import { BandwidthPanelProps } from './Types';
 import { formatBytes } from './Utils';
+import ActionIconButton from '../common/ActionIconButton';
+import { downloadSvgFromContainer } from '../../utils/downloadSvg';
 
 const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
   bandwidthHistory,
 }) => {
+  const chartContainerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleDownload = () => {
+    if (!chartContainerRef.current) return;
+    downloadSvgFromContainer(chartContainerRef.current, 'bandwidth-usage');
+  };
+
   if (bandwidthHistory.length === 0) {
     return (
       <div className="bg-[#1e1e1e] border border-gray-700 rounded-xl shadow-md p-4 text-center text-white">
@@ -24,47 +33,64 @@ const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
   }
 
   return (
-    <div className="bg-[#1e1e1e] border border-gray-700 rounded-xl shadow-md p-4">
+    <div className="bg-[#1e1e1e] border border-gray-700 rounded-xl shadow-md p-4 relative">
+      <div className="absolute right-3 top-3 z-10">
+        <ActionIconButton
+          onClick={handleDownload}
+          icon={
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 20 20"
+              fill="currentColor"
+            >
+              <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
+              <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
+            </svg>
+          }
+        />
+      </div>
       <h3 className="text-lg font-semibold text-white mb-4 text-center">
         Real-Time Bandwidth Usage
       </h3>
 
-      <ResponsiveContainer width="100%" height={350}>
-        <LineChart
-          data={bandwidthHistory}
-          margin={{ top: 30, right: 30, left: 0, bottom: 5 }}
-        >
-          <CartesianGrid strokeDasharray="3 3" stroke="#444" />
-          <XAxis
-            dataKey="timestamp"
-            tickFormatter={(ts) => new Date(ts).toLocaleTimeString()}
-            stroke="#aaa"
-          />
-          <YAxis
-            stroke="#aaa"
-            tickFormatter={(value) => formatBytes(value)}
-            allowDataOverflow
-          />
-          <Tooltip
-            contentStyle={{ backgroundColor: '#222', borderColor: '#555' }}
-            labelFormatter={(ts) => new Date(ts).toLocaleTimeString()}
-            formatter={(value: number, name: string) => [
-              formatBytes(value),
-              name,
-            ]}
-          />
-          <Line
-            dataKey="bandwidthRecv"
-            stroke="#4ade80"
-            name="Bytes Received/sec"
-          />
-          <Line
-            dataKey="bandwidthSent"
-            stroke="#60a5fa"
-            name="Bytes Sent/sec"
-          />
-        </LineChart>
-      </ResponsiveContainer>
+      <div ref={chartContainerRef}>
+        <ResponsiveContainer width="100%" height={350}>
+          <LineChart
+            data={bandwidthHistory}
+            margin={{ top: 30, right: 30, left: 0, bottom: 5 }}
+          >
+            <CartesianGrid strokeDasharray="3 3" stroke="#444" />
+            <XAxis
+              dataKey="timestamp"
+              tickFormatter={(ts) => new Date(ts).toLocaleTimeString()}
+              stroke="#aaa"
+            />
+            <YAxis
+              stroke="#aaa"
+              tickFormatter={(value) => formatBytes(value)}
+              allowDataOverflow
+            />
+            <Tooltip
+              contentStyle={{ backgroundColor: '#222', borderColor: '#555' }}
+              labelFormatter={(ts) => new Date(ts).toLocaleTimeString()}
+              formatter={(value: number, name: string) => [
+                formatBytes(value),
+                name,
+              ]}
+            />
+            <Line
+              dataKey="bandwidthRecv"
+              stroke="#4ade80"
+              name="Bytes Received/sec"
+            />
+            <Line
+              dataKey="bandwidthSent"
+              stroke="#60a5fa"
+              name="Bytes Sent/sec"
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </div>
     </div>
   );
 };

--- a/dashboard/src/components/common/ActionIconButton.tsx
+++ b/dashboard/src/components/common/ActionIconButton.tsx
@@ -4,22 +4,24 @@ interface ActionIconButtonProps {
   icon: React.ReactElement<any>;
   onClick?: () => void;
   className?: string;
+  ariaLabel: string;
 }
 const ActionIconButton: React.FC<ActionIconButtonProps> = ({
   icon,
   onClick,
   className = '',
+  ariaLabel,
 }) => {
   return (
     <button
+      type="button"
       onClick={onClick}
+      aria-label={ariaLabel}
       className={`
         flex items-center justify-center
         w-[34px] h-[34px] sm:w-[34px] sm:h-[34px] xs:w-[28px] xs:h-[28px]
         p-1 rounded-full bg-[#36454F] text-white
-        shadow-md hover:shadow-lg hover:w-[48px] hover:h-[48px] hover:bg-black
-        transition-all duration-200 ease-in-out
-        hover:scale-105 active:scale-95
+        shadow-md hover:shadow-lg hover:bg-black
         focus:outline-none focus:ring-2 focus:ring-white/70 focus:ring-offset-1
         ${className}
       `}

--- a/dashboard/src/utils/downloadSvg.ts
+++ b/dashboard/src/utils/downloadSvg.ts
@@ -1,0 +1,133 @@
+function getBackgroundColor(element: HTMLElement): string {
+  const computedStyle = window.getComputedStyle(element);
+  let backgroundColor = computedStyle.backgroundColor;
+
+  const isTransparent =
+    backgroundColor === 'transparent' ||
+    backgroundColor === 'rgba(0, 0, 0, 0)' ||
+    (backgroundColor.startsWith('rgba') &&
+      (() => {
+        const rgbaMatch = backgroundColor.match(/rgba\(([^)]+)\)/);
+        if (rgbaMatch) {
+          const values = rgbaMatch[1].split(',').map((v) => v.trim());
+          const alpha = parseFloat(values[3] || '1');
+          return alpha < 0.1;
+        }
+        return false;
+      })());
+
+  if (isTransparent) {
+    const parent = element.parentElement;
+    if (parent) {
+      const parentStyle = window.getComputedStyle(parent);
+      backgroundColor = parentStyle.backgroundColor;
+    }
+  }
+
+  if (
+    !backgroundColor ||
+    backgroundColor === 'transparent' ||
+    backgroundColor === 'rgba(0, 0, 0, 0)' ||
+    backgroundColor === ''
+  ) {
+    return '#121212';
+  }
+
+  return backgroundColor;
+}
+
+function sanitizeFileName(fileName: string): string {
+  const fallback = 'download';
+  let name = fileName || fallback;
+
+  name = name.replace(/[/\\?%*:|"<>]/g, '_');
+
+  name = name.replace(/\s+/g, ' ').trim();
+  if (!name) {
+    name = fallback;
+  }
+  return name;
+}
+
+export function downloadSvgFromContainer(
+  container: HTMLElement | null,
+  fileName: string
+) {
+  if (!container) return;
+
+  const svg = container.querySelector('svg');
+  if (!svg) return;
+
+  const clonedSvg = svg.cloneNode(true) as SVGSVGElement;
+
+  if (!clonedSvg.getAttribute('xmlns')) {
+    clonedSvg.setAttribute('xmlns', 'http://www.w3.org/2000/svg');
+  }
+
+  const widthAttr = clonedSvg.getAttribute('width');
+  const heightAttr = clonedSvg.getAttribute('height');
+
+  const svgRect = svg.getBoundingClientRect();
+  const svgRenderedWidth = svgRect.width;
+  const svgRenderedHeight = svgRect.height;
+  const containerWidth = container.clientWidth || container.offsetWidth;
+  const containerHeight = container.clientHeight || container.offsetHeight;
+
+  let widthNum: number;
+  let heightNum: number;
+  if (widthAttr && !widthAttr.includes('%')) {
+    const parsed = parseFloat(widthAttr);
+    widthNum =
+      !isNaN(parsed) && parsed > 0
+        ? parsed
+        : svgRenderedWidth || containerWidth || 800;
+  } else {
+    widthNum = svgRenderedWidth || containerWidth || 800;
+  }
+  if (heightAttr && !heightAttr.includes('%')) {
+    const parsed = parseFloat(heightAttr);
+    heightNum =
+      !isNaN(parsed) && parsed > 0
+        ? parsed
+        : svgRenderedHeight || containerHeight || 350;
+  } else {
+    heightNum = svgRenderedHeight || containerHeight || 350;
+  }
+
+  clonedSvg.setAttribute('width', String(widthNum));
+  clonedSvg.setAttribute('height', String(heightNum));
+
+  const backgroundColor = getBackgroundColor(container);
+
+  const backgroundRect = document.createElementNS(
+    'http://www.w3.org/2000/svg',
+    'rect'
+  );
+  backgroundRect.setAttribute('width', String(widthNum));
+  backgroundRect.setAttribute('height', String(heightNum));
+  backgroundRect.setAttribute('fill', backgroundColor);
+  backgroundRect.setAttribute('x', '0');
+  backgroundRect.setAttribute('y', '0');
+
+  if (clonedSvg.firstChild) {
+    clonedSvg.insertBefore(backgroundRect, clonedSvg.firstChild);
+  } else {
+    clonedSvg.appendChild(backgroundRect);
+  }
+
+  const serializer = new XMLSerializer();
+  const source = serializer.serializeToString(clonedSvg);
+  const blob = new Blob([source], {
+    type: 'image/svg+xml;charset=utf-8',
+  });
+
+  const url = URL.createObjectURL(blob);
+  const safeFileName = sanitizeFileName(fileName);
+  const link = document.createElement('a');
+  link.href = url;
+  link.download = `${safeFileName}.svg`;
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}


### PR DESCRIPTION
Resolves #317 

Changes:
Added a download functionality for each graph. The downloaded file is in SVG format. 
It captures the current state of the graph when the user clicks download.

### Updated UI: 
<img width="1395" height="799" alt="Screenshot 2025-12-24 at 11 50 20 PM" src="https://github.com/user-attachments/assets/c0b47ed6-8716-4d10-a1bc-dd7e2b07a77b" />

<img width="1470" height="872" alt="Screenshot 2025-12-24 at 11 57 41 PM" src="https://github.com/user-attachments/assets/57381119-5c51-4351-b628-5700a51b2e31" />
</br>

### After clicking download button:
<img width="1470" height="878" alt="Screenshot 2025-12-24 at 11 58 45 PM" src="https://github.com/user-attachments/assets/e21a4b47-6055-4e6c-951e-8fb769d832e7" />
</br>

### Downloaded svgs:

![advanced-chart](https://github.com/user-attachments/assets/976ccf33-9d9f-491c-89f0-be71b14dbcd1)
![bitcoin-price-range (1)](https://github.com/user-attachments/assets/d0ac98b2-e4db-40e4-9477-c5c940c0ceac)
![bitcoin-price-history (1)](https://github.com/user-attachments/assets/a2d19837-7fa2-406a-a974-3b41a2ed2e1f)
![bitcoin-price-history (2)](https://github.com/user-attachments/assets/87e993c0-00a1-4b37-83b6-66341435209e)
