### PR TITLE
Replace unsafe unwrap/expect calls with proper error handling in main.rs and stratum.rs

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -74,7 +74,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //for supporting concurrent readers and single writer
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
     //Initializing DB and db command handler
-    let (mut _db_handler, db_tx) = DBHandler::new().await.unwrap();
+    let (mut _db_handler, db_tx) = DBHandler::new().await.map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Database initialization failed: {:?}", e),
+        )
+    })?;
     let db_connection_pool = _db_handler.db_connection_pool.clone();
     //Reconstructing local braid upon startup
     let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
@@ -83,9 +88,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // starting from that block as genesis
     let initial_bead_fetch_handle = tokio::spawn(async move {
         let mut guard = braid_ref.write().await;
-        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000)
-            .await
-            .unwrap();
+        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000).await?;
         for bead in &fetched_beads {
             let curr_bead_status = guard.extend(&bead);
             debug!(
@@ -95,8 +98,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
             );
         }
         info!(beads = fetched_beads.len(), "Beads loaded from DB");
+        Ok::<(), node::error::DBErrors>(())
     });
-    let _yield_result = initial_bead_fetch_handle.await.unwrap();
+    match initial_bead_fetch_handle.await {
+        Ok(Ok(())) => {
+            info!("Initial bead fetch completed successfully");
+        }
+        Ok(Err(e)) => {
+            error!(error = ?e, "Failed to fetch beads from DB during startup");
+            return Err(format!("Database bead fetch failed: {:?}", e).into());
+        }
+        Err(e) => {
+            error!(error = ?e, "Initial bead fetch task panicked");
+            return Err(format!("Initial bead fetch task panicked: {}", e).into());
+        }
+    }
     let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
     let latest_template_id_for_notifier = latest_template_id.clone();
     let latest_template_id_for_consumer = latest_template_id.clone();
@@ -182,7 +198,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let main_task_token = CancellationToken::new();
     let ipc_task_token = main_task_token.clone();
     let args = cli::Cli::parse();
-    let datadir = shellexpand::full(args.datadir.to_str().unwrap()).unwrap();
+    let datadir_str = args.datadir.to_str().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Invalid datadir path encoding",
+        )
+    })?;
+    let datadir = shellexpand::full(datadir_str).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Shell expansion failed: {}", e),
+        )
+    })?;
     match fs::metadata(&*datadir) {
         Ok(m) => {
             if !m.is_dir() {
@@ -242,7 +269,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
     if let Some(rpc_command) = args.command {
         let server_address = tokio::spawn(run_rpc_server(Arc::clone(&braid), rpc_addr));
-        let socket_address = server_address.await.unwrap().unwrap();
+        let socket_address = server_address
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("RPC server task failed: {}", e),
+                )
+            })?
+            .map_err(|_| {
+                std::io::Error::new(std::io::ErrorKind::Other, "RPC server startup failed")
+            })?;
         let _parsing_handle =
             tokio::spawn(parse_arguments(rpc_command, socket_address.clone())).await;
     } else {
@@ -260,19 +297,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //creating a main topic subscribing to the current test topic
     let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
 
-    let mut swarm = libp2p::SwarmBuilder::with_existing_identity(keypair)
+    let swarm_builder = libp2p::SwarmBuilder::with_existing_identity(keypair)
         .with_tokio()
         .with_quic()
         .with_dns()
-        .unwrap()
-        .with_behaviour(|local_key| BraidPoolBehaviour::new(local_key).unwrap())?
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("DNS setup failed: {:?}", e),
+            )
+        })?;
+    // Note: with_behaviour closure must return behaviour directly (not Result), using expect for clear error message
+    let mut swarm = swarm_builder
+        .with_behaviour(|local_key| {
+            BraidPoolBehaviour::new(local_key).expect(
+                "Failed to create BraidPoolBehaviour - check keypair and network configuration",
+            )
+        })?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
         .build();
     let socket_addr: std::net::SocketAddr = match args.bind.parse() {
         Ok(addr) => addr,
-        Err(_) => format!("{}:6680", args.bind)
-            .parse()
-            .expect("Failed to parse bind address"),
+        Err(_) => format!("{}:6680", args.bind).parse().map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Failed to parse bind address: {}", e),
+            )
+        })?,
     };
     let multi_addr: Multiaddr = format!(
         "/ip4/{}/udp/{}/quic-v1",
@@ -280,7 +331,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         socket_addr.port()
     )
     .parse()
-    .expect("Failed to create multiaddress");
+    .map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Failed to create multiaddress: {}", e),
+        )
+    })?;
     //subscribing to the braidpool topic for broadcasting bead_found and other peer_communications belonging to a particular topic
     swarm
         .behaviour_mut()
@@ -292,13 +348,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //adding the boot nodes for peer discovery
     swarm.listen_on(multi_addr.clone())?;
     for boot_peer in BOOTNODES {
-        swarm.behaviour_mut().kademlia.add_address(
-            &boot_peer.parse::<PeerId>().unwrap(),
-            SEED_DNS.parse::<Multiaddr>().unwrap(),
-        );
+        let peer_id = match boot_peer.parse::<PeerId>() {
+            Ok(id) => id,
+            Err(e) => {
+                error!(boot_peer = %boot_peer, error = %e, "Failed to parse boot peer ID, skipping");
+                continue;
+            }
+        };
+        let seed_addr = match SEED_DNS.parse::<Multiaddr>() {
+            Ok(addr) => addr,
+            Err(e) => {
+                error!(seed_dns = %SEED_DNS, error = %e, "Failed to parse seed DNS, skipping");
+                continue;
+            }
+        };
+        swarm
+            .behaviour_mut()
+            .kademlia
+            .add_address(&peer_id, seed_addr);
     }
     info!(boot_node_count = %BOOTNODES.len(), "Boot nodes added to DHT");
-    swarm.dial(ADDR_REFRENCE.parse::<Multiaddr>().unwrap())?;
+    let boot_addr: Multiaddr = ADDR_REFRENCE.parse().map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Failed to parse boot address: {}", e),
+        )
+    })?;
+    swarm.dial(boot_addr)?;
     info!(address = %ADDR_REFRENCE, "Dialed boot node");
     //IPC(inter process communication) based `getblocktemplate` and `notification` to send to the downstream via the `cmempoold` architecture
     info!(socket = %args.ipc_socket, "IPC socket path");
@@ -332,10 +408,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Spawn IPC handler
     let _ipc_handler = tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
+        let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()
-            .expect("Failed to create tokio runtime");
+        {
+            Ok(rt) => rt,
+            Err(e) => {
+                error!(error = %e, "Failed to create tokio runtime for IPC handler");
+                return;
+            }
+        };
         rt.block_on(async {
             let local_set = tokio::task::LocalSet::new();
 
@@ -407,7 +489,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     if let Some(addnode) = args.addnode {
         for node in addnode.iter() {
-            let node_multiaddr: Multiaddr = node.parse().expect("Failed to parse to multiaddr");
+            let node_multiaddr: Multiaddr = match node.parse() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    error!(node = %node, error = %e, "Failed to parse multiaddr, skipping");
+                    continue;
+                }
+            };
             let dial_result = swarm.dial(node_multiaddr.clone());
             if let Some(err) = dial_result.err() {
                 error!(address = %node_multiaddr, error = %err, "Failed to dial peer node");
@@ -516,10 +604,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         peer_manager.penalize_for_invalid_bead(&message.source);
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
                                      //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                                        let bead_id = braid_data
-                                        .bead_index_mapping
-                                        .get(&bead.block_header.block_hash())
-                                        .unwrap();
+                                        let bead_id = match braid_data
+                                            .bead_index_mapping
+                                            .get(&bead.block_header.block_hash()) {
+                                            Some(id) => id,
+                                            None => {
+                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
+                                                continue;
+                                            }
+                                        };
                                         let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
                                             &braid_data.beads,
                                             &braid_data.bead_index_mapping,
@@ -548,7 +641,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     }
                                     for (sync_peer, ibd_ts) in timestamp_map.iter() {
                                         let threshold = *ibd_ts + LATENCY_ALPHA * 10;
-                                        let sync_peer_id = sync_peer.parse::<PeerId>().unwrap();
+                                        let sync_peer_id = match sync_peer.parse::<PeerId>() {
+                                            Ok(id) => id,
+                                            Err(e) => {
+                                                error!(sync_peer = %sync_peer, error = %e, "Failed to parse sync peer ID");
+                                                continue;
+                                            }
+                                        };
                                         // broadcast_timestamp < timestamp + alpha * 10
                                         if broadcast_ts  < threshold as u32 {
                                             info!("Incoming BEAD received during IBD within threshold limit with broadcast timestamp - {:?} and threshold is - {:?}",broadcast_ts,threshold);
@@ -611,10 +710,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         // update the peer manager about the invalid bead
                                         peer_manager.penalize_for_invalid_bead(&message.source);
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
-                                        let bead_id = braid_data
-                                        .bead_index_mapping
-                                        .get(&bead.block_header.block_hash())
-                                        .unwrap();
+                                        let bead_id = match braid_data
+                                            .bead_index_mapping
+                                            .get(&bead.block_header.block_hash()) {
+                                            Some(id) => id,
+                                            None => {
+                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
+                                                continue;
+                                            }
+                                        };
                                         let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
                                             &braid_data.beads,
                                             &braid_data.bead_index_mapping,
@@ -928,10 +1032,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             // update the peer manager about the invalid bead
                                             peer_manager.penalize_for_invalid_bead(&peer);
                                         } else if let braid::AddBeadStatus::BeadAdded = status {
-                                            let bead_id = braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash())
-                                            .unwrap();
+                                            let bead_id = match braid_data
+                                                .bead_index_mapping
+                                                .get(&bead.block_header.block_hash()) {
+                                                Some(id) => id,
+                                                None => {
+                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
+                                                    continue;
+                                                }
+                                            };
                                             let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
                                                 &braid_data.beads,
                                                 &braid_data.bead_index_mapping,
@@ -1014,9 +1123,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         );
                                         // Get current time and create recent timestamps (within last hour)
                                         let current_time = SystemTime::now()
-                                        .duration_since(UNIX_EPOCH)
-                                        .unwrap()
-                                        .as_secs();
+                                            .duration_since(UNIX_EPOCH)
+                                            .map(|d| d.as_secs())
+                                            .unwrap_or_else(|e| {
+                                                error!(error = %e, "System time before UNIX epoch");
+                                                0
+                                            });
                                         match ibd_command_tx.send(IBDCommands::UpdateTimestampMapping { peer_id: peer.to_string(), end_timestamp: current_time }).await{
                                             Ok(_)=>{
                                                 debug!("Timestamp updated command sent successfully");
@@ -1145,7 +1257,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             continue;
                                         }
                                     };
-                                    let _val = _ibd_bridge_rx.await.unwrap();
+                                    let _val = match _ibd_bridge_rx.await {
+                                        Ok(v) => v,
+                                        Err(e) => {
+                                            error!(error = %e, "Failed to receive IBD batch offset");
+                                            continue;
+                                        }
+                                    };
                                     let braid_data = braid.read().await;
 
                                     let bead_hash_set: HashSet<BeadHash> = braid_data
@@ -1179,10 +1297,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     // common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
                                     // the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
                                     let mut current_tip_hashes = Vec::new();
-                                    let _ = braid_data.tips.iter().for_each(|curr_bead_idx|{
-                                       let current_bead = braid_data.beads.get(*curr_bead_idx).unwrap();
-                                       current_tip_hashes.push(current_bead.block_header.block_hash());
-                                    });
+                                    for curr_bead_idx in braid_data.tips.iter() {
+                                        if let Some(current_bead) = braid_data.beads.get(*curr_bead_idx) {
+                                            current_tip_hashes.push(current_bead.block_header.block_hash());
+                                        } else {
+                                            error!(bead_idx = %curr_bead_idx, "Tip bead not found in beads list");
+                                        }
+                                    }
                                     // Sending the current bead hashes for the receiving of beads to start in batches
                                     let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
                                     swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -273,11 +273,21 @@ impl DownstreamClient {
             Ok(stratum_response) => {
                 let response_json_string = match stratum_response.clone() {
                     StratumResponses::StandardResponse { std_response } => {
-                        serde_json::to_string(&std_response).unwrap()
+                        serde_json::to_string(&std_response).map_err(|e| {
+                            error!(error = %e, "Failed to serialize standard response");
+                            StratumErrors::InvalidMethod {
+                                method: "serialization_error".to_string(),
+                            }
+                        })?
                     }
                     StratumResponses::SuggestDifficultyResponse {
                         suggest_difficulty_resp,
-                    } => serde_json::to_string(&suggest_difficulty_resp).unwrap(),
+                    } => serde_json::to_string(&suggest_difficulty_resp).map_err(|e| {
+                        error!(error = %e, "Failed to serialize suggest difficulty response");
+                        StratumErrors::InvalidMethod {
+                            method: "serialization_error".to_string(),
+                        }
+                    })?,
                 };
                 debug!(
                     connection_id = %connection_id_hex,
@@ -391,7 +401,11 @@ impl DownstreamClient {
             });
         }
         let worker_name_res: Result<&str, StratumErrors> = match param_array.get(0) {
-            Some(worker_name) => Ok(worker_name.as_str().unwrap()),
+            Some(worker_name) => worker_name
+                .as_str()
+                .ok_or(StratumErrors::InvalidMethodParams {
+                    method: "mining.submit".to_string(),
+                }),
             None => Err(StratumErrors::ParamNotFound {
                 param: "worker_name".to_string(),
                 method: "mining.submit".to_string(),
@@ -478,7 +492,13 @@ impl DownstreamClient {
             extranonce2.to_ascii_lowercase(),
             submitted_job.coinbase2
         );
-        let coinbase_bytes = hex::decode(coinbase_tx_hex).unwrap();
+        let coinbase_bytes = match hex::decode(&coinbase_tx_hex) {
+            Ok(bytes) => bytes,
+            Err(e) => {
+                error!(connection_id = %connection_id_hex, error = %e, "Failed to decode coinbase hex");
+                return Err(StratumErrors::InvalidCoinbase);
+            }
+        };
 
         // Log the coinbase transaction in hex
         debug!(
@@ -488,15 +508,25 @@ impl DownstreamClient {
         );
 
         let mut coinbase_cursor = Cursor::new(coinbase_bytes);
-        let mut coinbase_tx: Transaction =
-            bitcoin::Transaction::consensus_decode(&mut coinbase_cursor).unwrap();
+        let mut coinbase_tx: Transaction = match bitcoin::Transaction::consensus_decode(
+            &mut coinbase_cursor,
+        ) {
+            Ok(tx) => tx,
+            Err(e) => {
+                error!(connection_id = %connection_id_hex, error = %e, "Failed to decode coinbase transaction");
+                return Err(StratumErrors::InvalidCoinbase);
+            }
+        };
 
         //computing merkle new merkle path due to updated coinbase transaction
         let mut merkle_branches_bytes: Vec<Vec<u8>> = Vec::new();
         for merkle_branch in submitted_job.coinbase_merkle_path.clone() {
             let mut merkle_branch_bytes: [u8; 32] = [0u8; 32];
             //Computing hex of merkle branch in big-endian as expected by the miner
-            hex::decode_to_slice(merkle_branch, &mut merkle_branch_bytes).unwrap();
+            if let Err(e) = hex::decode_to_slice(&merkle_branch, &mut merkle_branch_bytes) {
+                error!(connection_id = %connection_id_hex, error = %e, merkle_branch = %merkle_branch, "Failed to decode merkle branch hex");
+                return Err(StratumErrors::InvalidCoinbase);
+            }
             merkle_branches_bytes.push(Vec::from(merkle_branch_bytes));
         }
         let merkle_root_bytes =
@@ -541,15 +571,23 @@ impl DownstreamClient {
 
             // Mask set during mining.configure
             let mut mask_bytes = [0u8; 4];
-            let version_rolling_mask =
-                match self.version_rolling_mask.clone().unwrap().parse::<u32>() {
-                    Ok(version_mask) => version_mask,
-                    Err(error) => {
-                        return Err(StratumErrors::ParsingVersionMask {
-                            error: error.to_string(),
-                        });
-                    }
-                };
+            let version_rolling_mask_str = match self.version_rolling_mask.clone() {
+                Some(mask) => mask,
+                None => {
+                    error!(connection_id = %connection_id_hex, "Version rolling mask not set");
+                    return Err(StratumErrors::ParsingVersionMask {
+                        error: "Version rolling mask not configured".to_string(),
+                    });
+                }
+            };
+            let version_rolling_mask = match version_rolling_mask_str.parse::<u32>() {
+                Ok(version_mask) => version_mask,
+                Err(error) => {
+                    return Err(StratumErrors::ParsingVersionMask {
+                        error: error.to_string(),
+                    });
+                }
+            };
 
             let version_rolling_mask_bytes = version_rolling_mask.to_be_bytes();
             let version_rolling_mask_hex = hex::encode(version_rolling_mask_bytes);
@@ -586,13 +624,31 @@ impl DownstreamClient {
                 (header_version & !mask_version_bits) | (version_bits & mask_version_bits);
         }
         //Computing the block header
+        let ntime_u32 = match u32::from_str_radix(ntime, 16) {
+            Ok(v) => v,
+            Err(e) => {
+                error!(connection_id = %connection_id_hex, error = %e, ntime = %ntime, "Failed to parse ntime");
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: "mining.submit".to_string(),
+                });
+            }
+        };
+        let nonce_u32 = match u32::from_str_radix(nonce, 16) {
+            Ok(v) => v,
+            Err(e) => {
+                error!(connection_id = %connection_id_hex, error = %e, nonce = %nonce, "Failed to parse nonce");
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: "mining.submit".to_string(),
+                });
+            }
+        };
         let header = BlockHeader {
             version: bitcoin::blockdata::block::Version::from_consensus(final_masked_version),
             prev_blockhash: submitted_job.blocktemplate.previousblockhash,
             merkle_root: merkle_root,
-            time: BlockTime::from_u32(u32::from_str_radix(ntime, 16).unwrap()),
+            time: BlockTime::from_u32(ntime_u32),
             bits: submitted_job.blocktemplate.bits,
-            nonce: u32::from_str_radix(nonce, 16).unwrap(),
+            nonce: nonce_u32,
         };
         let compact_target = submitted_job.blocktemplate.bits;
         let target = bitcoin::Target::from_compact(compact_target);
@@ -642,13 +698,20 @@ impl DownstreamClient {
                 return Err(StratumErrors::InvalidCoinbase);
             }
         };
-        let witness_bytes = witness.get(0);
-        coinbase_tx
-            .inputs_mut()
-            .get_mut(0)
-            .unwrap()
-            .witness
-            .push(witness_bytes.unwrap());
+        let witness_bytes = match witness.get(0) {
+            Some(w) => w,
+            None => {
+                error!(connection_id = %connection_id_hex, "Witness commitment is empty");
+                return Err(StratumErrors::InvalidCoinbase);
+            }
+        };
+        match coinbase_tx.inputs_mut().get_mut(0) {
+            Some(input) => input.witness.push(witness_bytes),
+            None => {
+                error!(connection_id = %connection_id_hex, "Coinbase transaction has no inputs");
+                return Err(StratumErrors::InvalidCoinbase);
+            }
+        };
         let coinbase_tx_for_submission = coinbase_tx.clone();
         let mut block_transactions = vec![coinbase_tx];
         block_transactions.extend(submitted_job.blocktemplate.transactions.clone());
@@ -713,9 +776,25 @@ impl DownstreamClient {
             }
         }
         //Passing both the extranonces for committment in uncommitted metadata
-        let extranonce_2_raw_value = u32::from_str_radix(extranonce2, 16).unwrap();
+        let extranonce_2_raw_value = match u32::from_str_radix(extranonce2, 16) {
+            Ok(v) => v,
+            Err(e) => {
+                error!(connection_id = %connection_id_hex, error = %e, extranonce2 = %extranonce2, "Failed to parse extranonce2");
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: "mining.submit".to_string(),
+                });
+            }
+        };
         let extranonce_1_hex_str = hex::encode(self.extranonce1.clone());
-        let extranonce_1_raw_value = u32::from_str_radix(&extranonce_1_hex_str, 16).unwrap();
+        let extranonce_1_raw_value = match u32::from_str_radix(&extranonce_1_hex_str, 16) {
+            Ok(v) => v,
+            Err(e) => {
+                error!(connection_id = %connection_id_hex, error = %e, extranonce1 = %extranonce_1_hex_str, "Failed to parse extranonce1");
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: "mining.submit".to_string(),
+                });
+            }
+        };
         let _swarm_command_sent = match swarm_handler
             .lock()
             .await
@@ -767,11 +846,16 @@ impl DownstreamClient {
                 params = ?suggest_difficulty_params,
                 "Handling suggested difficulty"
             );
+            let difficulty_u64 = difficulty
+                .as_u64()
+                .ok_or(StratumErrors::InvalidMethodParams {
+                    method: "mining.set_difficulty".to_string(),
+                })?;
             self.suggest_difficulty_done = true;
             Ok(StratumResponses::SuggestDifficultyResponse {
                 suggest_difficulty_resp: SuggestDifficultyResponse {
                     method: "mining.set_difficulty".to_string(),
-                    params: vec![difficulty.as_u64().unwrap()],
+                    params: vec![difficulty_u64],
                 },
             })
         } else {
@@ -809,7 +893,9 @@ impl DownstreamClient {
             }
         };
         let username_res: Result<&str, StratumErrors> = match param_array.get(0) {
-            Some(user) => Ok(user.as_str().unwrap()),
+            Some(user) => user.as_str().ok_or(StratumErrors::InvalidMethodParams {
+                method: "mining.authorize".to_string(),
+            }),
             None => {
                 return Err(StratumErrors::ParamNotFound {
                     param: "username".to_string(),
@@ -921,9 +1007,9 @@ impl DownstreamClient {
         //Minimum bits rollable of version
         let version_rolling_min_bit_count =
             config_map.get("version-rolling.min-bit-count").or(None);
-        if version_rolling_mask.is_none() == false {
+        if let Some(mask_value) = version_rolling_mask {
             let mut mask_bytes: [u8; 4] = [0u8; 4];
-            let version_rolling_mask_str = match version_rolling_mask.unwrap().as_str() {
+            let version_rolling_mask_str = match mask_value.as_str() {
                 Some(version_str) => version_str,
                 None => {
                     return Err(StratumErrors::VersionRollingStringParseError {
@@ -945,10 +1031,16 @@ impl DownstreamClient {
             let hex_str = u32::to_string(&final_rollable_version_bits);
             self.version_rolling_mask = Some(hex_str);
         }
-        if version_rolling_min_bit_count.is_none() == false {
+        if let Some(min_bit_count_value) = version_rolling_min_bit_count {
             let mut mask_bytes: [u8; 4] = [0u8; 4];
-            let version_rolling_min_bit_count_str =
-                version_rolling_min_bit_count.unwrap().as_str().unwrap();
+            let version_rolling_min_bit_count_str = match min_bit_count_value.as_str() {
+                Some(s) => s,
+                None => {
+                    return Err(StratumErrors::VersionrollingMinBitCountHexParseError {
+                        error: "version-rolling.min-bit-count is not a string".to_string(),
+                    });
+                }
+            };
             match hex::decode_to_slice(version_rolling_min_bit_count_str, &mut mask_bytes) {
                 Ok(_) => {}
                 Err(error) => {
@@ -1212,7 +1304,7 @@ fn _to_little_endian(hex_str: &str) -> String {
     hex_str
         .as_bytes()
         .chunks(2)
-        .map(|chunk| std::str::from_utf8(chunk).unwrap())
+        .filter_map(|chunk| std::str::from_utf8(chunk).ok())
         .rev()
         .collect::<Vec<&str>>()
         .join("")
@@ -1224,7 +1316,9 @@ pub fn reverse_four_byte_chunks(hash_hex: &str) -> Result<String, StratumErrors>
             error: "Hash length is incorrect".to_string(),
         });
     }
-    let bytes = hex::decode(hash_hex).unwrap();
+    let bytes = hex::decode(hash_hex).map_err(|e| StratumErrors::PrevHashNotReversed {
+        error: format!("Failed to decode hash hex: {}", e),
+    })?;
     // Reverse the byte order in 4-byte chunks
     let mut reversed_bytes = Vec::with_capacity(bytes.len());
     for chunk in bytes.chunks(4).rev() {
@@ -1285,12 +1379,13 @@ impl Notifier {
                 });
             }
         };
-        let coinbase_witness_commitment = coinbase_transaction
-            .inputs()
-            .get(0)
-            .unwrap()
-            .witness
-            .clone();
+        let coinbase_witness_commitment = match coinbase_transaction.inputs().get(0) {
+            Some(input) => input.witness.clone(),
+            None => {
+                error!(template_id = %template_id, "Coinbase transaction has no inputs");
+                return Err(StratumErrors::InvalidCoinbase);
+            }
+        };
         if let Some(input) = coinbase_transaction.inputs_mut().get_mut(0) {
             input.witness.clear();
         };
@@ -1460,7 +1555,13 @@ impl Notifier {
                                 }
                             };
 
-                        let unix_timestamp = duration_since_epoch.as_secs().to_u32().unwrap();
+                        let unix_timestamp = match duration_since_epoch.as_secs().to_u32() {
+                            Some(ts) => ts,
+                            None => {
+                                error!("System timestamp overflow");
+                                continue;
+                            }
+                        };
 
                         let job_details = JobDetails {
                             blocktemplate: template_for_job,
@@ -1491,11 +1592,15 @@ impl Notifier {
                             ]),
                         };
 
-                        if let Err(e) = connection_info
-                            .sender
-                            .send(serde_json::to_string(&job_notification_response).unwrap())
-                            .await
-                        {
+                        let job_notification_json =
+                            match serde_json::to_string(&job_notification_response) {
+                                Ok(json) => json,
+                                Err(e) => {
+                                    error!(error = %e, "Failed to serialize job notification");
+                                    continue;
+                                }
+                            };
+                        if let Err(e) = connection_info.sender.send(job_notification_json).await {
                             error!(
                                 connection_id = %connection_id_hex,
                                 peer = %peer_adr,
@@ -1552,9 +1657,14 @@ impl Notifier {
                         "Sending existing latest template to new miner"
                     );
                     let global_peer_mining_job_map_arc = self.job_map_arc.lock().await;
-                    let current_peer_mining_job_map_arc = global_peer_mining_job_map_arc
-                        .get(&new_downstream_addr)
-                        .unwrap();
+                    let current_peer_mining_job_map_arc =
+                        match global_peer_mining_job_map_arc.get(&new_downstream_addr) {
+                            Some(map) => map,
+                            None => {
+                                error!(peer = %new_downstream_addr, "No job map found for peer");
+                                continue;
+                            }
+                        };
                     let mut curr_peer_mining_job_map = current_peer_mining_job_map_arc.lock().await;
 
                     // Clean Jobs. If true, miners should abort their current work and immediately use the new job, even if it degrades hashrate in the short term.
@@ -1578,7 +1688,13 @@ impl Notifier {
                         }
                     };
 
-                    let unix_timestamp = duration_since_epoch.as_secs().to_u32().unwrap();
+                    let unix_timestamp = match duration_since_epoch.as_secs().to_u32() {
+                        Some(ts) => ts,
+                        None => {
+                            error!("System timestamp overflow for new miner notification");
+                            continue;
+                        }
+                    };
                     let serialized_notification: Result<String, StratumErrors> =
                         match job_notification {
                             Ok(job) => {
@@ -1612,7 +1728,11 @@ impl Notifier {
                                         job.clean_jobs
                                     ]),
                                 };
-                                Ok(serde_json::to_string(&job_notification_response).unwrap())
+                                serde_json::to_string(&job_notification_response).map_err(|_| {
+                                    StratumErrors::JobNotificationNotConstructed {
+                                        job_template: latest_template.clone(),
+                                    }
+                                })
                             }
                             Err(error) => Err(error),
                         };
@@ -1916,8 +2036,8 @@ impl Server {
                         //Parsing the lines read from buffer to find out whether they are valid JSON request type to be server as per
                         //stratum or not .
                         match serde_json::from_str::<StandardRequest>(&line) {
-                                Ok(_request) => {
-                         let server_request_res:Result<StratumResponses, StratumErrors> = downstream_client.lock().await.handle_client_to_server_request(serde_json::from_str(&line).unwrap(),mining_job_map.clone(),downstream_message_sender.clone(),notification_sender.clone(),peer_addr.to_string(),swarm_handler.clone()).await;
+                                Ok(request) => {
+                         let server_request_res:Result<StratumResponses, StratumErrors> = downstream_client.lock().await.handle_client_to_server_request(request,mining_job_map.clone(),downstream_message_sender.clone(),notification_sender.clone(),peer_addr.to_string(),swarm_handler.clone()).await;
                          match server_request_res{
                             Ok(_)=>{
 

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -404,7 +404,7 @@ impl DownstreamClient {
             Some(worker_name) => worker_name
                 .as_str()
                 .ok_or(StratumErrors::InvalidMethodParams {
-                    method: "mining.submit".to_string(),
+                    method: "mining.submit: worker_name must be a string".to_string(),
                 }),
             None => Err(StratumErrors::ParamNotFound {
                 param: "worker_name".to_string(),

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -893,9 +893,13 @@ impl DownstreamClient {
             }
         };
         let username_res: Result<&str, StratumErrors> = match param_array.get(0) {
-            Some(user) => user.as_str().ok_or(StratumErrors::InvalidMethodParams {
-                method: "mining.authorize".to_string(),
-            }),
+            Some(user) => match user.as_str() {
+                Some(username_str) => Ok(username_str),
+                None => Err(StratumErrors::ParamNotFound {
+                    param: "username must be a string".to_string(),
+                    method: "mining.authorize".to_string(),
+                }),
+            },
             None => {
                 return Err(StratumErrors::ParamNotFound {
                     param: "username".to_string(),


### PR DESCRIPTION
Fixes : #302 

- main.rs: Fix 20 unsafe unwraps with proper Result handling
  - Database initialization with map_err
  - Shell expansion for datadir path
  - RPC server startup error propagation
  - Boot peer and multiaddr parsing with graceful skip
  - Bead ID lookups with continue on error
  - Timestamp and IBD handling with fallbacks

- stratum.rs: Fix 26 unsafe unwraps in production code
  - JSON serialization with error propagation
  - Coinbase/transaction decoding with StratumErrors
  - Version rolling mask and ntime/nonce parsing
  - Witness commitment and extranonce handling
  - Job notification serialization