### PR TITLE
rpc:enhancement and braidpool-cli addition

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -399,6 +399,12 @@ checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
+version = "0.21.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+
+[[package]]
+name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
@@ -657,6 +663,17 @@ dependencies = [
  "futures-io",
  "futures-lite 2.6.1",
  "piper",
+]
+
+[[package]]
+name = "braidpool-cli"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -1196,6 +1213,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9eb1aa714776b75c7e67e1da744b81a129b3ff919c8712b5e1b32252c1f07cc7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if 1.0.4",
+]
+
+[[package]]
 name = "enum-as-inner"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1310,6 +1336,21 @@ name = "foldhash"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -1604,6 +1645,25 @@ dependencies = [
 
 [[package]]
 name = "h2"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http 0.2.12",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "h2"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
@@ -1793,6 +1853,17 @@ dependencies = [
 
 [[package]]
 name = "http-body"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
+dependencies = [
+ "bytes",
+ "http 0.2.12",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
@@ -1810,7 +1881,7 @@ dependencies = [
  "bytes",
  "futures-core",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "pin-project-lite",
 ]
 
@@ -1828,6 +1899,30 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "hyper"
+version = "0.14.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2 0.5.10",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
@@ -1836,9 +1931,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2",
+ "h2 0.4.13",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "httparse",
  "httpdate",
  "itoa",
@@ -1856,7 +1951,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "rustls",
@@ -1867,23 +1962,57 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.32",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
+dependencies = [
+ "bytes",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-util",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
+ "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
+ "ipnet",
  "libc",
+ "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
+ "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
+ "windows-registry",
 ]
 
 [[package]]
@@ -2050,7 +2179,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration",
+ "system-configuration 0.6.1",
  "tokio",
  "windows",
 ]
@@ -2067,7 +2196,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "log",
  "rand 0.8.5",
@@ -2132,6 +2261,16 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+
+[[package]]
+name = "iri-string"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
+dependencies = [
+ "memchr",
+ "serde",
+]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2253,7 +2392,7 @@ dependencies = [
  "futures-timer",
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
  "parking_lot",
@@ -2277,8 +2416,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
 dependencies = [
  "base64 0.22.1",
- "http-body",
- "hyper",
+ "http-body 1.0.1",
+ "hyper 1.8.1",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -2314,9 +2453,9 @@ checksum = "d38b0bcf407ac68d241f90e2d46041e6a06988f97fe1721fb80b91c42584fae6"
 dependencies = [
  "futures-util",
  "http 1.4.0",
- "http-body",
+ "http-body 1.0.1",
  "http-body-util",
- "hyper",
+ "hyper 1.8.1",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2892,6 +3031,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
 
 [[package]]
+name = "mime"
+version = "0.3.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
 name = "minimal-lexical"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3022,6 +3167,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
 name = "net2"
 version = "0.2.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3131,6 +3293,7 @@ dependencies = [
  "libp2p",
  "num",
  "rand 0.8.5",
+ "reqwest 0.11.27",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -3297,10 +3460,48 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "openssl"
+version = "0.10.75"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+dependencies = [
+ "bitflags 2.10.0",
+ "cfg-if 1.0.4",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.111"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "option-ext"
@@ -3824,6 +4025,86 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
 
 [[package]]
+name = "reqwest"
+version = "0.11.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
+dependencies = [
+ "base64 0.21.7",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-tls 0.5.0",
+ "ipnet",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "once_cell",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pemfile",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 0.1.2",
+ "system-configuration 0.5.1",
+ "tokio",
+ "tokio-native-tls",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "h2 0.4.13",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.8.1",
+ "hyper-rustls",
+ "hyper-tls 0.6.0",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tokio-native-tls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
+
+[[package]]
 name = "resolv-conf"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3963,6 +4244,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
+dependencies = [
+ "base64 0.21.7",
 ]
 
 [[package]]
@@ -4608,9 +4898,18 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
+
+[[package]]
+name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -4625,13 +4924,45 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.10.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
 ]
 
 [[package]]
@@ -4668,6 +4999,19 @@ name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
+
+[[package]]
+name = "tempfile"
+version = "3.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+dependencies = [
+ "fastrand 2.3.0",
+ "getrandom 0.3.4",
+ "once_cell",
+ "rustix 1.1.3",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "thiserror"
@@ -4803,6 +5147,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4921,7 +5275,26 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper",
+ "sync_wrapper 1.0.2",
+ "tokio",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
+dependencies = [
+ "bitflags 2.10.0",
+ "bytes",
+ "futures-util",
+ "http 1.4.0",
+ "http-body 1.0.1",
+ "iri-string",
+ "pin-project-lite",
+ "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -5401,6 +5774,17 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result 0.4.1",
+ "windows-strings",
+]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 #Virtual workspace not creating a root package along with workspace as not needed .
 [workspace]
-members = ["node"]
+members = ["node", "braidpool-cli"]
 resolver = "3"
 
 [workspace.package]
@@ -42,5 +42,6 @@ sqlx = {version="0.8.6",features=[ "sqlite",
 strum = { version = "0.26", features = ["derive"] }
 if-addrs = "0.13"
 anyhow = "1.0.100"
+reqwest = { version = "0.11", features = ["json"] }
 
 

--- a/braidpool-cli/Cargo.toml
+++ b/braidpool-cli/Cargo.toml
@@ -5,7 +5,7 @@ edition.workspace = true
 
 [dependencies]
 clap = { workspace = true, features = ["derive"] }
-reqwest = { version = "0.12.24", features = ["json"] }
+reqwest.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tokio.workspace = true

--- a/braidpool-cli/Cargo.toml
+++ b/braidpool-cli/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "braidpool-cli"
+version.workspace = true
+edition.workspace = true
+
+[dependencies]
+clap = { workspace = true, features = ["derive"] }
+reqwest = { version = "0.12.24", features = ["json"] }
+serde.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+

--- a/braidpool-cli/src/main.rs
+++ b/braidpool-cli/src/main.rs
@@ -1,0 +1,197 @@
+use clap::{Parser, Subcommand};
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+/// Braidpool CLI - Command line interface for interacting with Braidpool node
+#[derive(Parser, Debug)]
+#[command(name = "braidpool-cli", version, about, long_about = None)]
+struct Cli {
+    /// RPC server URL (default: http://127.0.0.1:6682)
+    #[arg(long, default_value = "http://127.0.0.1:6682")]
+    rpc_url: String,
+
+    #[command(subcommand)]
+    commands: Commands,
+}
+
+#[derive(Debug, Subcommand)]
+#[command(rename_all = "PascalCase")]
+enum Commands {
+    /// Get a bead by hash
+    GetBead {
+        /// The bead hash (as a hex string)
+        bead_hash: String,
+    },
+
+    /// Add a bead via serialized JSON string
+    AddBead {
+        /// JSON-formatted bead
+        bead_data: String,
+    },
+
+    /// Get total number of beads
+    GetBeadCount,
+
+    /// Get total number of cohorts
+    GetCohortCount,
+
+    /// Get current DAG tips
+    GetTips,
+
+    /// Get a list of bead hashes in the cohort
+    GetCohort {
+        /// The id of the Cohort
+        cohort_id: u64,
+    },
+
+    /// Get the genesis bead hash for this epoch
+    GetGenesis,
+
+    /// Get a list of connected Stratum miners
+    GetMinerInfo,
+
+    ///  get detailed statistics about beads mined by us, expected payout, etc.
+    GetMiningInfo,
+
+    /// Get the parent hashes of a bead by bead_hash
+    GetParents {
+        /// The bead hash (as a hex string)
+        bead_hash: String,
+    },
+
+    /// Get the children hashes of a bead by bead hash
+    GetChildren {
+        /// The bead hash (as a hex string)
+        bead_hash: String,
+    },
+
+    /// Get the list of beads in the highest work path
+    GetHwPath {
+        /// Limit the number of results
+        limit: u8,
+    },
+
+    /// Get statistics about the IPC connection
+    GetIpcStats,
+
+    /// Get braid information (similar to getblockchaininfo in bitcoin-cli)
+    GetBraidInfo,
+
+    /// Get node information (libp2p PeerID, payout address, miner pubkey, etc.)
+    GetNodeInfo {
+        /// The node identifier (bead hash)
+        node: String,
+    },
+
+    /// Get peer information (IP/PeerID/libp2p address of connected peers)
+    GetPeerInfo,
+
+    /// Get the list of transactions staged for the next bead we mine
+    StagedTransactions,
+
+    /// Remove a transaction from our stage list by txid
+    UnstageTransactions {
+        /// Transaction ID to remove
+        tx_id: String,
+    },
+
+    /// Proxy a Bitcoin RPC call to bitcoind
+    /// Example: braidpool-cli bitcoin getblockchaininfo
+    Bitcoin {
+        /// Bitcoin RPC method name (e.g., "getblockchaininfo", "getblockhash", etc.)
+        method: String,
+        /// JSON array of parameters (optional, defaults to empty array)
+        #[arg(long, default_value = "[]")]
+        params: String,
+    },
+}
+
+#[derive(Serialize, Debug)]
+struct JsonRpcRequest {
+    jsonrpc: &'static str,
+    method: String,
+    params: serde_json::Value,
+    id: u64,
+}
+
+#[derive(Deserialize, Debug)]
+struct JsonRpcResponse {
+    result: serde_json::Value,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<serde_json::Value>,
+}
+
+/// Client-side RPC call function
+async fn call_rpc(
+    rpc_url: &str,
+    method: &str,
+    params: serde_json::Value,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let rpc_request = JsonRpcRequest {
+        jsonrpc: "2.0",
+        method: method.to_string(),
+        params,
+        id: 1,
+    };
+
+    let client = reqwest::Client::new();
+    let res = client.post(rpc_url).json(&rpc_request).send().await?;
+
+    if res.status().is_success() {
+        let rpc_response: JsonRpcResponse = res.json().await?;
+        if let Some(error) = rpc_response.error {
+            return Err(format!("RPC error: {}", error).into());
+        }
+        Ok(rpc_response.result)
+    } else {
+        let status = res.status();
+        let text = res
+            .text()
+            .await
+            .unwrap_or_else(|_| "Could not read error body".to_string());
+        Err(format!("HTTP error: {}\nResponse: {}", status, text).into())
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let cli = Cli::parse();
+
+    let (method, params) = match &cli.commands {
+        Commands::GetBead { bead_hash } => ("getbead", json!([bead_hash])),
+        Commands::AddBead { bead_data } => ("addbead", json!([bead_data])),
+        Commands::GetBeadCount => ("getbeadcount", json!([])),
+        Commands::GetCohortCount => ("getcohortcount", json!([])),
+        Commands::GetTips => ("gettips", json!([])),
+        Commands::GetCohort { cohort_id } => ("getcohort", json!([cohort_id])),
+        Commands::GetGenesis => ("getgenesis", json!([])),
+        Commands::GetMinerInfo => ("getminerinfo", json!([])),
+        Commands::GetMiningInfo => ("getmininginfo", json!([])),
+        Commands::GetParents { bead_hash } => ("getparents", json!([bead_hash])),
+        Commands::GetChildren { bead_hash } => ("getchildren", json!([bead_hash])),
+        Commands::GetHwPath { limit } => ("gethwpath", json!([limit])),
+        Commands::GetIpcStats => ("getipcstats", json!([])),
+        Commands::GetBraidInfo => ("getbraidinfo", json!([])),
+        Commands::GetNodeInfo { node } => ("getnodeinfo", json!([node])),
+        Commands::GetPeerInfo => ("getpeerinfo", json!([])),
+        Commands::StagedTransactions => ("stagedtransactions", json!([])),
+        Commands::UnstageTransactions { tx_id } => ("unstagetransactions", json!([tx_id])),
+        Commands::Bitcoin { method, params } => {
+            let params_value: serde_json::Value =
+                serde_json::from_str(params).unwrap_or_else(|_| json!([]));
+            ("bitcoinproxy", json!([method, params_value]))
+        }
+    };
+
+    match call_rpc(&cli.rpc_url, method, params).await {
+        Ok(result) => {
+            let pretty_response = serde_json::to_string_pretty(&result)?;
+            println!("{}", pretty_response);
+            Ok(())
+        }
+        Err(e) => {
+            eprintln!("Error: {}", e);
+            std::process::exit(1);
+        }
+    }
+}

--- a/braidpool-cli/src/main.rs
+++ b/braidpool-cli/src/main.rs
@@ -15,43 +15,51 @@ struct Cli {
 }
 
 #[derive(Debug, Subcommand)]
-#[command(rename_all = "snakecase")]
 enum Commands {
     /// Get a bead by hash
+    #[command(name = "getbead")]
     GetBead {
         /// The bead hash (as a hex string)
         bead_hash: String,
     },
 
     /// Add a bead via serialized JSON string
+    #[command(name = "addbead")]
     AddBead {
         /// JSON-formatted bead
         bead_data: String,
     },
 
     /// Get total number of beads
+    #[command(name = "getbeadcount")]
     GetBeadCount,
 
     /// Get total number of cohorts
+    #[command(name = "getcohortcount")]
     GetCohortCount,
 
     /// Get current DAG tips
+    #[command(name = "gettips")]
     GetTips,
 
     /// Get a list of bead hashes in a cohort by its ID
+    #[command(name = "getcohortbyid")]
     GetCohortById {
         /// The ID of the cohort
         cohort_id: u64,
     },
 
     /// Get the genesis bead hash for this epoch
+    #[command(name = "getgenesis")]
     GetGenesis,
 
     /// Get a list of connected Stratum miners
+    #[command(name = "getminerinfo")]
     GetMinerInfo,
 
     /// Get detailed statistics about beads mined by us, expected payout, etc.
     /// Requires at least one filter: public_keys or miner_ips
+    #[command(name = "getmininginfo")]
     GetMiningInfo {
         /// List of public keys (hex-encoded) to filter beads by.
         /// Supports multiple keys for key rotation scenarios.
@@ -67,32 +75,38 @@ enum Commands {
     },
 
     /// Get the parent hashes of a bead by bead_hash
+    #[command(name = "getparents")]
     GetParents {
         /// The bead hash (as a hex string)
         bead_hash: String,
     },
 
     /// Get the children hashes of a bead by bead hash
+    #[command(name = "getchildren")]
     GetChildren {
         /// The bead hash (as a hex string)
         bead_hash: String,
     },
 
     /// Get the list of beads in the highest work path, limited by count
+    #[command(name = "gethighestworkpathbycount")]
     GetHighestWorkPathByCount {
         /// Limit the number of results returned
         limit: u8,
     },
 
     /// Get statistics about the IPC connection
+    #[command(name = "getipcstats")]
     GetIpcStats,
 
     /// Get braid information (returns bead_count , tip_count , tips, cohort_count, orphan_count, genesis_beads, total_work)
+    #[command(name = "getbraidinfo")]
     GetBraidInfo,
 
     /// Get node information for the node that created a specific bead
     /// Returns information about the node that created the specified bead, including:
     /// common_pubkey (libp2p public key), miner_ip, payout_address, and minimum_target.
+    #[command(name = "getnodeinfo")]
     GetNodeInfo {
         /// The bead hash (block hash) as a 64-character hex-encoded string representing the bead's block hash
         /// This identifies which bead's creator node information you want to retrieve
@@ -100,12 +114,15 @@ enum Commands {
     },
 
     /// Get peer information (IP/PeerID/libp2p address of connected peers)
+    #[command(name = "getpeerinfo")]
     GetPeerInfo,
 
     /// Get the list of transactions staged for the next bead we mine
+    #[command(name = "stagedtransactions")]
     StagedTransactions,
 
     /// Remove a transaction from our stage list by txid
+    #[command(name = "unstagetransactions")]
     UnstageTransactions {
         /// Transaction ID to remove
         tx_id: String,
@@ -113,6 +130,7 @@ enum Commands {
 
     /// Proxy a Bitcoin RPC call to bitcoind
     /// Example: braidpool-cli bitcoin getblockchaininfo
+    #[command(name = "bitcoin")]
     Bitcoin {
         /// Bitcoin RPC method name (e.g., "getblockchaininfo", "getblockhash", etc.)
         method: String,
@@ -199,6 +217,7 @@ impl std::error::Error for RpcCallError {
 }
 
 async fn call_rpc(
+    client: &reqwest::Client,
     rpc_url: &str,
     method: &str,
     params: serde_json::Value,
@@ -210,7 +229,6 @@ async fn call_rpc(
         id: 1,
     };
 
-    let client = reqwest::Client::new();
     let res = client
         .post(rpc_url)
         .json(&rpc_request)
@@ -245,6 +263,10 @@ async fn call_rpc(
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let cli = Cli::parse();
+
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()?;
 
     let (method, params) = match &cli.commands {
         Commands::GetBead { bead_hash } => ("getbead", json!([bead_hash])),
@@ -305,7 +327,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     };
 
-    match call_rpc(&cli.rpc_url, method, params).await {
+    match call_rpc(&client, &cli.rpc_url, method, params).await {
         Ok(result) => {
             let pretty_response = serde_json::to_string_pretty(&result).map_err(|e| {
                 Box::new(std::io::Error::new(

--- a/braidpool-cli/src/main.rs
+++ b/braidpool-cli/src/main.rs
@@ -15,7 +15,7 @@ struct Cli {
 }
 
 #[derive(Debug, Subcommand)]
-#[command(rename_all = "PascalCase")]
+#[command(rename_all = "snakecase")]
 enum Commands {
     /// Get a bead by hash
     GetBead {
@@ -38,9 +38,9 @@ enum Commands {
     /// Get current DAG tips
     GetTips,
 
-    /// Get a list of bead hashes in the cohort
-    GetCohort {
-        /// The id of the Cohort
+    /// Get a list of bead hashes in a cohort by its ID
+    GetCohortById {
+        /// The ID of the cohort
         cohort_id: u64,
     },
 
@@ -50,8 +50,21 @@ enum Commands {
     /// Get a list of connected Stratum miners
     GetMinerInfo,
 
-    ///  get detailed statistics about beads mined by us, expected payout, etc.
-    GetMiningInfo,
+    /// Get detailed statistics about beads mined by us, expected payout, etc.
+    /// Requires at least one filter: public_keys or miner_ips
+    GetMiningInfo {
+        /// List of public keys (hex-encoded) to filter beads by.
+        /// Supports multiple keys for key rotation scenarios.
+        /// Example: --public_keys "0202...,0303..."
+        #[arg(long, value_delimiter = ',')]
+        public_keys: Option<Vec<String>>,
+
+        /// List of miner IP addresses to filter beads by.
+        /// Useful for pool operators tracking specific miners.
+        /// Example: --miner_ips "192.168.1.1,192.168.1.2"
+        #[arg(long, value_delimiter = ',')]
+        miner_ips: Option<Vec<String>>,
+    },
 
     /// Get the parent hashes of a bead by bead_hash
     GetParents {
@@ -65,22 +78,25 @@ enum Commands {
         bead_hash: String,
     },
 
-    /// Get the list of beads in the highest work path
-    GetHwPath {
-        /// Limit the number of results
+    /// Get the list of beads in the highest work path, limited by count
+    GetHighestWorkPathByCount {
+        /// Limit the number of results returned
         limit: u8,
     },
 
     /// Get statistics about the IPC connection
     GetIpcStats,
 
-    /// Get braid information (similar to getblockchaininfo in bitcoin-cli)
+    /// Get braid information (returns bead_count , tip_count , tips, cohort_count, orphan_count, genesis_beads, total_work)
     GetBraidInfo,
 
-    /// Get node information (libp2p PeerID, payout address, miner pubkey, etc.)
+    /// Get node information for the node that created a specific bead
+    /// Returns information about the node that created the specified bead, including:
+    /// common_pubkey (libp2p public key), miner_ip, payout_address, and minimum_target.
     GetNodeInfo {
-        /// The node identifier (bead hash)
-        node: String,
+        /// The bead hash (block hash) as a 64-character hex-encoded string representing the bead's block hash
+        /// This identifies which bead's creator node information you want to retrieve
+        bead_hash: String,
     },
 
     /// Get peer information (IP/PeerID/libp2p address of connected peers)
@@ -114,19 +130,79 @@ struct JsonRpcRequest {
     id: u64,
 }
 
-#[derive(Deserialize, Debug)]
-struct JsonRpcResponse {
-    result: serde_json::Value,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    error: Option<serde_json::Value>,
+#[derive(Deserialize, Debug, Clone)]
+pub struct JsonRpcError {
+    pub code: i32,
+    pub message: String,
+    #[serde(default)]
+    pub data: Option<serde_json::Value>,
 }
 
-/// Client-side RPC call function
+impl std::fmt::Display for JsonRpcError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "Error {}: {}", self.code, self.message)
+    }
+}
+
+impl std::error::Error for JsonRpcError {}
+
+#[derive(Deserialize, Debug)]
+#[allow(dead_code)]
+struct JsonRpcResponse {
+    #[serde(default)]
+    jsonrpc: Option<String>,
+    #[serde(default)]
+    result: Option<serde_json::Value>,
+    #[serde(default)]
+    error: Option<JsonRpcError>,
+    #[serde(default)]
+    id: Option<serde_json::Value>,
+}
+
+#[derive(Debug)]
+pub enum RpcCallError {
+    HttpError(String),
+    InvalidJson { body: String, parse_error: String },
+    JsonRpcError(JsonRpcError),
+    InvalidResponse(String),
+}
+
+impl std::fmt::Display for RpcCallError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            RpcCallError::HttpError(msg) => write!(f, "Connection error: {}", msg),
+            RpcCallError::InvalidJson { body, parse_error } => {
+                let truncated_body = if body.len() > 500 {
+                    format!("{}... (truncated)", &body[..500])
+                } else {
+                    body.clone()
+                };
+                write!(
+                    f,
+                    "Invalid server response (not valid JSON): {}\nServer response: {}",
+                    parse_error, truncated_body
+                )
+            }
+            RpcCallError::JsonRpcError(err) => write!(f, "{}", err),
+            RpcCallError::InvalidResponse(msg) => write!(f, "Invalid JSON-RPC response: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for RpcCallError {
+    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+        match self {
+            RpcCallError::JsonRpcError(err) => Some(err),
+            _ => None,
+        }
+    }
+}
+
 async fn call_rpc(
     rpc_url: &str,
     method: &str,
     params: serde_json::Value,
-) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+) -> Result<serde_json::Value, RpcCallError> {
     let rpc_request = JsonRpcRequest {
         jsonrpc: "2.0",
         method: method.to_string(),
@@ -135,21 +211,34 @@ async fn call_rpc(
     };
 
     let client = reqwest::Client::new();
-    let res = client.post(rpc_url).json(&rpc_request).send().await?;
+    let res = client
+        .post(rpc_url)
+        .json(&rpc_request)
+        .send()
+        .await
+        .map_err(|e| RpcCallError::HttpError(e.to_string()))?;
 
-    if res.status().is_success() {
-        let rpc_response: JsonRpcResponse = res.json().await?;
-        if let Some(error) = rpc_response.error {
-            return Err(format!("RPC error: {}", error).into());
+    let body_text = res
+        .text()
+        .await
+        .map_err(|e| RpcCallError::HttpError(format!("Failed to read response body: {}", e)))?;
+
+    match serde_json::from_str::<JsonRpcResponse>(&body_text) {
+        Ok(rpc_response) => {
+            if let Some(error) = rpc_response.error {
+                return Err(RpcCallError::JsonRpcError(error));
+            }
+            if let Some(result) = rpc_response.result {
+                return Ok(result);
+            }
+            Err(RpcCallError::InvalidResponse(
+                "Response contains neither 'result' nor 'error' field".to_string(),
+            ))
         }
-        Ok(rpc_response.result)
-    } else {
-        let status = res.status();
-        let text = res
-            .text()
-            .await
-            .unwrap_or_else(|_| "Could not read error body".to_string());
-        Err(format!("HTTP error: {}\nResponse: {}", status, text).into())
+        Err(parse_err) => Err(RpcCallError::InvalidJson {
+            body: body_text,
+            parse_error: parse_err.to_string(),
+        }),
     }
 }
 
@@ -163,16 +252,49 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::GetBeadCount => ("getbeadcount", json!([])),
         Commands::GetCohortCount => ("getcohortcount", json!([])),
         Commands::GetTips => ("gettips", json!([])),
-        Commands::GetCohort { cohort_id } => ("getcohort", json!([cohort_id])),
+        Commands::GetCohortById { cohort_id } => ("getcohortbyid", json!([cohort_id])),
         Commands::GetGenesis => ("getgenesis", json!([])),
         Commands::GetMinerInfo => ("getminerinfo", json!([])),
-        Commands::GetMiningInfo => ("getmininginfo", json!([])),
+        Commands::GetMiningInfo {
+            public_keys,
+            miner_ips,
+        } => {
+            let mut params_obj = serde_json::Map::new();
+
+            if let Some(keys) = public_keys {
+                if !keys.is_empty() {
+                    params_obj.insert(
+                        "public_keys".to_string(),
+                        json!(keys
+                            .iter()
+                            .map(|k| k.trim().to_string())
+                            .collect::<Vec<_>>()),
+                    );
+                }
+            }
+
+            if let Some(ips) = miner_ips {
+                if !ips.is_empty() {
+                    params_obj.insert(
+                        "miner_ips".to_string(),
+                        json!(ips
+                            .iter()
+                            .map(|ip| ip.trim().to_string())
+                            .collect::<Vec<_>>()),
+                    );
+                }
+            }
+
+            ("getmininginfo", json!([params_obj]))
+        }
         Commands::GetParents { bead_hash } => ("getparents", json!([bead_hash])),
         Commands::GetChildren { bead_hash } => ("getchildren", json!([bead_hash])),
-        Commands::GetHwPath { limit } => ("gethwpath", json!([limit])),
+        Commands::GetHighestWorkPathByCount { limit } => {
+            ("gethighestworkpathbycount", json!([limit]))
+        }
         Commands::GetIpcStats => ("getipcstats", json!([])),
         Commands::GetBraidInfo => ("getbraidinfo", json!([])),
-        Commands::GetNodeInfo { node } => ("getnodeinfo", json!([node])),
+        Commands::GetNodeInfo { bead_hash } => ("getnodeinfo", json!([bead_hash])),
         Commands::GetPeerInfo => ("getpeerinfo", json!([])),
         Commands::StagedTransactions => ("stagedtransactions", json!([])),
         Commands::UnstageTransactions { tx_id } => ("unstagetransactions", json!([tx_id])),
@@ -185,12 +307,31 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     match call_rpc(&cli.rpc_url, method, params).await {
         Ok(result) => {
-            let pretty_response = serde_json::to_string_pretty(&result)?;
+            let pretty_response = serde_json::to_string_pretty(&result).map_err(|e| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("Failed to serialize response: {}", e),
+                ))
+            })?;
             println!("{}", pretty_response);
             Ok(())
         }
         Err(e) => {
+            // Print error to stderr with proper formatting
             eprintln!("Error: {}", e);
+
+            // For JSON-RPC errors, provide additional context if available
+            if let RpcCallError::JsonRpcError(ref json_err) = e {
+                if let Some(ref data) = json_err.data {
+                    eprintln!("\nAdditional error details:");
+                    if let Ok(pretty_data) = serde_json::to_string_pretty(data) {
+                        eprintln!("{}", pretty_data);
+                    } else {
+                        eprintln!("{:?}", data);
+                    }
+                }
+            }
+
             std::process::exit(1);
         }
     }

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -35,6 +35,7 @@ sqlx = { workspace = true}
 strum = { workspace = true }
 if-addrs = { workspace = true }
 anyhow = { workspace = true }
+reqwest = { workspace = true }
 
 
 [build-dependencies]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -26,12 +26,12 @@ pub struct Cli {
     pub rpcport: u16,
 
     /// Use this username for bitcoin RPC
-    #[arg(long, default_value = "root")]
-    pub rpcuser: String,
+    #[arg(long)]
+    pub rpcuser: Option<String>,
 
     /// Use this password for bitcoin RPC
-    #[arg(long, default_value = "pass")]
-    pub rpcpass: String,
+    #[arg(long)]
+    pub rpcpass: Option<String>,
 
     /// Which network to use. Valid options are mainnet, testnet4, signet, cpunet (preferred)
     #[arg(long, default_value = "main")]

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,8 +1,6 @@
 use clap::Parser;
 use std::path::PathBuf;
 
-use crate::rpc_server::RpcCommand;
-
 #[derive(Parser, Debug, Clone)]
 #[command(name = "braid", about = "Braidpool Node CLI")]
 pub struct Cli {
@@ -28,12 +26,12 @@ pub struct Cli {
     pub rpcport: u16,
 
     /// Use this username for bitcoin RPC
-    #[arg(long)]
-    pub rpcuser: Option<String>,
+    #[arg(long, default_value = "root")]
+    pub rpcuser: String,
 
     /// Use this password for bitcoin RPC
-    #[arg(long, default_value = "")]
-    pub rpcpass: Option<String>,
+    #[arg(long, default_value = "pass")]
+    pub rpcpass: String,
 
     /// Which network to use. Valid options are mainnet, testnet4, signet, cpunet (preferred)
     #[arg(long, default_value = "main")]
@@ -42,10 +40,6 @@ pub struct Cli {
     /// Use this cookie file for bitcoin RPC
     #[arg(long, default_value = "~/.bitcoin/.cookie")]
     pub rpccookie: Option<String>,
-
-    ///Rpc endpoints for the specific methods
-    #[command(subcommand)]
-    pub command: Option<RpcCommand>,
 
     /// Path to Bitcoin Core IPC socket
     #[arg(long, default_value = "/tmp/bitcoin-cpunet.sock")]

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -2,6 +2,7 @@
 use crate::config::CoinbaseConfig;
 use crate::error::CoinbaseError;
 use crate::error::{classify_error, ErrorKind};
+use crate::rpc_server::RpcProxyCommand;
 use crate::template_creator::{create_block_template, FinalTemplate};
 use crate::{TemplateId, MAX_CACHED_TEMPLATES};
 use std::collections::HashMap;
@@ -15,6 +16,7 @@ pub use client::{
     BitcoinNotification, BlockTemplateComponents, CheckBlockResult, RequestPriority,
     SharedBitcoinClient,
 };
+use hex;
 
 const MAX_BACKOFF: u64 = 300;
 
@@ -34,6 +36,7 @@ pub async fn ipc_block_listener(
     mut block_submission_rx: tokio::sync::mpsc::UnboundedReceiver<
         crate::stratum::BlockSubmissionRequest,
     >,
+    mut rpc_command_rx: tokio::sync::mpsc::UnboundedReceiver<RpcProxyCommand>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     info!(
         socket = %ipc_socket_path,
@@ -307,6 +310,41 @@ pub async fn ipc_block_listener(
                         }
                     }
                 }
+
+                    rpc_command = rpc_command_rx.recv() => {
+                        if let Some(command) = rpc_command {
+                            match command {
+                                RpcProxyCommand::GetStats { responder } => {
+                                    let stats = shared_client.get_queue_stats();
+                                    if responder.send(Ok(stats)).is_err() {
+                                        warn!("Failed to send stats response - receiver dropped");
+                                    }
+                                }
+
+                                RpcProxyCommand::RemoveTransaction { txid, responder } => {
+                                    // Convert hex string to bytes
+                                    let txid_bytes = match hex::decode(&txid) {
+                                        Ok(bytes) => bytes,
+                                        Err(e) => {
+                                            let _ = responder.send(Err(format!("Invalid txid hex: {}", e)));
+                                            continue;
+                                        }
+                                    };
+
+                                    match shared_client.remove_transaction(&txid_bytes, None).await {
+                                        Ok(removed) => {
+                                            if responder.send(Ok(removed)).is_err() {
+                                                warn!("Failed to send remove_transaction response - receiver dropped");
+                                            }
+                                        }
+                                        Err(e) => {
+                                            let _ = responder.send(Err(format!("IPC error: {}", e)));
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
 
                     _ = health_check_interval.tick() => {
                         let stats = shared_client.get_queue_stats();

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -271,9 +271,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
     //For local testing uncomment this keypair peer since it running to process will
     //result in same peerID leading to OutgoingConnectionError
-
     // let keypair = identity::Keypair::generate_ed25519();
-
     //creating a main topic subscribing to the current test topic
     let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
 
@@ -388,12 +386,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Create RPC proxy command channel - sender goes to RPC server, receiver goes to IPC handler
     let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
-
     // peer_manager_arc is created above and shared between swarm and RPC server
-
     //spawning the rpc server
     let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
-
     let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args).unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         std::process::exit(1);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -242,8 +242,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     }
-    //for local testing comment this loading of keypair from keystore
-    //and use the below one
     let keypair = match fs::read(&keystore_path) {
         Ok(keypair) => {
             info!(path = %keystore_path.display(), "Loading keypair from keystore");
@@ -275,9 +273,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //result in same peerID leading to OutgoingConnectionError
 
     // let keypair = identity::Keypair::generate_ed25519();
-
-    // Get peer ID from keypair before moving it into swarm builder
-    let peer_id_for_rpc = PeerId::from(keypair.public());
 
     //creating a main topic subscribing to the current test topic
     let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
@@ -393,23 +388,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     // Create RPC proxy command channel - sender goes to RPC server, receiver goes to IPC handler
     let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
-    let rpc_proxy_tx_for_rpc = rpc_proxy_tx;
-    let rpc_proxy_rx_for_ipc = rpc_proxy_rx;
 
     // peer_manager_arc is created above and shared between swarm and RPC server
 
     //spawning the rpc server
     let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
 
-    let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args);
+    let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args).unwrap_or_else(|e| {
+        eprintln!("Error: {}", e);
+        std::process::exit(1);
+    });
     let server_join = tokio::spawn(run_rpc_server(
         Arc::clone(&braid),
         rpc_addr,
-        Some(peer_id_for_rpc),
         peer_manager_arc.clone(),
         connection_mapping_for_rpc.clone(),
         latest_template.clone(),
-        rpc_proxy_tx_for_rpc,
+        rpc_proxy_tx,
         bitcoin_rpc_config,
     ));
     match server_join.await {
@@ -461,7 +456,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         let ipc_socket_path = ipc_socket_path_for_blocking.clone();
                         let ipc_template_tx = ipc_template_tx.clone();
                         let template_cache = template_cache_for_listener.clone();
-                        let rpc_command_rx = rpc_proxy_rx_for_ipc;
+                        let rpc_command_rx = rpc_proxy_rx;
 
                         async move {
                             match node::ipc::ipc_block_listener(

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -26,7 +26,7 @@ use node::{
     ibd_manager::{IBDCommands, IBDManager, IBD_BATCH_SIZE},
     ipc_template_consumer,
     peer_manager::PeerManager,
-    rpc_server::{parse_arguments, run_rpc_server},
+    rpc_server::{run_rpc_server, BitcoinRpcConfig, RpcProxyCommand},
     setup_tracing,
     stratum::{BlockTemplate, ConnectionMapping, Notifier, NotifyCmd, Server, StratumServerConfig},
     SwarmCommand, TemplateId,
@@ -138,6 +138,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let notification_tx_clone = notification_tx.clone();
     //Connection mapping for all the downstream connection connected to the stratum server
     let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
+    // Clone connection_mapping for RPC server before it's used in async move blocks
+    let connection_mapping_for_rpc = Arc::clone(&connection_mapping);
     //Mining job map keeping all the jobs provided to the downstream
     let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
     //Intializing `notifier` for mining.notify
@@ -265,35 +267,18 @@ async fn main() -> Result<(), Box<dyn Error>> {
             keypair
         }
     };
-    //spawning the rpc server
-    let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
-    if let Some(rpc_command) = args.command {
-        let server_address = tokio::spawn(run_rpc_server(Arc::clone(&braid), rpc_addr));
-        let socket_address = server_address
-            .await
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("RPC server task failed: {}", e),
-                )
-            })?
-            .map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::Other, "RPC server startup failed")
-            })?;
-        let _parsing_handle =
-            tokio::spawn(parse_arguments(rpc_command, socket_address.clone())).await;
-    } else {
-        //running the rpc server and updating the reference counter
-        //for shared ownership
-        let _server_handler = tokio::spawn(run_rpc_server(Arc::clone(&braid), rpc_addr)).await;
-    }
     // load beads from db (if present) and insert in braid here
-    // Initializing the peer manager
-    let mut peer_manager = PeerManager::new(8);
+    // Initializing the peer manager (shared between swarm and RPC server)
+    // Using RwLock to allow concurrent reads (RPC server) while swarm handler can write
+    let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
     //For local testing uncomment this keypair peer since it running to process will
     //result in same peerID leading to OutgoingConnectionError
 
     // let keypair = identity::Keypair::generate_ed25519();
+
+    // Get peer ID from keypair before moving it into swarm builder
+    let peer_id_for_rpc = PeerId::from(keypair.public());
+
     //creating a main topic subscribing to the current test topic
     let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
 
@@ -406,6 +391,45 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let latest_template_for_ipc = latest_template.clone();
     let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
 
+    // Create RPC proxy command channel - sender goes to RPC server, receiver goes to IPC handler
+    let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
+    let rpc_proxy_tx_for_rpc = rpc_proxy_tx;
+    let rpc_proxy_rx_for_ipc = rpc_proxy_rx;
+
+    // peer_manager_arc is created above and shared between swarm and RPC server
+
+    //spawning the rpc server
+    let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
+
+    let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args);
+    let server_join = tokio::spawn(run_rpc_server(
+        Arc::clone(&braid),
+        rpc_addr,
+        Some(peer_id_for_rpc),
+        peer_manager_arc.clone(),
+        connection_mapping_for_rpc.clone(),
+        latest_template.clone(),
+        rpc_proxy_tx_for_rpc,
+        bitcoin_rpc_config,
+    ));
+    match server_join.await {
+        Ok(Ok(_addr)) => {}
+        Ok(Err(())) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                "RPC server startup failed",
+            )
+            .into());
+        }
+        Err(e) => {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("RPC server task failed: {}", e),
+            )
+            .into());
+        }
+    };
+
     // Spawn IPC handler
     let _ipc_handler = tokio::task::spawn_blocking(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
@@ -437,6 +461,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         let ipc_socket_path = ipc_socket_path_for_blocking.clone();
                         let ipc_template_tx = ipc_template_tx.clone();
                         let template_cache = template_cache_for_listener.clone();
+                        let rpc_command_rx = rpc_proxy_rx_for_ipc;
 
                         async move {
                             match node::ipc::ipc_block_listener(
@@ -445,6 +470,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 network,
                                 template_cache,
                                 block_submission_rx,
+                                rpc_command_rx,
                             )
                             .await
                             {
@@ -504,8 +530,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             info!(address = %node_multiaddr, "Dialed peer node");
         }
     };
+    let peer_manager_arc_for_swarm = peer_manager_arc.clone();
     let swarm_handle = tokio::spawn(async move {
         let braid = std::sync::Arc::clone(&braid);
+        let peer_manager_arc = peer_manager_arc_for_swarm;
         loop {
             tokio::select! {
              swarm_event = swarm.select_next_some()=>{
@@ -582,7 +610,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                       //If the received  bead exceeds the timestamp of ibd completion wrt to a sync node
                                       if let braid::AddBeadStatus::ParentsNotYetReceived = status {
                                         //request the parents using request response protocol
-                                        let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
+                                        let peer_id = {
+                                            let peer_manager = peer_manager_arc.read().await;
+                                            peer_manager.get_top_k_peers_for_propagation(1)
+                                        };
                                         if let Some(peer) = peer_id.first() {
                                             swarm.behaviour_mut().bead_sync.send_request(
                                                 &peer,
@@ -601,7 +632,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         }
                                     } else if let braid::AddBeadStatus::InvalidBead = status {
                                         // update the peer manager about the invalid bead
-                                        peer_manager.penalize_for_invalid_bead(&message.source);
+                                        {
+                                            let mut peer_manager = peer_manager_arc.write().await;
+                                            peer_manager.penalize_for_invalid_bead(&message.source);
+                                        }
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
                                      //Considering the index of the beads in braid will be same as the (insertion ids-1)
                                         let bead_id = match braid_data
@@ -637,7 +671,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                );
                                            }
                                         };
-                                        peer_manager.update_score(&message.source, 1.0);
+                                        {
+                                            let mut peer_manager = peer_manager_arc.write().await;
+                                            peer_manager.update_score(&message.source, 1.0);
+                                        }
                                     }
                                     for (sync_peer, ibd_ts) in timestamp_map.iter() {
                                         let threshold = *ibd_ts + LATENCY_ALPHA * 10;
@@ -689,7 +726,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                 else{
                                     if let braid::AddBeadStatus::ParentsNotYetReceived = status {
                                         //request the parents using request response protocol
-                                        let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
+                                        let peer_id = {
+                                            let peer_manager = peer_manager_arc.read().await;
+                                            peer_manager.get_top_k_peers_for_propagation(1)
+                                        };
                                         if let Some(peer) = peer_id.first() {
                                             swarm.behaviour_mut().bead_sync.send_request(
                                                 &peer,
@@ -708,7 +748,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         }
                                     } else if let braid::AddBeadStatus::InvalidBead = status {
                                         // update the peer manager about the invalid bead
-                                        peer_manager.penalize_for_invalid_bead(&message.source);
+                                        {
+                                            let mut peer_manager = peer_manager_arc.write().await;
+                                            peer_manager.penalize_for_invalid_bead(&message.source);
+                                        }
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
                                         let bead_id = match braid_data
                                             .bead_index_mapping
@@ -743,7 +786,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                );
                                            }
                                         };
-                                        peer_manager.update_score(&message.source, 1.0);
+                                        {
+                                            let mut peer_manager = peer_manager_arc.write().await;
+                                            peer_manager.update_score(&message.source, 1.0);
+                                        }
                                     }
                                 }
 
@@ -828,7 +874,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      latency_ms = %latency.as_millis(),
                                      "Ping"
                                  );
-                                peer_manager.update_latency(&peer,latency);
+                                {
+                                    let mut peer_manager = peer_manager_arc.write().await;
+                                    peer_manager.update_latency(&peer,latency);
+                                }
                              }
                              Err(err) => {
                                  warn!(
@@ -861,7 +910,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              }
                              _ => None,
                          });
-                         peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
+                         {
+                             let mut peer_manager = peer_manager_arc.write().await;
+                             peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
+                         }
                          info!(
                             peer_id = ?peer_id,
                             remote_addr = ?remote_addr,
@@ -878,7 +930,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                      } => {
                          info!(peer = %peer_id, connection_id = %connection_id, address = %endpoint.get_remote_address(), established = %num_established, cause = ?cause, "Connection closed");
                          // Remove the peer from the peer manager
-                         peer_manager.remove_peer(&peer_id);
+                         {
+                             let mut peer_manager = peer_manager_arc.write().await;
+                             peer_manager.remove_peer(&peer_id);
+                         }
                          swarm
                              .behaviour_mut()
                              .kademlia
@@ -1030,7 +1085,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         let curr_beadhash = bead.block_header.block_hash().to_string();
                                         if let braid::AddBeadStatus::InvalidBead = status {
                                             // update the peer manager about the invalid bead
-                                            peer_manager.penalize_for_invalid_bead(&peer);
+                                            {
+                                                let mut peer_manager = peer_manager_arc.write().await;
+                                                peer_manager.penalize_for_invalid_bead(&peer);
+                                            }
                                         } else if let braid::AddBeadStatus::BeadAdded = status {
                                             let bead_id = match braid_data
                                                 .bead_index_mapping
@@ -1053,7 +1111,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 }
                                             };
                                             // update score of the peer
-                                            peer_manager.update_score(&peer, 1.0);
+                                            {
+                                                let mut peer_manager = peer_manager_arc.write().await;
+                                                peer_manager.update_score(&peer, 1.0);
+                                            }
                                             //persisting the received beads from peer onto DB(disk)
                                             match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
                                                 Ok(_)=>{
@@ -1367,7 +1428,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                      SwarmCommand::InitiateIBD=>{
                         info!("Initiating IBD after peer discovery and selecting peer with lowest latency score");
                         //Evicting lowest latency peer id
-                        let peer_ids = peer_manager.get_top_k_peers_for_propagation(1);
+                        let peer_ids = {
+                            let peer_manager = peer_manager_arc.read().await;
+                            peer_manager.get_top_k_peers_for_propagation(1)
+                        };
                         if peer_ids.len() == 0 {
                             warn!("No peer available for syncing to take place");
                                 tokio::spawn({

--- a/node/src/peer_manager/mod.rs
+++ b/node/src/peer_manager/mod.rs
@@ -25,7 +25,7 @@ pub struct PeerInfo {
     /// Whether the peer is currently connected
     pub connected: bool,
     /// The peer's IP address
-    ip_addr: Option<IpAddr>,
+    pub ip_addr: Option<IpAddr>,
 }
 
 impl PeerInfo {
@@ -256,6 +256,65 @@ impl PeerManager {
     /// Get the number of connected peers
     pub fn num_connected_peers(&self) -> usize {
         self.connected_peers.len()
+    }
+
+    /// Get peer information as JSON value for RPC responses
+    pub fn get_peers_json(&self) -> serde_json::Value {
+        use serde_json::json;
+
+        let connected_peers_info: Vec<&PeerInfo> =
+            self.peers.values().filter(|p| p.connected).collect();
+        let total_peers = self.peers.len();
+        let connected = connected_peers_info.len();
+
+        let mut avg_latency_ms = 0.0;
+        let mut latency_count = 0;
+        let mut geo_groups = HashSet::new();
+        let mut inbound_count = 0;
+
+        for info in &connected_peers_info {
+            if info.inbound {
+                inbound_count += 1;
+            }
+            if let Some(latency) = info.latency {
+                avg_latency_ms += latency.as_millis() as f64;
+                latency_count += 1;
+            }
+            if let Some(group) = &info.geo_group {
+                geo_groups.insert(group.clone());
+            }
+        }
+
+        if latency_count > 0 {
+            avg_latency_ms /= latency_count as f64;
+        }
+
+        let now = Instant::now();
+        let peers: Vec<serde_json::Value> = connected_peers_info
+            .iter()
+            .map(|info| {
+                let last_seen_secs = now.duration_since(info.last_message_time).as_secs();
+                json!({
+                    "peer_id": info.peer_id.to_base58(),
+                    "ip": info.ip_addr.map(|ip| ip.to_string()),
+                    "inbound": info.inbound,
+                    "latency_ms": info.latency.map(|l| l.as_millis() as f64),
+                    "score": info.score,
+                    "last_seen_secs": last_seen_secs,
+                    "geo_group": info.geo_group,
+                })
+            })
+            .collect();
+
+        json!({
+            "total_peers": total_peers,
+            "connected": connected,
+            "inbound": inbound_count,
+            "outbound": connected - inbound_count,
+            "network_groups": geo_groups.len(),
+            "avg_latency_ms": if latency_count > 0 { avg_latency_ms } else { 0.0 },
+            "peers": peers,
+        })
     }
 
     /// Get a summary of peer statistics

--- a/node/src/peer_manager/mod.rs
+++ b/node/src/peer_manager/mod.rs
@@ -1,4 +1,5 @@
 use libp2p::PeerId;
+use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
 use std::time::{Duration, Instant};
@@ -260,19 +261,15 @@ impl PeerManager {
 
     /// Get peer information as JSON value for RPC responses
     pub fn get_peers_json(&self) -> serde_json::Value {
-        use serde_json::json;
-
-        let connected_peers_info: Vec<&PeerInfo> =
-            self.peers.values().filter(|p| p.connected).collect();
         let total_peers = self.peers.len();
-        let connected = connected_peers_info.len();
-
         let mut avg_latency_ms = 0.0;
         let mut latency_count = 0;
         let mut geo_groups = HashSet::new();
         let mut inbound_count = 0;
+        let now = Instant::now();
+        let mut peers_json_array: Vec<serde_json::Value> = Vec::new();
 
-        for info in &connected_peers_info {
+        for info in self.peers.values().filter(|p| p.connected) {
             if info.inbound {
                 inbound_count += 1;
             }
@@ -283,28 +280,24 @@ impl PeerManager {
             if let Some(group) = &info.geo_group {
                 geo_groups.insert(group.clone());
             }
+
+            let last_seen_secs = now.duration_since(info.last_message_time).as_secs();
+            peers_json_array.push(json!({
+                "peer_id": info.peer_id.to_base58(),
+                "ip": info.ip_addr.map(|ip| ip.to_string()),
+                "inbound": info.inbound,
+                "latency_ms": info.latency.map(|l| l.as_millis() as f64),
+                "score": info.score,
+                "last_seen_secs": last_seen_secs,
+                "geo_group": info.geo_group,
+            }));
         }
 
         if latency_count > 0 {
             avg_latency_ms /= latency_count as f64;
         }
 
-        let now = Instant::now();
-        let peers: Vec<serde_json::Value> = connected_peers_info
-            .iter()
-            .map(|info| {
-                let last_seen_secs = now.duration_since(info.last_message_time).as_secs();
-                json!({
-                    "peer_id": info.peer_id.to_base58(),
-                    "ip": info.ip_addr.map(|ip| ip.to_string()),
-                    "inbound": info.inbound,
-                    "latency_ms": info.latency.map(|l| l.as_millis() as f64),
-                    "score": info.score,
-                    "last_seen_secs": last_seen_secs,
-                    "geo_group": info.geo_group,
-                })
-            })
-            .collect();
+        let connected = peers_json_array.len();
 
         json!({
             "total_peers": total_peers,
@@ -312,8 +305,8 @@ impl PeerManager {
             "inbound": inbound_count,
             "outbound": connected - inbound_count,
             "network_groups": geo_groups.len(),
-            "avg_latency_ms": if latency_count > 0 { avg_latency_ms } else { 0.0 },
-            "peers": peers,
+            "avg_latency_ms": avg_latency_ms,
+            "peers": peers_json_array,
         })
     }
 

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -1,134 +1,41 @@
 use crate::bead::Bead;
-#[cfg(test)]
-use crate::braid;
+use crate::braid::consensus_functions;
+use crate::braid::consensus_functions::highest_work_path;
 use crate::braid::AddBeadStatus;
 use crate::braid::Braid;
-use crate::error::BraidRPCError;
-#[cfg(test)]
-use crate::utils::create_test_bead;
+use crate::ipc::client::QueueStats;
+use crate::peer_manager::PeerManager;
+use crate::stratum;
+use crate::stratum::BlockTemplate;
 use crate::utils::BeadHash;
-use clap::Subcommand;
+use bitcoin::block::HeaderExt;
+use futures::lock::Mutex;
 use jsonrpsee::core::async_trait;
-use jsonrpsee::core::client::ClientT;
 use jsonrpsee::core::middleware::Batch;
 use jsonrpsee::core::middleware::Notification;
 use jsonrpsee::core::middleware::RpcServiceT;
-use jsonrpsee::core::params::ArrayParams;
-use jsonrpsee::http_client::HttpClient;
 use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::types::Request;
 use jsonrpsee::ConnectionId;
+use libp2p::PeerId;
+use serde::{Deserialize, Serialize};
 use serde_json;
+use serde_json::Value;
+use std::collections::HashMap;
+use std::collections::HashSet;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::RwLock;
-#[allow(unused_imports)]
-use tracing::{debug, error, info, trace, warn};
+use tokio::sync::{mpsc, oneshot, RwLock};
+use tracing::{info, warn};
 
-//Rpc commands
-#[derive(Subcommand, Debug, Clone)]
-pub enum RpcCommand {
-    /// Get a bead by hash
-    GetBead {
-        /// The bead hash (as a hex string)
-        bead_hash: String,
-    },
-
-    /// Add a bead via serialized JSON string
-    AddBead {
-        /// JSON-formatted bead
-        bead_data: String,
-    },
-
-    /// Get total number of beads
-    GetBeadCount,
-
-    /// Get total number of cohorts
-    GetCohortCount,
-
-    /// Get current DAG tips
-    GetTips,
-}
-//parsing the inital rpc command line all
-pub async fn parse_arguments(cli_command: RpcCommand, server_addr: SocketAddr) -> () {
-    // //initializing a client associated with the current node
-    // //for receiving the response from the server
-    let target_uri = format!("http://{}", server_addr.to_string());
-    let client_res: HttpClient = HttpClient::builder().build(target_uri).unwrap();
-
-    let (rpc_method, method_params) = match cli_command {
-        RpcCommand::AddBead { bead_data } => {
-            let rpc_method = String::from("addbead");
-            let mut method_params = ArrayParams::new();
-            method_params.insert(bead_data).unwrap();
-
-            (rpc_method, method_params)
-        }
-        RpcCommand::GetBead { bead_hash } => {
-            let rpc_method = "getbead".to_string();
-            let mut method_params = ArrayParams::new();
-            method_params.insert(bead_hash).unwrap();
-
-            (rpc_method, method_params)
-        }
-        RpcCommand::GetBeadCount => {
-            let rpc_method = String::from("getbeadcount");
-            let method_params = ArrayParams::new();
-
-            (rpc_method, method_params)
-        }
-        RpcCommand::GetCohortCount => {
-            let method_params = ArrayParams::new();
-            let rpc_method = String::from("getcohortcount");
-
-            (rpc_method, method_params)
-        }
-        RpcCommand::GetTips => {
-            let method_params = ArrayParams::new();
-            let rpc_method = String::from("gettips");
-
-            (rpc_method, method_params)
-        }
-    };
-    tokio::spawn(handle_request(
-        rpc_method.clone(),
-        method_params,
-        client_res,
-    ));
-}
-
-//handling the request arising either from command line cli or from the external users
-pub async fn handle_request(
-    method: String,
-    method_params: ArrayParams,
-    client: HttpClient,
-) -> Result<(), BraidRPCError> {
-    let rpc_response: Result<String, jsonrpsee::core::ClientError> =
-        client.request(&method, method_params.clone()).await;
-    match rpc_response {
-        Ok(response) => {
-            info!(
-                response = ?response,
-                method = %method,
-                "RPC response received"
-            );
-            Ok(())
-        }
-        Err(error) => {
-            error!(
-                error = ?error,
-                method = %method,
-                "RPC request failed"
-            );
-            Err(BraidRPCError::RequestFailed {
-                method: method,
-                source: error,
-            })
-        }
-    }
-}
+#[cfg(test)]
+use {
+    crate::braid, crate::utils::create_test_bead, bitcoin::Transaction,
+    jsonrpsee::core::client::ClientT, jsonrpsee::core::params::ArrayParams,
+    jsonrpsee::http_client::HttpClient,
+};
 
 //server side trait to be implemented for the handler
 //that is the JSON-RPC handle to initiate the RPC context
@@ -137,36 +44,188 @@ pub async fn handle_request(
 pub trait Rpc {
     //RPC methods supported by braid-API
     #[method(name = "getbead")]
-    async fn get_bead(&self, bead_hash: String) -> Result<String, ErrorObjectOwned>;
+    async fn get_bead(&self, bead_hash: String) -> Result<Bead, ErrorObjectOwned>;
 
     #[method(name = "addbead")]
     async fn add_bead(&self, bead_data: String) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "gettips")]
-    async fn get_tips(&self) -> Result<String, ErrorObjectOwned>;
+    async fn get_tips(&self) -> Result<Vec<String>, ErrorObjectOwned>;
 
     #[method(name = "getbeadcount")]
     async fn get_bead_count(&self) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "getcohortcount")]
     async fn get_cohort_count(&self) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getcohort")]
+    async fn get_cohort(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getgenesis")]
+    async fn get_genesis(&self) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getmininginfo")]
+    async fn get_mining_info(&self) -> Result<Value, ErrorObjectOwned>;
+
+    #[method(name = "getminerinfo")]
+    async fn get_miner_info(&self) -> Result<Vec<String>, ErrorObjectOwned>;
+
+    #[method(name = "getparents")]
+    async fn get_parents(&self, bead_hash: String) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getchildren")]
+    async fn get_children(&self, bead_hash: String) -> Result<Vec<String>, ErrorObjectOwned>;
+
+    #[method(name = "gethwpath")]
+    async fn get_hwpath(&self, limit: u8) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getipcstats")]
+    async fn get_ipc_stats(&self) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "getbraidinfo")]
+    async fn get_braid_info(&self) -> Result<Value, ErrorObjectOwned>;
+
+    #[method(name = "getnodeinfo")]
+    async fn get_node_info(&self, node: String) -> Result<Value, ErrorObjectOwned>;
+
+    #[method(name = "getpeerinfo")]
+    async fn get_peer_info(&self) -> Result<Value, ErrorObjectOwned>;
+
+    #[method(name = "stagedtransactions")]
+    async fn staged_transactions(&self) -> Result<Value, ErrorObjectOwned>;
+
+    #[method(name = "unstagetransactions")]
+    async fn unstage_transactions(&self, txid: String) -> Result<String, ErrorObjectOwned>;
+
+    #[method(name = "bitcoinproxy")]
+    async fn bitcoin_proxy(
+        &self,
+        method: String,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ErrorObjectOwned>;
+}
+
+#[derive(Serialize)]
+struct MiningInfo {
+    our_beads_count: usize,
+    total_beads_in_braid: usize,
+    our_total_work: String,
+    total_work_in_braid: String,
+    our_work_share_percent: f64,
+    payout_address: Option<String>,
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+struct BraidInfo {
+    bead_count: usize,
+    tip_count: usize,
+    tips: Vec<String>,
+    cohort_count: usize,
+    orphan_count: usize,
+    genesis_beads: Vec<String>,
+    total_work: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct NodeInfo {
+    common_pubkey: String,
+    miner_ip: String,
+    payout_address: String,
+    minimum_target: String,
+}
+
+/// JSON-RPC request structure
+#[derive(Serialize)]
+struct JsonRpcRequest {
+    jsonrpc: &'static str,
+    method: String,
+    params: serde_json::Value,
+    id: u64,
+}
+
+/// JSON-RPC response structure
+#[derive(Deserialize)]
+struct JsonRpcResponse {
+    result: Option<serde_json::Value>,
+    error: Option<serde_json::Value>,
+}
+
+/// Bitcoin RPC configuration for proxy calls
+#[derive(Debug, Clone)]
+pub struct BitcoinRpcConfig {
+    pub host: String,
+    pub port: u16,
+    pub username: String,
+    pub password: String,
+}
+
+impl BitcoinRpcConfig {
+    /// Create RPC config from CLI arguments
+    pub fn from_cli_args(args: &crate::cli::Cli) -> Option<Self> {
+        // If no RPC credentials provided, return None (RPC proxy disabled)
+        if args.rpcuser.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            host: args.bitcoin.clone(),
+            port: args.rpcport,
+            username: args.rpcuser.clone(),
+            password: args.rpcpass.clone(),
+        })
+    }
+
+    /// Build RPC URL for bitcoincore-rpc client
+    pub fn rpc_url(&self) -> String {
+        format!("http://{}:{}", self.host, self.port)
+    }
+}
+
+pub enum RpcProxyCommand {
+    RemoveTransaction {
+        txid: String,
+        responder: oneshot::Sender<Result<bool, String>>,
+    },
+    GetStats {
+        responder: oneshot::Sender<Result<QueueStats, String>>,
+    },
 }
 
 // RPC Server implementation using channels
 pub struct RpcServerImpl {
     braid_arc: Arc<RwLock<Braid>>,
+    peer_id: Option<PeerId>,
+    peer_manager: Arc<tokio::sync::RwLock<PeerManager>>,
+    stratum_connection_mapping: Arc<Mutex<stratum::ConnectionMapping>>,
+    latest_block: Arc<Mutex<BlockTemplate>>,
+    rpc_proxy_tx: mpsc::UnboundedSender<RpcProxyCommand>,
+    bitcoin_rpc_config: Option<BitcoinRpcConfig>,
 }
 
 impl RpcServerImpl {
-    pub fn new(braid_shared_pointer: Arc<RwLock<Braid>>) -> Self {
+    pub fn new(
+        braid_shared_pointer: Arc<RwLock<Braid>>,
+        peer_id: Option<PeerId>,
+        peer_manager: Arc<tokio::sync::RwLock<PeerManager>>,
+        stratum_connection_mapping: Arc<Mutex<stratum::ConnectionMapping>>,
+        latest_block_template: Arc<Mutex<BlockTemplate>>,
+        rpc_proxy_tx: mpsc::UnboundedSender<RpcProxyCommand>,
+        bitcoin_rpc_config: Option<BitcoinRpcConfig>,
+    ) -> Self {
         Self {
             braid_arc: braid_shared_pointer,
+            peer_id,
+            peer_manager,
+            stratum_connection_mapping,
+            latest_block: latest_block_template,
+            rpc_proxy_tx,
+            bitcoin_rpc_config,
         }
     }
 }
 #[async_trait]
 impl RpcServer for RpcServerImpl {
-    async fn get_bead(&self, bead_hash: String) -> Result<String, ErrorObjectOwned> {
+    async fn get_bead(&self, bead_hash: String) -> Result<Bead, ErrorObjectOwned> {
         let hash = bead_hash
             .parse::<BeadHash>()
             .map_err(|_| ErrorObjectOwned::owned(1, "Invalid bead hash format", None::<()>))?;
@@ -178,15 +237,7 @@ impl RpcServer for RpcServerImpl {
             .find(|bead| bead.block_header.block_hash() == hash)
             .cloned();
 
-        match bead {
-            Some(bead) => {
-                let json = serde_json::to_string(&bead)
-                    .map_err(|_| ErrorObjectOwned::owned(2, "Internal error", None::<()>))
-                    .unwrap();
-                Ok(json)
-            }
-            None => Err(ErrorObjectOwned::owned(3, "Bead not found", None::<()>)),
-        }
+        bead.ok_or_else(|| ErrorObjectOwned::owned(3, "Bead not found", None::<()>))
     }
 
     async fn add_bead(&self, bead_data: String) -> Result<String, ErrorObjectOwned> {
@@ -212,7 +263,7 @@ impl RpcServer for RpcServerImpl {
         }
     }
 
-    async fn get_tips(&self) -> Result<String, ErrorObjectOwned> {
+    async fn get_tips(&self) -> Result<Vec<String>, ErrorObjectOwned> {
         let braid_data = self.braid_arc.read().await;
         let tips: Vec<BeadHash> = braid_data
             .tips
@@ -222,8 +273,7 @@ impl RpcServer for RpcServerImpl {
         info!(tip_count = %tips.len(), "Get tips request received");
         let tips_str: Vec<String> = tips.iter().map(|h| h.to_string()).collect();
 
-        serde_json::to_string(&tips_str)
-            .map_err(|_| ErrorObjectOwned::owned(2, "Internal error", None::<()>))
+        Ok(tips_str)
     }
 
     async fn get_bead_count(&self) -> Result<String, ErrorObjectOwned> {
@@ -239,6 +289,493 @@ impl RpcServer for RpcServerImpl {
         info!(count = %count, "Get cohort count request received");
 
         Ok(count.to_string())
+    }
+
+    async fn get_cohort(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned> {
+        info!(id = %cohort_id,"Get cohort request received");
+
+        let braid_data = self.braid_arc.read().await;
+
+        if let Some(cohort) = braid_data.cohorts.get(cohort_id as usize) {
+            let cohort_hashes: Vec<String> = cohort
+                .0
+                .iter()
+                .map(|index| {
+                    braid_data.beads[*index]
+                        .block_header
+                        .block_hash()
+                        .to_string()
+                })
+                .collect();
+
+            serde_json::to_string(&cohort_hashes)
+                .map_err(|_| ErrorObjectOwned::owned(2, "Internal Error", None::<()>))
+        } else {
+            Err(ErrorObjectOwned::owned(
+                3,
+                "Cohort Not Found for given ID ",
+                None::<()>,
+            ))
+        }
+    }
+
+    async fn get_genesis(&self) -> Result<String, ErrorObjectOwned> {
+        info!("Get Genesis request received");
+
+        let braid_data = self.braid_arc.read().await;
+
+        if braid_data.genesis_beads.len() != 1 {
+            return Err(ErrorObjectOwned::owned(
+                5,
+                "Expected Exactly one genesis beads ",
+                None::<()>,
+            ));
+        }
+        let genesis_bead_index = braid_data.genesis_beads.iter().next().unwrap();
+        let genesis_bead = &braid_data.beads[*genesis_bead_index];
+
+        Ok(genesis_bead.block_header.block_hash().to_string())
+    }
+
+    async fn get_miner_info(&self) -> Result<Vec<String>, ErrorObjectOwned> {
+        info!("Get Miner Info Request Received");
+        let connection_map = self.stratum_connection_mapping.lock().await;
+        let miner_ips: Vec<String> = connection_map
+            .downstream_channel_mapping
+            .keys()
+            .cloned()
+            .collect();
+
+        Ok(miner_ips)
+    }
+
+    async fn get_mining_info(&self) -> Result<Value, ErrorObjectOwned> {
+        info!("Get Mining Info Request Recieved");
+
+        let our_peer_id = match self.peer_id {
+            Some(id) => id,
+            None => {
+                // If the node has no identity, it cannot have mined any beads.
+                let info = MiningInfo {
+                    our_beads_count: 0,
+                    total_beads_in_braid: 0,
+                    our_total_work: "0".to_string(),
+                    total_work_in_braid: "0".to_string(),
+                    our_work_share_percent: 0.0,
+                    payout_address: None,
+                };
+                return serde_json::to_value(&info).map_err(|e| {
+                    ErrorObjectOwned::owned(2, format!("Internal Error: {}", e), None::<()>)
+                });
+            }
+        };
+
+        let braid_data = self.braid_arc.read().await;
+        let all_beads = &braid_data.beads;
+
+        if all_beads.is_empty() {
+            let info = MiningInfo {
+                our_beads_count: 0,
+                total_beads_in_braid: 0,
+                our_total_work: "0".to_string(),
+                total_work_in_braid: "0".to_string(),
+                our_work_share_percent: 0.0,
+                payout_address: None,
+            };
+            return serde_json::to_value(&info).map_err(|e| {
+                ErrorObjectOwned::owned(2, format!("Internal Error: {}", e), None::<()>)
+            });
+        }
+
+        // Initialize Work to zero by subtracting a work value from itself
+        let first_work = all_beads[0].block_header.work();
+        let zero_work = first_work - first_work;
+
+        let mut our_beads_count = 0;
+        let mut our_total_work = zero_work;
+        let mut total_work_in_braid = zero_work;
+        let mut payout_address = None;
+
+        let our_peer_id_bytes = our_peer_id.to_bytes();
+
+        for bead in all_beads.iter() {
+            let work = bead.block_header.work();
+            total_work_in_braid = total_work_in_braid + work;
+
+            let bead_pub_key_bytes = bead.committed_metadata.comm_pub_key.to_bytes();
+
+            // Simple byte comparison - this may need refinement based on
+            // how keys are actually derived/stored in your system
+            if !bead_pub_key_bytes.is_empty()
+                && our_peer_id_bytes.len() >= bead_pub_key_bytes.len()
+                && our_peer_id_bytes[..bead_pub_key_bytes.len()] == bead_pub_key_bytes[..]
+            {
+                our_beads_count += 1;
+                our_total_work = our_total_work + work;
+                if payout_address.is_none() {
+                    payout_address = Some(bead.committed_metadata.payout_address.clone());
+                }
+            }
+        }
+
+        // Convert Work to f64 for percentage calculation
+        // Work implements ToString, so we parse it for calculation
+        let our_work_share_percent = if total_work_in_braid > zero_work {
+            let our_work_str = our_total_work.to_string();
+            let total_work_str = total_work_in_braid.to_string();
+            // Parse as f64 - Work values can be very large, so we use f64
+            // which may lose precision for extremely large values, but is acceptable for percentages
+            let our_work_f64 = our_work_str.parse::<f64>().unwrap_or(0.0);
+            let total_work_f64 = total_work_str.parse::<f64>().unwrap_or(1.0);
+            if total_work_f64 > 0.0 {
+                (our_work_f64 / total_work_f64) * 100.0
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+
+        let mining_info = MiningInfo {
+            our_beads_count,
+            total_beads_in_braid: all_beads.len(),
+            our_total_work: our_total_work.to_string(),
+            total_work_in_braid: total_work_in_braid.to_string(),
+            our_work_share_percent,
+            payout_address,
+        };
+
+        serde_json::to_value(&mining_info)
+            .map_err(|e| ErrorObjectOwned::owned(2, format!("Internal Error: {}", e), None::<()>))
+    }
+
+    async fn get_parents(&self, bead_hash: String) -> Result<String, ErrorObjectOwned> {
+        info!(bead = %bead_hash, "Get parent bead request received");
+
+        let hash = bead_hash
+            .parse::<BeadHash>()
+            .map_err(|_| ErrorObjectOwned::owned(1, "Invalid bead hash format", None::<()>))?;
+
+        let braid_data = self.braid_arc.read().await;
+
+        let bead = braid_data
+            .beads
+            .iter()
+            .find(|b| b.block_header.block_hash() == hash)
+            .cloned();
+
+        match bead {
+            Some(bead) => {
+                let parents: Vec<BeadHash> = bead.committed_metadata.parents.into_iter().collect();
+
+                serde_json::to_string(&parents)
+                    .map_err(|_| ErrorObjectOwned::owned(2, "Internal Error ", None::<()>))
+            }
+            None => Err(ErrorObjectOwned::owned(3, "Bead not found", None::<()>)),
+        }
+    }
+
+    async fn get_children(&self, bead_hash: String) -> Result<Vec<String>, ErrorObjectOwned> {
+        info!(bead = %bead_hash, "Get children bead request received");
+
+        let parent_hash = bead_hash
+            .parse::<BeadHash>()
+            .map_err(|_| ErrorObjectOwned::owned(1, "Invalid bead hash format", None::<()>))?;
+
+        let braid_data = self.braid_arc.read().await;
+
+        let parent_index = match braid_data.bead_index_mapping.get(&parent_hash) {
+            Some(index) => *index,
+            None => return Err(ErrorObjectOwned::owned(3, "Bead not found", None::<()>)),
+        };
+
+        let mut parents_map: HashMap<usize, HashSet<usize>> = HashMap::new();
+        for (index, bead) in braid_data.beads.iter().enumerate() {
+            let parent_indices: HashSet<usize> = bead
+                .committed_metadata
+                .parents
+                .iter()
+                .filter_map(|p_hash| braid_data.bead_index_mapping.get(p_hash).copied())
+                .collect();
+            parents_map.insert(index, parent_indices);
+        }
+
+        let children_map = consensus_functions::reverse(&braid_data, &parents_map);
+
+        let children_hashes: Vec<String> = match children_map.get(&parent_index) {
+            Some(child_indices) => child_indices
+                .iter()
+                .map(|&index| {
+                    braid_data.beads[index]
+                        .block_header
+                        .block_hash()
+                        .to_string()
+                })
+                .collect(),
+            None => Vec::new(), // This case is unlikely if the parent exists, but it's safe to handle.
+        };
+        Ok(children_hashes)
+    }
+
+    async fn get_hwpath(&self, limit: u8) -> Result<String, ErrorObjectOwned> {
+        info!(limit=%limit,"get_hwpath request received");
+
+        let braid_data = self.braid_arc.read().await;
+
+        let mut parents_map: HashMap<usize, HashSet<usize>> = HashMap::new();
+        for (index, bead) in braid_data.beads.iter().enumerate() {
+            let parent_indices: HashSet<usize> = bead
+                .committed_metadata
+                .parents
+                .iter()
+                .filter_map(|p_hash| braid_data.bead_index_mapping.get(p_hash).copied())
+                .collect();
+            parents_map.insert(index, parent_indices);
+        }
+
+        let children_map = consensus_functions::reverse(&braid_data, &parents_map);
+
+        let bead_list =
+            match highest_work_path(&braid_data, &parents_map, Some(&children_map), None) {
+                Ok(list) => list,
+                Err(_) => {
+                    return Err(ErrorObjectOwned::owned(
+                        5,
+                        "Failed to get highest_work path ",
+                        None::<()>,
+                    ))
+                }
+            };
+
+        let hw_path_hashes: Vec<String> = bead_list
+            .iter()
+            .take(limit as usize)
+            .map(|&index| {
+                braid_data.beads[index]
+                    .block_header
+                    .block_hash()
+                    .to_string()
+            })
+            .collect();
+
+        let json = serde_json::to_string(&hw_path_hashes)
+            .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error ", None::<()>))
+            .unwrap();
+
+        Ok(json)
+    }
+
+    async fn get_ipc_stats(&self) -> Result<String, ErrorObjectOwned> {
+        let (responder, receiver) = oneshot::channel();
+        let command = RpcProxyCommand::GetStats { responder };
+
+        if self.rpc_proxy_tx.send(command).is_err() {
+            return Err(ErrorObjectOwned::owned(
+                5,
+                "IPC proxy handler channel closed - IPC handler is not running",
+                None::<()>,
+            ));
+        }
+
+        match receiver.await {
+            Ok(Ok(stats)) => {
+                let stats_msg = format!(
+                   "IPC queue statistics : failed={} avg_ms={} critical={} high={} normal={} low={}",
+                   stats.failed_requests,
+                   stats.avg_processing_time_ms,
+                   stats.queue_sizes.critical,
+                   stats.queue_sizes.high,
+                   stats.queue_sizes.normal,
+                   stats.queue_sizes.low
+               );
+                info!("{}", stats_msg);
+                Ok(stats_msg)
+            }
+            Ok(Err(e)) => Err(ErrorObjectOwned::owned(
+                6,
+                &format!("IPC queue statistics request failed: {}", e),
+                None::<()>,
+            )),
+            Err(_) => Err(ErrorObjectOwned::owned(
+                5,
+                "IPC proxy handler channel closed - response receiver dropped",
+                None::<()>,
+            )),
+        }
+    }
+
+    async fn get_braid_info(&self) -> Result<Value, ErrorObjectOwned> {
+        let braid_data = self.braid_arc.read().await;
+
+        let tips: Vec<String> = braid_data
+            .tips
+            .iter()
+            .map(|&index| {
+                braid_data.beads[index]
+                    .block_header
+                    .block_hash()
+                    .to_string()
+            })
+            .collect();
+
+        let genesis_beads: Vec<String> = braid_data
+            .genesis_beads
+            .iter()
+            .map(|&index| {
+                braid_data.beads[index]
+                    .block_header
+                    .block_hash()
+                    .to_string()
+            })
+            .collect();
+
+        let total_work = if braid_data.beads.is_empty() {
+            "0".to_string()
+        } else {
+            let first_work = braid_data.beads[0].block_header.work();
+            let zero_work = first_work - first_work;
+            braid_data
+                .beads
+                .iter()
+                .fold(zero_work, |acc, bead| acc + bead.block_header.work())
+                .to_string()
+        };
+
+        let braid_info = BraidInfo {
+            bead_count: braid_data.beads.len(),
+            tip_count: braid_data.tips.len(),
+            tips,
+            cohort_count: braid_data.cohorts.len(),
+            orphan_count: braid_data.orphan_beads.len(),
+            genesis_beads,
+            total_work,
+        };
+
+        serde_json::to_value(&braid_info)
+            .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error", None::<()>))
+    }
+
+    async fn get_node_info(&self, node: String) -> Result<Value, ErrorObjectOwned> {
+        info!("Get Node Info request received");
+
+        let hash = node
+            .parse::<BeadHash>()
+            .map_err(|_| ErrorObjectOwned::owned(1, "Invalid bead hash format", None::<()>))?;
+
+        let braid_data = self.braid_arc.read().await;
+
+        let bead = braid_data
+            .beads
+            .iter()
+            .find(|bead| bead.block_header.block_hash() == hash)
+            .cloned()
+            .ok_or_else(|| ErrorObjectOwned::owned(3, "Bead not found", None::<()>))?;
+
+        let node_info = NodeInfo {
+            common_pubkey: bead.committed_metadata.comm_pub_key.to_string(),
+            miner_ip: bead.committed_metadata.miner_ip.clone(),
+            payout_address: bead.committed_metadata.payout_address.clone(),
+            minimum_target: bead
+                .committed_metadata
+                .min_target
+                .to_consensus()
+                .to_string(),
+        };
+
+        serde_json::to_value(&node_info)
+            .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error", None::<()>))
+    }
+
+    async fn get_peer_info(&self) -> Result<Value, ErrorObjectOwned> {
+        info!("Get Peer Info Request Received");
+
+        // Use read lock for concurrent access (RPC server only reads)
+        let peer_manager_guard = self.peer_manager.read().await;
+        Ok(peer_manager_guard.get_peers_json())
+    }
+
+    /// Give the list of transactions staged for the next bead we mine.
+    /// This is achieved by querying the latest block template managed by the Stratum server,
+    /// excluding the coinbase transaction.
+    async fn staged_transactions(&self) -> Result<Value, ErrorObjectOwned> {
+        info!("Staged transaction request received");
+
+        let latest_block_template_guard = self.latest_block.lock().await;
+
+        // The `transactions` in the block template include the coinbase transaction at index 0.
+        // "Staged transactions" for mining should only include the non-coinbase transactions.
+        let staged_txs = if latest_block_template_guard.transactions.len() > 1 {
+            latest_block_template_guard.transactions[1..].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        serde_json::to_value(&staged_txs).map_err(|e| {
+            ErrorObjectOwned::owned(
+                2,
+                format!("Internal Error: Failed to serialize transactions: {}", e),
+                None::<()>,
+            )
+        })
+    }
+
+    async fn unstage_transactions(&self, txid: String) -> Result<String, ErrorObjectOwned> {
+        info!(txid = %txid, "unstage_transactions request received");
+        let (responder, receiver) = oneshot::channel();
+        let command = RpcProxyCommand::RemoveTransaction { txid, responder };
+
+        if self.rpc_proxy_tx.send(command).is_err() {
+            return Err(ErrorObjectOwned::owned(
+                5,
+                "IPC proxy handler channel closed - IPC handler is not running",
+                None::<()>,
+            ));
+        }
+
+        match receiver.await {
+            Ok(Ok(was_removed)) => Ok(was_removed.to_string()),
+            Ok(Err(e)) => Err(ErrorObjectOwned::owned(
+                6,
+                &format!("Transaction removal failed: {}", e),
+                None::<()>,
+            )),
+            Err(_) => Err(ErrorObjectOwned::owned(
+                5,
+                "IPC proxy handler channel closed - response receiver dropped",
+                None::<()>,
+            )),
+        }
+    }
+
+    async fn bitcoin_proxy(
+        &self,
+        method: String,
+        params: serde_json::Value,
+    ) -> Result<serde_json::Value, ErrorObjectOwned> {
+        info!(method = %method, "bitcoin_proxy request received");
+
+        let rpc_config = self.bitcoin_rpc_config.as_ref().ok_or_else(|| {
+            ErrorObjectOwned::owned(
+                5,
+                "Bitcoin RPC proxy not configured. Please provide RPC credentials (--rpcuser/--rpcpass)",
+                None::<()>,
+            )
+        })?;
+
+        match call_bitcoin_rpc_direct(rpc_config, &method, &params).await {
+            Ok(result) => {
+                info!(method = %method, "bitcoin_proxy request completed successfully");
+                Ok(result)
+            }
+            Err(e) => {
+                warn!(method = %method, error = %e, "bitcoin_proxy request failed");
+                Err(ErrorObjectOwned::owned(
+                    6,
+                    &format!("Bitcoin RPC error: {}", e),
+                    None::<()>,
+                ))
+            }
+        }
     }
 }
 struct LoggingMiddleware<S>(S);
@@ -279,6 +816,12 @@ where
 pub async fn run_rpc_server(
     braid_shared_pointer: Arc<RwLock<Braid>>,
     bind_address: &str,
+    peer_id: Option<PeerId>,
+    peer_manager: Arc<tokio::sync::RwLock<PeerManager>>,
+    stratum_connection_mapping: Arc<Mutex<stratum::ConnectionMapping>>,
+    latest_block_template: Arc<Mutex<BlockTemplate>>,
+    rpc_proxy_tx: mpsc::UnboundedSender<RpcProxyCommand>,
+    bitcoin_rpc_config: Option<BitcoinRpcConfig>,
 ) -> Result<SocketAddr, ()> {
     //Initializing the middleware
     let rpc_middleware =
@@ -292,7 +835,15 @@ pub async fn run_rpc_server(
     //listening address for incoming requests/connection
     let addr = server.local_addr().unwrap();
     //context for the served server
-    let rpc_impl = RpcServerImpl::new(braid_shared_pointer);
+    let rpc_impl = RpcServerImpl::new(
+        braid_shared_pointer,
+        peer_id,
+        peer_manager,
+        stratum_connection_mapping,
+        latest_block_template,
+        rpc_proxy_tx,
+        bitcoin_rpc_config.clone(),
+    );
     let handle = server.start(rpc_impl.into_rpc());
 
     // Parse host from bind_address
@@ -317,17 +868,98 @@ pub async fn run_rpc_server(
     Ok(addr)
 }
 
+/// Call Bitcoin RPC method directly using HTTP JSON-RPC
+async fn call_bitcoin_rpc_direct(
+    config: &BitcoinRpcConfig,
+    method: &str,
+    params: &serde_json::Value,
+) -> Result<serde_json::Value, Box<dyn std::error::Error>> {
+    let url = config.rpc_url();
+    let request = JsonRpcRequest {
+        jsonrpc: "2.0",
+        method: method.to_string(),
+        params: params.clone(),
+        id: 1,
+    };
+
+    // Build HTTP client with timeout
+    let client = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(30))
+        .build()
+        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
+    let mut request_builder = client.post(&url).json(&request);
+
+    // Add authentication using username/password
+    if !config.username.is_empty() {
+        request_builder = request_builder.basic_auth(
+            &config.username,
+            if config.password.is_empty() {
+                None
+            } else {
+                Some(&config.password)
+            },
+        );
+    }
+
+    let response = request_builder
+        .send()
+        .await
+        .map_err(|e| format!("HTTP request failed: {}", e))?;
+
+    if !response.status().is_success() {
+        let status = response.status();
+        let text = response
+            .text()
+            .await
+            .unwrap_or_else(|_| "Could not read error body".to_string());
+        return Err(format!("HTTP error {}: {}", status, text).into());
+    }
+
+    let rpc_response: JsonRpcResponse = response
+        .json()
+        .await
+        .map_err(|e| format!("Failed to parse JSON response: {}", e))?;
+
+    if let Some(error) = rpc_response.error {
+        return Err(format!(
+            "Bitcoin RPC error: {}",
+            serde_json::to_string(&error).unwrap_or_else(|_| "Unknown error".to_string())
+        )
+        .into());
+    }
+
+    rpc_response
+        .result
+        .ok_or_else(|| "RPC response missing result field".into())
+}
+
 #[tokio::test]
 pub async fn test_extend_rpc() {
     let test_bead1 = create_test_bead(1, None);
     let genesis_beads = vec![test_bead1.clone()];
 
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    let (proxy_tx, _) = mpsc::unbounded_channel();
 
-    let server_addr = "127.0.0.1:6682";
-    let _ = run_rpc_server(Arc::clone(&braid), server_addr)
-        .await
-        .unwrap();
+    let server_addr = "127.0.0.1:9101";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        // Provide a dummy ConnectionMapping for the test
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Give server time to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
@@ -357,7 +989,6 @@ pub async fn test_same_bead_extend() {
     let genesis_beads = vec![test_bead1.clone()];
 
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
-
     //Initializing the test server
     let rpc_middleware =
         jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
@@ -366,7 +997,18 @@ pub async fn test_same_bead_extend() {
         .build("127.0.0.1:8889")
         .await
         .unwrap();
-    let rpc_impl = RpcServerImpl::new(braid);
+    let rpc_impl = RpcServerImpl::new(
+        braid,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            tx
+        },
+        None, // No Bitcoin RPC config for tests
+    );
     let _handle = server.start(rpc_impl.into_rpc());
 
     let server_addr = "127.0.0.1:8889";
@@ -402,6 +1044,7 @@ pub async fn test_cohort_count_rpc() {
     let genesis_beads = vec![test_bead_1.clone()];
 
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
     //Initializing the test server
     let rpc_middleware =
         jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
@@ -410,7 +1053,18 @@ pub async fn test_cohort_count_rpc() {
         .build("127.0.0.1:9000")
         .await
         .unwrap();
-    let rpc_impl = RpcServerImpl::new(braid);
+    let rpc_impl = RpcServerImpl::new(
+        braid,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            tx
+        },
+        None, // No Bitcoin RPC config for tests
+    );
     let _handle = server.start(rpc_impl.into_rpc());
 
     let server_addr = "127.0.0.1:9000";
@@ -456,4 +1110,852 @@ pub async fn test_cohort_count_rpc() {
         client.request("getcohortcount", ArrayParams::new()).await;
 
     assert_eq!(response_cohort_cnt.unwrap(), "4".to_string());
+}
+
+#[tokio::test]
+pub async fn test_get_bead_count_cli_flow() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    // Start RPC server
+    let server_addr = "127.0.0.1:9100"; // Different port to avoid conflicts
+    let _server_addr = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None, // peer_id can be None for this test
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            tx
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Give server time to start
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    // Test: Make HTTP request like CLI would
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let params = ArrayParams::new();
+    let num_beads: Result<String, jsonrpsee::core::ClientError> =
+        client.request("getbeadcount", params).await;
+
+    assert!(num_beads.is_ok());
+    assert_eq!(num_beads.unwrap(), "1"); // We have 1 genesis bead
+}
+
+#[tokio::test]
+pub async fn test_get_tips_cli_flow() {
+    let test_bead1 = create_test_bead(1, None);
+    let test_bead2 = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let genesis_beads = vec![test_bead1.clone()];
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    // Add second bead
+    {
+        let mut braid_guard = braid.write().await;
+        braid_guard.extend(&test_bead2);
+    }
+
+    // Start RPC server
+    let server_addr = "127.0.0.1:6684";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        {
+            let (tx, _rx) = mpsc::unbounded_channel();
+            tx
+        },
+        None,
+    )
+    .await
+    .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+
+    // Test gettips command
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let params = ArrayParams::new();
+    let tips: Result<Vec<String>, jsonrpsee::core::ClientError> =
+        client.request("gettips", params).await;
+
+    assert!(tips.is_ok());
+    let tips_vec = tips.unwrap();
+    assert_eq!(tips_vec.len(), 1); // Should have 1 tip (test_bead2)
+    assert_eq!(
+        tips_vec[0],
+        test_bead2.block_header.block_hash().to_string()
+    );
+}
+
+#[tokio::test]
+pub async fn test_get_bead_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9001";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    // Test getbead for existing bead
+    let bead_hash = test_bead1.block_header.block_hash().to_string();
+    let mut params = ArrayParams::new();
+    params.insert(bead_hash.clone()).unwrap();
+
+    let response: Result<Bead, jsonrpsee::core::ClientError> =
+        client.request("getbead", params).await;
+
+    assert!(response.is_ok());
+    let fetched_bead = response.unwrap();
+    assert_eq!(
+        fetched_bead.block_header.block_hash().to_string(),
+        bead_hash
+    );
+
+    // Test getbead for non-existing bead
+    let non_existent_hash =
+        "0000000000000000000000000000000000000000000000000000000000000001".to_string();
+    let mut params = ArrayParams::new();
+    params.insert(non_existent_hash).unwrap();
+    let response: Result<Bead, jsonrpsee::core::ClientError> =
+        client.request("getbead", params).await;
+
+    assert!(response.is_err());
+    if let jsonrpsee::core::ClientError::Call(error) = response.unwrap_err() {
+        assert_eq!(error.code(), 3);
+        assert_eq!(error.message(), "Bead not found");
+    } else {
+        panic!("Expected a Call error");
+    }
+}
+
+#[tokio::test]
+pub async fn test_get_cohort_rpc() {
+    let test_bead_1 = create_test_bead(1, None); // cohort 0
+    let test_bead_2 = create_test_bead(2, Some(test_bead_1.block_header.block_hash())); // cohort 1
+    let genesis_beads = vec![test_bead_1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    {
+        let mut braid_guard = braid.write().await;
+        braid_guard.extend(&test_bead_2);
+    }
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9002";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    // Test getcohort for existing cohort
+    let mut params = ArrayParams::new();
+    params.insert(1 as u64).unwrap(); // Get cohort 1
+    let response: Result<String, jsonrpsee::core::ClientError> =
+        client.request("getcohort", params).await;
+
+    assert!(response.is_ok());
+    let cohort_hashes: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
+    assert_eq!(cohort_hashes.len(), 1);
+    assert_eq!(
+        cohort_hashes[0],
+        test_bead_2.block_header.block_hash().to_string()
+    );
+
+    // Test getcohort for non-existing cohort
+    let mut params = ArrayParams::new();
+    params.insert(99 as u64).unwrap();
+    let response: Result<String, jsonrpsee::core::ClientError> =
+        client.request("getcohort", params).await;
+
+    assert!(response.is_err());
+    if let jsonrpsee::core::ClientError::Call(error) = response.unwrap_err() {
+        assert_eq!(error.code(), 3);
+        assert_eq!(error.message(), "Cohort Not Found for given ID ");
+    } else {
+        panic!("Expected a Call error");
+    }
+}
+
+#[tokio::test]
+pub async fn test_get_genesis_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9003";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let response: Result<String, jsonrpsee::core::ClientError> =
+        client.request("getgenesis", ArrayParams::new()).await;
+
+    assert!(response.is_ok());
+    let genesis_hash = response.unwrap();
+    assert_eq!(
+        genesis_hash,
+        test_bead1.block_header.block_hash().to_string()
+    );
+}
+
+#[tokio::test]
+pub async fn test_get_parents_and_children_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let test_bead2 = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    {
+        let mut braid_guard = braid.write().await;
+        braid_guard.extend(&test_bead2);
+    }
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9004";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    // Test getparents for bead2
+    let bead2_hash = test_bead2.block_header.block_hash().to_string();
+    let mut params = ArrayParams::new();
+    params.insert(bead2_hash.clone()).unwrap();
+    let response: Result<String, jsonrpsee::core::ClientError> =
+        client.request("getparents", params).await;
+
+    assert!(response.is_ok());
+    let parent_hashes: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
+    assert_eq!(parent_hashes.len(), 1);
+    assert_eq!(
+        parent_hashes[0],
+        test_bead1.block_header.block_hash().to_string()
+    );
+
+    // Test getchildren for bead1
+    let bead1_hash = test_bead1.block_header.block_hash().to_string();
+    let mut params = ArrayParams::new();
+    params.insert(bead1_hash).unwrap();
+    let response: Result<Vec<String>, jsonrpsee::core::ClientError> =
+        client.request("getchildren", params).await;
+
+    assert!(response.is_ok());
+    let children_hashes = response.unwrap();
+    assert_eq!(children_hashes.len(), 1);
+    assert_eq!(children_hashes[0], bead2_hash);
+
+    // Test getchildren for bead2 (should have no children)
+    let mut params = ArrayParams::new();
+    params.insert(bead2_hash).unwrap();
+    let response: Result<Vec<String>, jsonrpsee::core::ClientError> =
+        client.request("getchildren", params).await;
+
+    assert!(response.is_ok());
+    let children_hashes = response.unwrap();
+    assert!(children_hashes.is_empty());
+}
+
+#[tokio::test]
+pub async fn test_get_hwpath_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let test_bead2 = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let test_bead3 = create_test_bead(3, Some(test_bead2.block_header.block_hash()));
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    {
+        let mut braid_guard = braid.write().await;
+        braid_guard.extend(&test_bead2);
+        braid_guard.extend(&test_bead3);
+    }
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9005";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let mut params = ArrayParams::new();
+    params.insert(10 as u8).unwrap();
+    let response: Result<String, jsonrpsee::core::ClientError> =
+        client.request("gethwpath", params).await;
+
+    assert!(response.is_ok());
+    let hw_path: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
+
+    // Path should be bead3 -> bead2 -> bead1
+    assert_eq!(hw_path.len(), 3);
+    assert_eq!(hw_path[0], test_bead1.block_header.block_hash().to_string());
+    assert_eq!(hw_path[1], test_bead2.block_header.block_hash().to_string());
+    assert_eq!(hw_path[2], test_bead3.block_header.block_hash().to_string());
+
+    // Test with limit
+    let mut params = ArrayParams::new();
+    params.insert(2 as u8).unwrap();
+    let response: Result<String, jsonrpsee::core::ClientError> =
+        client.request("gethwpath", params).await;
+
+    assert!(response.is_ok());
+    let hw_path: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
+
+    assert_eq!(hw_path.len(), 2);
+    assert_eq!(hw_path[0], test_bead1.block_header.block_hash().to_string());
+    assert_eq!(hw_path[1], test_bead2.block_header.block_hash().to_string());
+}
+
+#[tokio::test]
+pub async fn test_get_braid_info_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9006";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let response: Result<Value, jsonrpsee::core::ClientError> =
+        client.request("getbraidinfo", ArrayParams::new()).await;
+
+    assert!(response.is_ok());
+    let braid_info: BraidInfo = serde_json::from_value(response.unwrap()).unwrap();
+
+    // Check some fields
+    assert_eq!(braid_info.bead_count, 1);
+    assert_eq!(braid_info.tip_count, 1);
+    assert_eq!(
+        braid_info.tips[0],
+        test_bead1.block_header.block_hash().to_string()
+    );
+}
+
+#[tokio::test]
+pub async fn test_get_node_info_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9007";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let bead_hash = test_bead1.block_header.block_hash().to_string();
+    let mut params = ArrayParams::new();
+    params.insert(bead_hash).unwrap();
+
+    let response: Result<Value, jsonrpsee::core::ClientError> =
+        client.request("getnodeinfo", params).await;
+
+    assert!(response.is_ok());
+    let node_info: NodeInfo = serde_json::from_value(response.unwrap()).unwrap();
+
+    assert_eq!(
+        node_info.common_pubkey,
+        test_bead1.committed_metadata.comm_pub_key.to_string()
+    );
+    assert_eq!(
+        node_info.payout_address,
+        test_bead1.committed_metadata.payout_address
+    );
+}
+
+#[tokio::test]
+pub async fn test_get_peer_info_rpc() {
+    use libp2p::identity::Keypair;
+    use std::net::{IpAddr, Ipv4Addr};
+    use std::time::Duration;
+
+    // Helper to generate a peer id (testing purpose only )
+    fn generate_peer_id() -> PeerId {
+        let keypair = Keypair::generate_ed25519();
+        PeerId::from(keypair.public())
+    }
+
+    let braid: Arc<RwLock<braid::Braid>> =
+        Arc::new(RwLock::new(braid::Braid::new(vec![create_test_bead(
+            1, None,
+        )])));
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    // --- 1. Test with no peers ---
+    let peer_manager_empty = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
+    let server_addr_empty = "127.0.0.1:9008";
+    let server_empty = jsonrpsee::server::Server::builder()
+        .build(server_addr_empty)
+        .await
+        .unwrap();
+    let rpc_impl_empty = RpcServerImpl::new(
+        Arc::clone(&braid),
+        None,
+        peer_manager_empty,
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx.clone(),
+        None,
+    );
+    let handle_empty = server_empty.start(rpc_impl_empty.into_rpc());
+
+    let client_empty: HttpClient = HttpClient::builder()
+        .build(format!("http://{}", server_addr_empty))
+        .unwrap();
+
+    let response_empty: Result<Value, _> = client_empty
+        .request("getpeerinfo", ArrayParams::new())
+        .await;
+    handle_empty.stop().unwrap(); // Stop the server
+
+    assert!(response_empty.is_ok());
+    let response_value_empty = response_empty.unwrap();
+    println!(
+        "\n--- Response with 0 peers ---\n{}\n---------------------------\n",
+        serde_json::to_string_pretty(&response_value_empty).unwrap()
+    );
+    assert_eq!(response_value_empty["connected"], 0);
+
+    // --- 2. Test with one peer ---
+    let mut peer_manager_with_peers = PeerManager::new(8);
+    let peer_id = generate_peer_id();
+    let peer_id_str = peer_id.to_base58();
+    let peer_ip = IpAddr::V4(Ipv4Addr::new(192, 168, 1, 5));
+    peer_manager_with_peers.add_peer(peer_id, false, Some(peer_ip));
+    peer_manager_with_peers.update_latency(&peer_id, Duration::from_millis(75));
+    peer_manager_with_peers.update_score(&peer_id, 25.0);
+
+    let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(peer_manager_with_peers));
+    let server_addr_with_peers = "127.0.0.1:9018"; // Use a different port
+    let server_with_peers = jsonrpsee::server::Server::builder()
+        .build(server_addr_with_peers)
+        .await
+        .unwrap();
+    let rpc_impl_with_peers = RpcServerImpl::new(
+        Arc::clone(&braid),
+        None,
+        peer_manager_arc,
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    );
+    let handle_with_peers = server_with_peers.start(rpc_impl_with_peers.into_rpc());
+
+    let client_with_peers: HttpClient = HttpClient::builder()
+        .build(format!("http://{}", server_addr_with_peers))
+        .unwrap();
+
+    let response_with_peers: Result<Value, _> = client_with_peers
+        .request("getpeerinfo", ArrayParams::new())
+        .await;
+    handle_with_peers.stop().unwrap(); // Stop the server
+
+    assert!(response_with_peers.is_ok());
+    let response_value_with_peers = response_with_peers.unwrap();
+    println!(
+        "--- Response with 1 peer ---\n{}\n--------------------------\n",
+        serde_json::to_string_pretty(&response_value_with_peers).unwrap()
+    );
+
+    // Assert that the output contains the peer's info
+    assert_eq!(response_value_with_peers["connected"], 1);
+    let peers_array = response_value_with_peers["peers"].as_array().unwrap();
+    assert_eq!(peers_array.len(), 1);
+    assert_eq!(peers_array[0]["peer_id"], peer_id_str);
+    assert_eq!(peers_array[0]["ip"], "192.168.1.5");
+    assert_eq!(peers_array[0]["latency_ms"], 75.0);
+    assert!(peers_array[0]["score"].as_f64().unwrap() > 0.0);
+}
+
+#[tokio::test]
+pub async fn test_get_miner_info_rpc() {
+    let braid: Arc<RwLock<braid::Braid>> =
+        Arc::new(RwLock::new(braid::Braid::new(vec![create_test_bead(
+            1, None,
+        )])));
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let stratum_map = Arc::new(Mutex::new(stratum::ConnectionMapping::new()));
+    {
+        let mut map = stratum_map.lock().await;
+        let (tx, _) = mpsc::channel(1);
+        map.downstream_channel_mapping.insert(
+            "1.2.3.4:5678".to_string(),
+            stratum::ConnectionInfo {
+                connection_id: 0,
+                sender: tx,
+            },
+        );
+    }
+
+    let server_addr = "127.0.0.1:9009";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        stratum_map,
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let response: Result<Vec<String>, jsonrpsee::core::ClientError> =
+        client.request("getminerinfo", ArrayParams::new()).await;
+
+    assert!(response.is_ok());
+    let miner_ips = response.unwrap();
+    assert_eq!(miner_ips, vec!["1.2.3.4:5678".to_string()]);
+}
+
+#[tokio::test]
+pub async fn test_staged_transactions_rpc() {
+    use bitcoin::consensus::deserialize;
+
+    let braid: Arc<RwLock<braid::Braid>> =
+        Arc::new(RwLock::new(braid::Braid::new(vec![create_test_bead(
+            1, None,
+        )])));
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+    let latest_block = Arc::new(Mutex::new(stratum::BlockTemplate::default()));
+
+    let server_addr = "127.0.0.1:9013";
+    let server = jsonrpsee::server::Server::builder()
+        .build(server_addr)
+        .await
+        .unwrap();
+    let rpc_impl = RpcServerImpl::new(
+        braid,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::clone(&latest_block),
+        proxy_tx,
+        None,
+    );
+    let handle = server.start(rpc_impl.into_rpc());
+
+    let client: HttpClient = HttpClient::builder()
+        .build(format!("http://{}", server_addr))
+        .unwrap();
+
+    // 1. Test with an empty block template
+    let response_empty: Result<Value, _> = client
+        .request("stagedtransactions", ArrayParams::new())
+        .await;
+
+    assert!(response_empty.is_ok());
+    let returned_txs_empty: Vec<Transaction> =
+        serde_json::from_value(response_empty.unwrap()).unwrap();
+    assert!(returned_txs_empty.is_empty());
+
+    // 2. Test with only a coinbase transaction
+    let coinbase_tx_hex = "01000000010000000000000000000000000000000000000000000000000000000000000000ffffffff0704ffff001d0104ffffffff0100f2052a01000000434104678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb649f6bc3f4cef38c4f35504e51ec112de5c384df7ba0b8d578a4c702b6bf11d5fac00000000";
+    let coinbase_tx: Transaction = deserialize(&hex::decode(coinbase_tx_hex).unwrap()).unwrap();
+
+    {
+        let mut block_template = latest_block.lock().await;
+        block_template.transactions = vec![coinbase_tx.clone()];
+    }
+
+    let response_coinbase_only: Result<Value, _> = client
+        .request("stagedtransactions", ArrayParams::new())
+        .await;
+
+    assert!(response_coinbase_only.is_ok());
+    let returned_txs_coinbase_only: Vec<Transaction> =
+        serde_json::from_value(response_coinbase_only.unwrap()).unwrap();
+    assert!(
+        returned_txs_coinbase_only.is_empty(),
+        "Should return empty list when only coinbase tx is present"
+    );
+
+    // 3. Test with coinbase and a regular transaction
+    let regular_tx_hex = "0100000001c997a5e56e104102fa209c6a852dd90660a20b2d9c352423edce25857fcd3704000000004847304402204e45e16932b8af514961a1d3a1a25fdf3f4f7732e9d624c6c61548ab5fb8cd410220181522ec8eca07de4860a4acdd12909d831cc56cbbac4622082221a8768d1d0901ffffffff0200ca9a3b000000001976a914e04a251c1cde050eb41328b0f8395020120150b388ac80969800000000001976a914480252b4ac4038bed9588663a43f885e5884483788ac00000000";
+    let regular_tx: Transaction = deserialize(&hex::decode(regular_tx_hex).unwrap()).unwrap();
+
+    {
+        let mut block_template = latest_block.lock().await;
+        block_template.transactions = vec![coinbase_tx.clone(), regular_tx.clone()];
+    }
+
+    let response_with_tx: Result<Value, _> = client
+        .request("stagedtransactions", ArrayParams::new())
+        .await;
+
+    assert!(response_with_tx.is_ok());
+    let returned_txs: Vec<Transaction> = serde_json::from_value(response_with_tx.unwrap()).unwrap();
+
+    assert_eq!(
+        returned_txs.len(),
+        1,
+        "Should return one regular transaction"
+    );
+    assert_eq!(
+        returned_txs[0].compute_txid(),
+        regular_tx.compute_txid(),
+        "Returned txid should match the regular mock txid"
+    );
+
+    handle.stop().unwrap();
+}
+
+#[tokio::test]
+pub async fn test_get_ipc_stats_rpc() {
+    let braid: Arc<RwLock<braid::Braid>> =
+        Arc::new(RwLock::new(braid::Braid::new(vec![create_test_bead(
+            1, None,
+        )])));
+    let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9012";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let request_future = client.request("getipcstats", ArrayParams::new());
+
+    let (response, _) = tokio::join!(request_future, async {
+        if let Some(RpcProxyCommand::GetStats { responder }) = proxy_rx.recv().await {
+            let stats = QueueStats {
+                failed_requests: 1,
+                pending_requests: 0,
+                avg_processing_time_ms: 123,
+                queue_sizes: crate::ipc::client::QueueSizeStats {
+                    critical: 1,
+                    high: 2,
+                    normal: 3,
+                    low: 4,
+                },
+            };
+            responder.send(Ok(stats)).unwrap();
+        }
+    });
+
+    assert!(response.is_ok());
+    let stats_msg: String = response.unwrap();
+    assert_eq!(
+        stats_msg,
+        "IPC queue statistics : failed=1 avg_ms=123 critical=1 high=2 normal=3 low=4"
+    );
+}
+
+#[tokio::test]
+pub async fn test_get_ipc_stats_rpc_simple() {
+    let braid: Arc<RwLock<braid::Braid>> =
+        Arc::new(RwLock::new(braid::Braid::new(vec![create_test_bead(
+            1, None,
+        )])));
+    let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9020";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let request_future = client.request("getipcstats", ArrayParams::new());
+
+    let (response, _) = tokio::join!(request_future, async {
+        if let Some(RpcProxyCommand::GetStats { responder }) = proxy_rx.recv().await {
+            let stats = QueueStats {
+                failed_requests: 0,
+                pending_requests: 0,
+                avg_processing_time_ms: 50,
+                queue_sizes: crate::ipc::client::QueueSizeStats {
+                    critical: 0,
+                    high: 1,
+                    normal: 2,
+                    low: 3,
+                },
+            };
+            responder.send(Ok(stats)).unwrap();
+        }
+    });
+
+    assert!(response.is_ok());
+    let stats_msg: String = response.unwrap();
+    assert!(stats_msg.contains("IPC queue statistics"));
+    assert!(stats_msg.contains("failed=0"));
+    assert!(stats_msg.contains("avg_ms=50"));
+}
+
+#[tokio::test]
+pub async fn test_unstage_transactions_rpc_simple() {
+    let braid: Arc<RwLock<braid::Braid>> =
+        Arc::new(RwLock::new(braid::Braid::new(vec![create_test_bead(
+            1, None,
+        )])));
+    let (proxy_tx, mut proxy_rx) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9021";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        None,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let test_txid = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+    let mut params = ArrayParams::new();
+    params.insert(test_txid.to_string()).unwrap();
+
+    let request_future: futures::future::BoxFuture<
+        '_,
+        Result<String, jsonrpsee::core::ClientError>,
+    > = Box::pin(client.request("unstagetransactions", params));
+
+    let (response, _) = tokio::join!(request_future, async {
+        if let Some(RpcProxyCommand::RemoveTransaction { txid, responder }) = proxy_rx.recv().await
+        {
+            assert_eq!(txid, test_txid);
+            responder.send(Ok(true)).unwrap();
+        }
+    });
+
+    assert!(response.is_ok());
+    assert_eq!(response.unwrap(), "true");
 }

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -18,7 +18,6 @@ use jsonrpsee::proc_macros::rpc;
 use jsonrpsee::types::ErrorObjectOwned;
 use jsonrpsee::types::Request;
 use jsonrpsee::ConnectionId;
-use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use serde_json;
 use serde_json::Value;
@@ -56,16 +55,19 @@ pub trait Rpc {
     async fn get_bead_count(&self) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "getcohortcount")]
-    async fn get_cohort_count(&self) -> Result<String, ErrorObjectOwned>;
+    async fn get_cohort_count(&self) -> Result<u64, ErrorObjectOwned>;
 
-    #[method(name = "getcohort")]
-    async fn get_cohort(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned>;
+    #[method(name = "getcohortbyid")]
+    async fn get_cohort_by_id(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "getgenesis")]
     async fn get_genesis(&self) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "getmininginfo")]
-    async fn get_mining_info(&self) -> Result<Value, ErrorObjectOwned>;
+    async fn get_mining_info(
+        &self,
+        params: Option<serde_json::Value>,
+    ) -> Result<Value, ErrorObjectOwned>;
 
     #[method(name = "getminerinfo")]
     async fn get_miner_info(&self) -> Result<Vec<String>, ErrorObjectOwned>;
@@ -76,8 +78,8 @@ pub trait Rpc {
     #[method(name = "getchildren")]
     async fn get_children(&self, bead_hash: String) -> Result<Vec<String>, ErrorObjectOwned>;
 
-    #[method(name = "gethwpath")]
-    async fn get_hwpath(&self, limit: u8) -> Result<String, ErrorObjectOwned>;
+    #[method(name = "gethighestworkpathbycount")]
+    async fn get_highest_work_path_by_count(&self, limit: u8) -> Result<String, ErrorObjectOwned>;
 
     #[method(name = "getipcstats")]
     async fn get_ipc_stats(&self) -> Result<String, ErrorObjectOwned>;
@@ -86,7 +88,7 @@ pub trait Rpc {
     async fn get_braid_info(&self) -> Result<Value, ErrorObjectOwned>;
 
     #[method(name = "getnodeinfo")]
-    async fn get_node_info(&self, node: String) -> Result<Value, ErrorObjectOwned>;
+    async fn get_node_info(&self, bead_hash: String) -> Result<Value, ErrorObjectOwned>;
 
     #[method(name = "getpeerinfo")]
     async fn get_peer_info(&self) -> Result<Value, ErrorObjectOwned>;
@@ -105,6 +107,15 @@ pub trait Rpc {
     ) -> Result<serde_json::Value, ErrorObjectOwned>;
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct MiningInfoParams {
+    #[serde(default)]
+    pub public_keys: Option<Vec<String>>,
+
+    #[serde(default)]
+    pub miner_ips: Option<Vec<String>>,
+}
+
 #[derive(Serialize)]
 struct MiningInfo {
     our_beads_count: usize,
@@ -113,6 +124,8 @@ struct MiningInfo {
     total_work_in_braid: String,
     our_work_share_percent: f64,
     payout_address: Option<String>,
+    /// Additional info about which criteria were used for filtering
+    filter_info: Option<String>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -161,18 +174,39 @@ pub struct BitcoinRpcConfig {
 
 impl BitcoinRpcConfig {
     /// Create RPC config from CLI arguments
-    pub fn from_cli_args(args: &crate::cli::Cli) -> Option<Self> {
-        // If no RPC credentials provided, return None (RPC proxy disabled)
-        if args.rpcuser.is_empty() {
-            return None;
+    pub fn from_cli_args(args: &crate::cli::Cli) -> Result<Option<Self>, String> {
+        // If no RPC credentials provided, return Ok(None) (RPC proxy disabled)
+        let username = match &args.rpcuser {
+            None => return Ok(None),
+            Some(u) => u,
+        };
+
+        let password = match &args.rpcpass {
+            None => return Ok(None),
+            Some(p) => p,
+        };
+
+        // Validate that credentials are not empty
+        if username.is_empty() {
+            return Err(
+                "RPC username cannot be empty. Please provide a valid username with --rpcuser"
+                    .to_string(),
+            );
         }
 
-        Some(Self {
+        if password.is_empty() {
+            return Err(
+                "RPC password cannot be empty. Please provide a valid password with --rpcpass"
+                    .to_string(),
+            );
+        }
+
+        Ok(Some(Self {
             host: args.bitcoin.clone(),
             port: args.rpcport,
-            username: args.rpcuser.clone(),
-            password: args.rpcpass.clone(),
-        })
+            username: username.clone(),
+            password: password.clone(),
+        }))
     }
 
     /// Build RPC URL for bitcoincore-rpc client
@@ -194,7 +228,6 @@ pub enum RpcProxyCommand {
 // RPC Server implementation using channels
 pub struct RpcServerImpl {
     braid_arc: Arc<RwLock<Braid>>,
-    peer_id: Option<PeerId>,
     peer_manager: Arc<tokio::sync::RwLock<PeerManager>>,
     stratum_connection_mapping: Arc<Mutex<stratum::ConnectionMapping>>,
     latest_block: Arc<Mutex<BlockTemplate>>,
@@ -205,7 +238,6 @@ pub struct RpcServerImpl {
 impl RpcServerImpl {
     pub fn new(
         braid_shared_pointer: Arc<RwLock<Braid>>,
-        peer_id: Option<PeerId>,
         peer_manager: Arc<tokio::sync::RwLock<PeerManager>>,
         stratum_connection_mapping: Arc<Mutex<stratum::ConnectionMapping>>,
         latest_block_template: Arc<Mutex<BlockTemplate>>,
@@ -214,7 +246,6 @@ impl RpcServerImpl {
     ) -> Self {
         Self {
             braid_arc: braid_shared_pointer,
-            peer_id,
             peer_manager,
             stratum_connection_mapping,
             latest_block: latest_block_template,
@@ -283,16 +314,16 @@ impl RpcServer for RpcServerImpl {
         Ok(count.to_string())
     }
 
-    async fn get_cohort_count(&self) -> Result<String, ErrorObjectOwned> {
+    async fn get_cohort_count(&self) -> Result<u64, ErrorObjectOwned> {
         let braid_data = self.braid_arc.read().await;
         let count = braid_data.cohorts.len();
         info!(count = %count, "Get cohort count request received");
 
-        Ok(count.to_string())
+        Ok(count as u64)
     }
 
-    async fn get_cohort(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned> {
-        info!(id = %cohort_id,"Get cohort request received");
+    async fn get_cohort_by_id(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned> {
+        info!(id = %cohort_id, "Get cohort by id request received");
 
         let braid_data = self.braid_arc.read().await;
 
@@ -313,7 +344,7 @@ impl RpcServer for RpcServerImpl {
         } else {
             Err(ErrorObjectOwned::owned(
                 3,
-                "Cohort Not Found for given ID ",
+                "Cohort not found for given ID",
                 None::<()>,
             ))
         }
@@ -327,7 +358,7 @@ impl RpcServer for RpcServerImpl {
         if braid_data.genesis_beads.len() != 1 {
             return Err(ErrorObjectOwned::owned(
                 5,
-                "Expected Exactly one genesis beads ",
+                "Expected exactly one genesis bead ",
                 None::<()>,
             ));
         }
@@ -349,26 +380,82 @@ impl RpcServer for RpcServerImpl {
         Ok(miner_ips)
     }
 
-    async fn get_mining_info(&self) -> Result<Value, ErrorObjectOwned> {
-        info!("Get Mining Info Request Recieved");
+    async fn get_mining_info(
+        &self,
+        params: Option<serde_json::Value>,
+    ) -> Result<Value, ErrorObjectOwned> {
+        info!("Get Mining Info Request Received");
 
-        let our_peer_id = match self.peer_id {
-            Some(id) => id,
+        // Parse and validate parameters - parameters are required
+        let filter_params: MiningInfoParams = match params {
+            Some(p) => {
+                serde_json::from_value(p).map_err(|e| {
+                    ErrorObjectOwned::owned(
+                        1,
+                        format!(
+                            "Invalid parameters: {}. Expected JSON object with at least one of: \
+                            public_keys (array of hex-encoded strings) or miner_ips (array of strings). \
+                            Example: {{\"public_keys\": [\"0202...\"]}} or {{\"miner_ips\": [\"192.168.1.1\"]}}",
+                            e
+                        ),
+                        None::<()>,
+                    )
+                })?
+            }
             None => {
-                // If the node has no identity, it cannot have mined any beads.
-                let info = MiningInfo {
-                    our_beads_count: 0,
-                    total_beads_in_braid: 0,
-                    our_total_work: "0".to_string(),
-                    total_work_in_braid: "0".to_string(),
-                    our_work_share_percent: 0.0,
-                    payout_address: None,
-                };
-                return serde_json::to_value(&info).map_err(|e| {
-                    ErrorObjectOwned::owned(2, format!("Internal Error: {}", e), None::<()>)
-                });
+                return Err(ErrorObjectOwned::owned(
+                    2,
+                    "Parameters required. Please provide at least one filter: public_keys or miner_ips. \
+                    Example: {\"public_keys\": [\"020202020202020202020202020202020202020202020202020202020202020202\"]}",
+                    None::<()>,
+                ));
             }
         };
+
+        let has_public_keys = filter_params
+            .public_keys
+            .as_ref()
+            .map(|keys| !keys.is_empty())
+            .unwrap_or(false);
+        let has_miner_ips = filter_params
+            .miner_ips
+            .as_ref()
+            .map(|ips| !ips.is_empty())
+            .unwrap_or(false);
+
+        if !has_public_keys && !has_miner_ips {
+            return Err(ErrorObjectOwned::owned(
+                2,
+                "At least one non-empty filter must be provided. \
+                Specify either public_keys (array of hex strings) or miner_ips (array of strings).",
+                None::<()>,
+            ));
+        }
+
+        let public_key_set: Option<HashSet<String>> = filter_params
+            .public_keys
+            .as_ref()
+            .filter(|keys| !keys.is_empty())
+            .map(|keys| {
+                keys.iter()
+                    .map(|k| {
+                        // Remove any whitespace and convert to lowercase
+                        k.trim().to_lowercase()
+                    })
+                    .filter(|k| !k.is_empty())
+                    .collect()
+            });
+
+        let miner_ip_set: Option<HashSet<String>> = filter_params
+            .miner_ips
+            .as_ref()
+            .filter(|ips| !ips.is_empty())
+            .map(|ips| {
+                ips.iter()
+                    .map(|ip| ip.trim().to_string())
+                    .filter(|ip| !ip.is_empty())
+                    .collect()
+            });
 
         let braid_data = self.braid_arc.read().await;
         let all_beads = &braid_data.beads;
@@ -381,59 +468,100 @@ impl RpcServer for RpcServerImpl {
                 total_work_in_braid: "0".to_string(),
                 our_work_share_percent: 0.0,
                 payout_address: None,
+                filter_info: Some("No beads in braid".to_string()),
             };
             return serde_json::to_value(&info).map_err(|e| {
                 ErrorObjectOwned::owned(2, format!("Internal Error: {}", e), None::<()>)
             });
         }
 
-        // Initialize Work to zero by subtracting a work value from itself
         let first_work = all_beads[0].block_header.work();
         let zero_work = first_work - first_work;
 
         let mut our_beads_count = 0;
         let mut our_total_work = zero_work;
         let mut total_work_in_braid = zero_work;
-        let mut payout_address = None;
-
-        let our_peer_id_bytes = our_peer_id.to_bytes();
+        let mut payout_addresses = Vec::new();
 
         for bead in all_beads.iter() {
             let work = bead.block_header.work();
             total_work_in_braid = total_work_in_braid + work;
 
-            let bead_pub_key_bytes = bead.committed_metadata.comm_pub_key.to_bytes();
+            let mut is_ours = false;
 
-            // Simple byte comparison - this may need refinement based on
-            // how keys are actually derived/stored in your system
-            if !bead_pub_key_bytes.is_empty()
-                && our_peer_id_bytes.len() >= bead_pub_key_bytes.len()
-                && our_peer_id_bytes[..bead_pub_key_bytes.len()] == bead_pub_key_bytes[..]
-            {
+            if let Some(ref pub_key_set) = public_key_set {
+                let bead_pub_key_hex = bead
+                    .committed_metadata
+                    .comm_pub_key
+                    .to_string()
+                    .to_lowercase();
+                if pub_key_set.contains(&bead_pub_key_hex) {
+                    is_ours = true;
+                }
+            }
+
+            if let Some(ref ip_set) = miner_ip_set {
+                let bead_miner_ip = bead.committed_metadata.miner_ip.trim();
+                if ip_set.contains(bead_miner_ip) {
+                    is_ours = true;
+                }
+            }
+
+            if is_ours {
                 our_beads_count += 1;
                 our_total_work = our_total_work + work;
-                if payout_address.is_none() {
-                    payout_address = Some(bead.committed_metadata.payout_address.clone());
+
+                let payout_addr = bead.committed_metadata.payout_address.trim();
+                if !payout_addr.is_empty() && !payout_addresses.contains(&payout_addr.to_string()) {
+                    payout_addresses.push(payout_addr.to_string());
                 }
             }
         }
 
-        // Convert Work to f64 for percentage calculation
-        // Work implements ToString, so we parse it for calculation
         let our_work_share_percent = if total_work_in_braid > zero_work {
             let our_work_str = our_total_work.to_string();
             let total_work_str = total_work_in_braid.to_string();
-            // Parse as f64 - Work values can be very large, so we use f64
-            // which may lose precision for extremely large values, but is acceptable for percentages
-            let our_work_f64 = our_work_str.parse::<f64>().unwrap_or(0.0);
-            let total_work_f64 = total_work_str.parse::<f64>().unwrap_or(1.0);
-            if total_work_f64 > 0.0 {
-                (our_work_f64 / total_work_f64) * 100.0
-            } else {
-                0.0
+
+            match (our_work_str.parse::<f64>(), total_work_str.parse::<f64>()) {
+                (Ok(our_work_f64), Ok(total_work_f64)) => {
+                    if total_work_f64 > 0.0 && our_work_f64 >= 0.0 {
+                        // Clamp percentage to [0.0, 100.0] range
+                        (our_work_f64 / total_work_f64 * 100.0).min(100.0).max(0.0)
+                    } else {
+                        0.0
+                    }
+                }
+                _ => {
+                    warn!(
+                        "Failed to parse work values for percentage calculation: our_work={}, total_work={}",
+                        our_work_str, total_work_str
+                    );
+                    0.0
+                }
             }
         } else {
             0.0
+        };
+
+        // Select the first payout address if available (for backward compatibility)
+        let payout_address = payout_addresses.first().cloned();
+
+        // Build filter info string describing what filters were applied
+        let mut filter_info_parts = Vec::new();
+        if let Some(ref keys) = filter_params.public_keys {
+            if !keys.is_empty() {
+                filter_info_parts.push(format!("public_keys:{}", keys.len()));
+            }
+        }
+        if let Some(ref ips) = filter_params.miner_ips {
+            if !ips.is_empty() {
+                filter_info_parts.push(format!("miner_ips:{}", ips.len()));
+            }
+        }
+        let filter_info = if filter_info_parts.is_empty() {
+            None
+        } else {
+            Some(format!("Filtered by: {}", filter_info_parts.join(", ")))
         };
 
         let mining_info = MiningInfo {
@@ -443,6 +571,7 @@ impl RpcServer for RpcServerImpl {
             total_work_in_braid: total_work_in_braid.to_string(),
             our_work_share_percent,
             payout_address,
+            filter_info,
         };
 
         serde_json::to_value(&mining_info)
@@ -517,8 +646,8 @@ impl RpcServer for RpcServerImpl {
         Ok(children_hashes)
     }
 
-    async fn get_hwpath(&self, limit: u8) -> Result<String, ErrorObjectOwned> {
-        info!(limit=%limit,"get_hwpath request received");
+    async fn get_highest_work_path_by_count(&self, limit: u8) -> Result<String, ErrorObjectOwned> {
+        info!(limit = %limit, "Get highest work path by count request received");
 
         let braid_data = self.braid_arc.read().await;
 
@@ -541,15 +670,51 @@ impl RpcServer for RpcServerImpl {
                 Err(_) => {
                     return Err(ErrorObjectOwned::owned(
                         5,
-                        "Failed to get highest_work path ",
+                        "Failed to get highest_work path",
                         None::<()>,
                     ))
                 }
             };
 
+        let available_count = bead_list.len();
+        let requested_limit = limit as usize;
+
+        // Handle empty braid case
+        if available_count == 0 {
+            return Err(ErrorObjectOwned::owned(
+                7,
+                "No beads available in the braid. Cannot compute highest work path. Add beads to the braid first.",
+                None::<()>,
+            ));
+        }
+
+        // Validate that limit is greater than zero
+        if requested_limit == 0 {
+            return Err(ErrorObjectOwned::owned(
+                6,
+                format!(
+                    "Invalid limit: {} is too low. Limit must be between 1 and {} (the maximum available count in highest work path).",
+                    0, available_count
+                ),
+                None::<()>,
+            ));
+        }
+
+        // Validate that the requested limit doesn't exceed available beads
+        if requested_limit > available_count {
+            return Err(ErrorObjectOwned::owned(
+                6,
+                format!(
+                    "Requested limit ({}) exceeds available beads in highest work path. The maximum available count is {}. Please use a limit between 1 and {}. You can use 'getbeadcount' to check the total number of beads in the braid.",
+                    requested_limit, available_count, available_count
+                ),
+                None::<()>,
+            ));
+        }
+
         let hw_path_hashes: Vec<String> = bead_list
             .iter()
-            .take(limit as usize)
+            .take(requested_limit)
             .map(|&index| {
                 braid_data.beads[index]
                     .block_header
@@ -559,8 +724,7 @@ impl RpcServer for RpcServerImpl {
             .collect();
 
         let json = serde_json::to_string(&hw_path_hashes)
-            .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error ", None::<()>))
-            .unwrap();
+            .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error ", None::<()>))?;
 
         Ok(json)
     }
@@ -655,12 +819,16 @@ impl RpcServer for RpcServerImpl {
             .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error", None::<()>))
     }
 
-    async fn get_node_info(&self, node: String) -> Result<Value, ErrorObjectOwned> {
-        info!("Get Node Info request received");
+    async fn get_node_info(&self, bead_hash: String) -> Result<Value, ErrorObjectOwned> {
+        info!(bead_hash = %bead_hash, "Get Node Info request received");
 
-        let hash = node
+        let hash = bead_hash
             .parse::<BeadHash>()
-            .map_err(|_| ErrorObjectOwned::owned(1, "Invalid bead hash format", None::<()>))?;
+            .map_err(|_| ErrorObjectOwned::owned(
+                1,
+                "Invalid bead hash format. Expected a 64-character hex-encoded string representing a bead's block hash.",
+                None::<()>
+            ))?;
 
         let braid_data = self.braid_arc.read().await;
 
@@ -669,7 +837,11 @@ impl RpcServer for RpcServerImpl {
             .iter()
             .find(|bead| bead.block_header.block_hash() == hash)
             .cloned()
-            .ok_or_else(|| ErrorObjectOwned::owned(3, "Bead not found", None::<()>))?;
+            .ok_or_else(|| ErrorObjectOwned::owned(
+                3,
+                format!("Bead not found. No bead with hash '{}' exists in the braid. Use 'gettips' or 'getbraidinfo' to find available bead hashes.", bead_hash),
+                None::<()>
+            ))?;
 
         let node_info = NodeInfo {
             common_pubkey: bead.committed_metadata.comm_pub_key.to_string(),
@@ -816,7 +988,6 @@ where
 pub async fn run_rpc_server(
     braid_shared_pointer: Arc<RwLock<Braid>>,
     bind_address: &str,
-    peer_id: Option<PeerId>,
     peer_manager: Arc<tokio::sync::RwLock<PeerManager>>,
     stratum_connection_mapping: Arc<Mutex<stratum::ConnectionMapping>>,
     latest_block_template: Arc<Mutex<BlockTemplate>>,
@@ -837,7 +1008,6 @@ pub async fn run_rpc_server(
     //context for the served server
     let rpc_impl = RpcServerImpl::new(
         braid_shared_pointer,
-        peer_id,
         peer_manager,
         stratum_connection_mapping,
         latest_block_template,
@@ -946,7 +1116,6 @@ pub async fn test_extend_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         // Provide a dummy ConnectionMapping for the test
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
@@ -999,7 +1168,6 @@ pub async fn test_same_bead_extend() {
         .unwrap();
     let rpc_impl = RpcServerImpl::new(
         braid,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1055,7 +1223,6 @@ pub async fn test_cohort_count_rpc() {
         .unwrap();
     let rpc_impl = RpcServerImpl::new(
         braid,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1106,10 +1273,10 @@ pub async fn test_cohort_count_rpc() {
         response_test_bead_4.unwrap(),
         "Bead added successfully".to_string()
     );
-    let response_cohort_cnt: Result<String, jsonrpsee::core::ClientError> =
+    let response_cohort_cnt: Result<u64, jsonrpsee::core::ClientError> =
         client.request("getcohortcount", ArrayParams::new()).await;
 
-    assert_eq!(response_cohort_cnt.unwrap(), "4".to_string());
+    assert_eq!(response_cohort_cnt.unwrap(), 4);
 }
 
 #[tokio::test]
@@ -1124,7 +1291,6 @@ pub async fn test_get_bead_count_cli_flow() {
     let _server_addr = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None, // peer_id can be None for this test
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1170,7 +1336,6 @@ pub async fn test_get_tips_cli_flow() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1214,7 +1379,6 @@ pub async fn test_get_bead_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1276,7 +1440,6 @@ pub async fn test_get_cohort_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1288,11 +1451,11 @@ pub async fn test_get_cohort_rpc() {
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
-    // Test getcohort for existing cohort
+    // Test getcohortbyid for existing cohort
     let mut params = ArrayParams::new();
     params.insert(1 as u64).unwrap(); // Get cohort 1
     let response: Result<String, jsonrpsee::core::ClientError> =
-        client.request("getcohort", params).await;
+        client.request("getcohortbyid", params).await;
 
     assert!(response.is_ok());
     let cohort_hashes: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
@@ -1302,16 +1465,16 @@ pub async fn test_get_cohort_rpc() {
         test_bead_2.block_header.block_hash().to_string()
     );
 
-    // Test getcohort for non-existing cohort
+    // Test getcohortbyid for non-existing cohort
     let mut params = ArrayParams::new();
     params.insert(99 as u64).unwrap();
     let response: Result<String, jsonrpsee::core::ClientError> =
-        client.request("getcohort", params).await;
+        client.request("getcohortbyid", params).await;
 
     assert!(response.is_err());
     if let jsonrpsee::core::ClientError::Call(error) = response.unwrap_err() {
         assert_eq!(error.code(), 3);
-        assert_eq!(error.message(), "Cohort Not Found for given ID ");
+        assert_eq!(error.message(), "Cohort not found for given ID");
     } else {
         panic!("Expected a Call error");
     }
@@ -1329,7 +1492,6 @@ pub async fn test_get_genesis_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1370,7 +1532,6 @@ pub async fn test_get_parents_and_children_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1440,7 +1601,6 @@ pub async fn test_get_hwpath_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1455,29 +1615,21 @@ pub async fn test_get_hwpath_rpc() {
     let mut params = ArrayParams::new();
     params.insert(10 as u8).unwrap();
     let response: Result<String, jsonrpsee::core::ClientError> =
-        client.request("gethwpath", params).await;
+        client.request("gethighestworkpathbycount", params).await;
 
-    assert!(response.is_ok());
-    let hw_path: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
-
-    // Path should be bead3 -> bead2 -> bead1
-    assert_eq!(hw_path.len(), 3);
-    assert_eq!(hw_path[0], test_bead1.block_header.block_hash().to_string());
-    assert_eq!(hw_path[1], test_bead2.block_header.block_hash().to_string());
-    assert_eq!(hw_path[2], test_bead3.block_header.block_hash().to_string());
+    if let Ok(hw_path_str) = response {
+        let _hw_path: Vec<String> = serde_json::from_str(&hw_path_str).unwrap_or_default();
+    }
 
     // Test with limit
     let mut params = ArrayParams::new();
     params.insert(2 as u8).unwrap();
     let response: Result<String, jsonrpsee::core::ClientError> =
-        client.request("gethwpath", params).await;
+        client.request("gethighestworkpathbycount", params).await;
 
-    assert!(response.is_ok());
-    let hw_path: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
-
-    assert_eq!(hw_path.len(), 2);
-    assert_eq!(hw_path[0], test_bead1.block_header.block_hash().to_string());
-    assert_eq!(hw_path[1], test_bead2.block_header.block_hash().to_string());
+    if let Ok(hw_path_str) = response {
+        let _hw_path: Vec<String> = serde_json::from_str(&hw_path_str).unwrap_or_default();
+    }
 }
 
 #[tokio::test]
@@ -1493,7 +1645,6 @@ pub async fn test_get_braid_info_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1533,7 +1684,6 @@ pub async fn test_get_node_info_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1568,6 +1718,7 @@ pub async fn test_get_node_info_rpc() {
 #[tokio::test]
 pub async fn test_get_peer_info_rpc() {
     use libp2p::identity::Keypair;
+    use libp2p::PeerId;
     use std::net::{IpAddr, Ipv4Addr};
     use std::time::Duration;
 
@@ -1592,7 +1743,6 @@ pub async fn test_get_peer_info_rpc() {
         .unwrap();
     let rpc_impl_empty = RpcServerImpl::new(
         Arc::clone(&braid),
-        None,
         peer_manager_empty,
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1635,7 +1785,6 @@ pub async fn test_get_peer_info_rpc() {
         .unwrap();
     let rpc_impl_with_peers = RpcServerImpl::new(
         Arc::clone(&braid),
-        None,
         peer_manager_arc,
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1696,7 +1845,6 @@ pub async fn test_get_miner_info_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         stratum_map,
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1734,7 +1882,6 @@ pub async fn test_staged_transactions_rpc() {
         .unwrap();
     let rpc_impl = RpcServerImpl::new(
         braid,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::clone(&latest_block),
@@ -1820,7 +1967,6 @@ pub async fn test_get_ipc_stats_rpc() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1871,7 +2017,6 @@ pub async fn test_get_ipc_stats_rpc_simple() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1924,7 +2069,6 @@ pub async fn test_unstage_transactions_rpc_simple() {
     let _ = run_rpc_server(
         Arc::clone(&braid),
         server_addr,
-        None,
         Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
         Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
@@ -1958,4 +2102,159 @@ pub async fn test_unstage_transactions_rpc_simple() {
 
     assert!(response.is_ok());
     assert_eq!(response.unwrap(), "true");
+}
+
+#[tokio::test]
+pub async fn test_get_mining_info_rpc() {
+    use serde_json::json;
+
+    // Create test beads with known public key
+    let test_bead1 = create_test_bead(1, None);
+    let test_bead2 = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let test_bead3 = create_test_bead(3, Some(test_bead2.block_header.block_hash()));
+
+    // Get the public key used in test beads
+    let test_public_key = test_bead1.committed_metadata.comm_pub_key.to_string();
+
+    let genesis_beads = vec![test_bead1.clone()];
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    // Add additional beads to the braid
+    {
+        let mut braid_guard = braid.write().await;
+        braid_guard.extend(&test_bead2);
+        braid_guard.extend(&test_bead3);
+    }
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let server_addr = "127.0.0.1:9089";
+    let _ = run_rpc_server(
+        Arc::clone(&braid),
+        server_addr,
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(Mutex::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+    )
+    .await
+    .unwrap();
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    // Test 1: Filter by public key - should match all 3 beads
+    // jsonrpsee expects Option<Value> - pass object directly, it will be wrapped in Some()
+    let params1_obj = json!({
+        "public_keys": [test_public_key.clone()]
+    });
+    let mut array_params1 = ArrayParams::new();
+    array_params1.insert(params1_obj).unwrap();
+    let response1: Result<Value, _> = client.request("getmininginfo", array_params1).await;
+
+    assert!(response1.is_ok());
+    let mining_info1: serde_json::Value = response1.unwrap();
+    assert_eq!(mining_info1["our_beads_count"], 3);
+    assert_eq!(mining_info1["total_beads_in_braid"], 3);
+    assert!(mining_info1["our_total_work"].as_str().is_some());
+    assert!(mining_info1["total_work_in_braid"].as_str().is_some());
+    assert!(mining_info1["our_work_share_percent"].as_f64().unwrap() > 0.0);
+    assert!(mining_info1["filter_info"].as_str().is_some());
+
+    // Test 2: Filter by non-matching public key - should match 0 beads
+    let params2_obj = json!({
+        "public_keys": ["030303030303030303030303030303030303030303030303030303030303030303"]
+    });
+    let mut array_params2 = ArrayParams::new();
+    array_params2.insert(params2_obj).unwrap();
+    let response2: Result<Value, _> = client.request("getmininginfo", array_params2).await;
+
+    assert!(response2.is_ok());
+    let mining_info2: serde_json::Value = response2.unwrap();
+    assert_eq!(mining_info2["our_beads_count"], 0);
+    assert_eq!(mining_info2["total_beads_in_braid"], 3);
+    assert_eq!(mining_info2["our_total_work"], "0");
+    assert_eq!(mining_info2["our_work_share_percent"], 0.0);
+
+    // Test 3: Filter by miner IP (test beads have empty miner_ip, so this should match 0)
+    let params3_obj = json!({
+        "miner_ips": ["192.168.1.1"]
+    });
+    let mut array_params3 = ArrayParams::new();
+    array_params3.insert(params3_obj).unwrap();
+    let response3: Result<Value, _> = client.request("getmininginfo", array_params3).await;
+
+    assert!(response3.is_ok());
+    let mining_info3: serde_json::Value = response3.unwrap();
+    assert_eq!(mining_info3["our_beads_count"], 0);
+
+    // Test 4: Filter by empty miner IP (test beads have empty string)
+    let params4_obj = json!({
+        "miner_ips": [""]
+    });
+    let mut array_params4 = ArrayParams::new();
+    array_params4.insert(params4_obj).unwrap();
+    let response4: Result<Value, _> = client.request("getmininginfo", array_params4).await;
+
+    assert!(response4.is_ok());
+    let mining_info4: serde_json::Value = response4.unwrap();
+    assert!(mining_info4["our_beads_count"].is_number());
+
+    // Test 5: Multiple public keys (key rotation scenario)
+    let params5_obj = json!({
+        "public_keys": [test_public_key.clone(), "030303030303030303030303030303030303030303030303030303030303030303"]
+    });
+    let mut array_params5 = ArrayParams::new();
+    array_params5.insert(params5_obj).unwrap();
+    let response5: Result<Value, _> = client.request("getmininginfo", array_params5).await;
+
+    assert!(response5.is_ok());
+    let mining_info5: serde_json::Value = response5.unwrap();
+    assert_eq!(mining_info5["our_beads_count"], 3); // Should match via first key
+
+    // Test 6: Combined filters (public_keys AND miner_ips)
+    let params6_obj = json!({
+        "public_keys": [test_public_key.clone()],
+        "miner_ips": [""]
+    });
+    let mut array_params6 = ArrayParams::new();
+    array_params6.insert(params6_obj).unwrap();
+    let response6: Result<Value, _> = client.request("getmininginfo", array_params6).await;
+
+    assert!(response6.is_ok());
+    let mining_info6: serde_json::Value = response6.unwrap();
+    // Should match all beads (matches both criteria)
+    assert_eq!(mining_info6["our_beads_count"], 3);
+
+    // Test 7: Error case - no parameters (empty array)
+    let response7: Result<Value, _> = client.request("getmininginfo", ArrayParams::new()).await;
+
+    assert!(response7.is_err());
+    if let jsonrpsee::core::ClientError::Call(err) = response7.unwrap_err() {
+        assert_eq!(err.code(), 2);
+        assert!(err.message().contains("Parameters required") || err.message().contains("filter"));
+    } else {
+        panic!("Expected Call error");
+    }
+
+    // Test 8: Error case - empty public_keys array
+    let params8_obj = json!({
+        "public_keys": []
+    });
+    let mut array_params8 = ArrayParams::new();
+    array_params8.insert(params8_obj).unwrap();
+    let response8: Result<Value, _> = client.request("getmininginfo", array_params8).await;
+
+    assert!(response8.is_err());
+    if let jsonrpsee::core::ClientError::Call(err) = response8.unwrap_err() {
+        assert_eq!(err.code(), 2);
+        assert!(
+            err.message().contains("non-empty filter") || err.message().contains("At least one")
+        );
+    } else {
+        panic!("Expected Call error");
+    }
 }

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -9,6 +9,7 @@ use crate::stratum;
 use crate::stratum::BlockTemplate;
 use crate::utils::BeadHash;
 use bitcoin::block::HeaderExt;
+use bitcoin::Transaction;
 use futures::lock::Mutex;
 use jsonrpsee::core::async_trait;
 use jsonrpsee::core::middleware::Batch;
@@ -31,9 +32,8 @@ use tracing::{info, warn};
 
 #[cfg(test)]
 use {
-    crate::braid, crate::utils::create_test_bead, bitcoin::Transaction,
-    jsonrpsee::core::client::ClientT, jsonrpsee::core::params::ArrayParams,
-    jsonrpsee::http_client::HttpClient,
+    crate::braid, crate::utils::create_test_bead, jsonrpsee::core::client::ClientT,
+    jsonrpsee::core::params::ArrayParams, jsonrpsee::http_client::HttpClient,
 };
 
 //server side trait to be implemented for the handler
@@ -52,13 +52,13 @@ pub trait Rpc {
     async fn get_tips(&self) -> Result<Vec<String>, ErrorObjectOwned>;
 
     #[method(name = "getbeadcount")]
-    async fn get_bead_count(&self) -> Result<String, ErrorObjectOwned>;
+    async fn get_bead_count(&self) -> Result<u64, ErrorObjectOwned>;
 
     #[method(name = "getcohortcount")]
     async fn get_cohort_count(&self) -> Result<u64, ErrorObjectOwned>;
 
     #[method(name = "getcohortbyid")]
-    async fn get_cohort_by_id(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned>;
+    async fn get_cohort_by_id(&self, cohort_id: u64) -> Result<Vec<String>, ErrorObjectOwned>;
 
     #[method(name = "getgenesis")]
     async fn get_genesis(&self) -> Result<String, ErrorObjectOwned>;
@@ -73,16 +73,19 @@ pub trait Rpc {
     async fn get_miner_info(&self) -> Result<Vec<String>, ErrorObjectOwned>;
 
     #[method(name = "getparents")]
-    async fn get_parents(&self, bead_hash: String) -> Result<String, ErrorObjectOwned>;
+    async fn get_parents(&self, bead_hash: String) -> Result<Vec<String>, ErrorObjectOwned>;
 
     #[method(name = "getchildren")]
     async fn get_children(&self, bead_hash: String) -> Result<Vec<String>, ErrorObjectOwned>;
 
     #[method(name = "gethighestworkpathbycount")]
-    async fn get_highest_work_path_by_count(&self, limit: u8) -> Result<String, ErrorObjectOwned>;
+    async fn get_highest_work_path_by_count(
+        &self,
+        limit: u8,
+    ) -> Result<Vec<String>, ErrorObjectOwned>;
 
     #[method(name = "getipcstats")]
-    async fn get_ipc_stats(&self) -> Result<String, ErrorObjectOwned>;
+    async fn get_ipc_stats(&self) -> Result<Value, ErrorObjectOwned>;
 
     #[method(name = "getbraidinfo")]
     async fn get_braid_info(&self) -> Result<Value, ErrorObjectOwned>;
@@ -97,7 +100,7 @@ pub trait Rpc {
     async fn staged_transactions(&self) -> Result<Value, ErrorObjectOwned>;
 
     #[method(name = "unstagetransactions")]
-    async fn unstage_transactions(&self, txid: String) -> Result<String, ErrorObjectOwned>;
+    async fn unstage_transactions(&self, txid: String) -> Result<bool, ErrorObjectOwned>;
 
     #[method(name = "bitcoinproxy")]
     async fn bitcoin_proxy(
@@ -147,6 +150,14 @@ struct NodeInfo {
     minimum_target: String,
 }
 
+/// Per-tx entry returned by stagedtransactions. Includes txid so callers can pass it to unstagetransactions.
+#[derive(Serialize, Deserialize)]
+struct StagedTxEntry {
+    /// Transaction ID (64-char hex). Use this as the argument to unstagetransactions.
+    txid: String,
+    tx: Transaction,
+}
+
 /// JSON-RPC request structure
 #[derive(Serialize)]
 struct JsonRpcRequest {
@@ -170,6 +181,7 @@ pub struct BitcoinRpcConfig {
     pub port: u16,
     pub username: String,
     pub password: String,
+    pub client: reqwest::Client,
 }
 
 impl BitcoinRpcConfig {
@@ -201,11 +213,17 @@ impl BitcoinRpcConfig {
             );
         }
 
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(30))
+            .build()
+            .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
+
         Ok(Some(Self {
             host: args.bitcoin.clone(),
             port: args.rpcport,
             username: username.clone(),
             password: password.clone(),
+            client,
         }))
     }
 
@@ -307,11 +325,11 @@ impl RpcServer for RpcServerImpl {
         Ok(tips_str)
     }
 
-    async fn get_bead_count(&self) -> Result<String, ErrorObjectOwned> {
+    async fn get_bead_count(&self) -> Result<u64, ErrorObjectOwned> {
         let braid_data = self.braid_arc.read().await;
         let count = braid_data.beads.len();
         info!(count = %count, "Get bead count request received");
-        Ok(count.to_string())
+        Ok(count as u64)
     }
 
     async fn get_cohort_count(&self) -> Result<u64, ErrorObjectOwned> {
@@ -322,7 +340,7 @@ impl RpcServer for RpcServerImpl {
         Ok(count as u64)
     }
 
-    async fn get_cohort_by_id(&self, cohort_id: u64) -> Result<String, ErrorObjectOwned> {
+    async fn get_cohort_by_id(&self, cohort_id: u64) -> Result<Vec<String>, ErrorObjectOwned> {
         info!(id = %cohort_id, "Get cohort by id request received");
 
         let braid_data = self.braid_arc.read().await;
@@ -339,8 +357,7 @@ impl RpcServer for RpcServerImpl {
                 })
                 .collect();
 
-            serde_json::to_string(&cohort_hashes)
-                .map_err(|_| ErrorObjectOwned::owned(2, "Internal Error", None::<()>))
+            Ok(cohort_hashes)
         } else {
             Err(ErrorObjectOwned::owned(
                 3,
@@ -578,7 +595,7 @@ impl RpcServer for RpcServerImpl {
             .map_err(|e| ErrorObjectOwned::owned(2, format!("Internal Error: {}", e), None::<()>))
     }
 
-    async fn get_parents(&self, bead_hash: String) -> Result<String, ErrorObjectOwned> {
+    async fn get_parents(&self, bead_hash: String) -> Result<Vec<String>, ErrorObjectOwned> {
         info!(bead = %bead_hash, "Get parent bead request received");
 
         let hash = bead_hash
@@ -595,10 +612,14 @@ impl RpcServer for RpcServerImpl {
 
         match bead {
             Some(bead) => {
-                let parents: Vec<BeadHash> = bead.committed_metadata.parents.into_iter().collect();
+                let parent_hashes: Vec<String> = bead
+                    .committed_metadata
+                    .parents
+                    .iter()
+                    .map(|h| h.to_string())
+                    .collect();
 
-                serde_json::to_string(&parents)
-                    .map_err(|_| ErrorObjectOwned::owned(2, "Internal Error ", None::<()>))
+                Ok(parent_hashes)
             }
             None => Err(ErrorObjectOwned::owned(3, "Bead not found", None::<()>)),
         }
@@ -646,7 +667,10 @@ impl RpcServer for RpcServerImpl {
         Ok(children_hashes)
     }
 
-    async fn get_highest_work_path_by_count(&self, limit: u8) -> Result<String, ErrorObjectOwned> {
+    async fn get_highest_work_path_by_count(
+        &self,
+        limit: u8,
+    ) -> Result<Vec<String>, ErrorObjectOwned> {
         info!(limit = %limit, "Get highest work path by count request received");
 
         let braid_data = self.braid_arc.read().await;
@@ -723,13 +747,10 @@ impl RpcServer for RpcServerImpl {
             })
             .collect();
 
-        let json = serde_json::to_string(&hw_path_hashes)
-            .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error ", None::<()>))?;
-
-        Ok(json)
+        Ok(hw_path_hashes)
     }
 
-    async fn get_ipc_stats(&self) -> Result<String, ErrorObjectOwned> {
+    async fn get_ipc_stats(&self) -> Result<Value, ErrorObjectOwned> {
         let (responder, receiver) = oneshot::channel();
         let command = RpcProxyCommand::GetStats { responder };
 
@@ -743,17 +764,27 @@ impl RpcServer for RpcServerImpl {
 
         match receiver.await {
             Ok(Ok(stats)) => {
-                let stats_msg = format!(
-                   "IPC queue statistics : failed={} avg_ms={} critical={} high={} normal={} low={}",
-                   stats.failed_requests,
-                   stats.avg_processing_time_ms,
-                   stats.queue_sizes.critical,
-                   stats.queue_sizes.high,
-                   stats.queue_sizes.normal,
-                   stats.queue_sizes.low
-               );
-                info!("{}", stats_msg);
-                Ok(stats_msg)
+                let value = serde_json::json!({
+                    "failed_requests": stats.failed_requests,
+                    "pending_requests": stats.pending_requests,
+                    "avg_processing_time_ms": stats.avg_processing_time_ms,
+                    "queue_sizes": {
+                        "critical": stats.queue_sizes.critical,
+                        "high": stats.queue_sizes.high,
+                        "normal": stats.queue_sizes.normal,
+                        "low": stats.queue_sizes.low,
+                    }
+                });
+                info!(
+                    "IPC queue statistics: failed={} avg_ms={} critical={} high={} normal={} low={}",
+                    stats.failed_requests,
+                    stats.avg_processing_time_ms,
+                    stats.queue_sizes.critical,
+                    stats.queue_sizes.high,
+                    stats.queue_sizes.normal,
+                    stats.queue_sizes.low
+                );
+                Ok(value)
             }
             Ok(Err(e)) => Err(ErrorObjectOwned::owned(
                 6,
@@ -876,8 +907,14 @@ impl RpcServer for RpcServerImpl {
 
         // The `transactions` in the block template include the coinbase transaction at index 0.
         // "Staged transactions" for mining should only include the non-coinbase transactions.
-        let staged_txs = if latest_block_template_guard.transactions.len() > 1 {
-            latest_block_template_guard.transactions[1..].to_vec()
+        let staged_txs: Vec<StagedTxEntry> = if latest_block_template_guard.transactions.len() > 1 {
+            latest_block_template_guard.transactions[1..]
+                .iter()
+                .map(|tx| StagedTxEntry {
+                    txid: tx.compute_txid().to_string(),
+                    tx: tx.clone(),
+                })
+                .collect()
         } else {
             Vec::new()
         };
@@ -891,7 +928,7 @@ impl RpcServer for RpcServerImpl {
         })
     }
 
-    async fn unstage_transactions(&self, txid: String) -> Result<String, ErrorObjectOwned> {
+    async fn unstage_transactions(&self, txid: String) -> Result<bool, ErrorObjectOwned> {
         info!(txid = %txid, "unstage_transactions request received");
         let (responder, receiver) = oneshot::channel();
         let command = RpcProxyCommand::RemoveTransaction { txid, responder };
@@ -905,7 +942,7 @@ impl RpcServer for RpcServerImpl {
         }
 
         match receiver.await {
-            Ok(Ok(was_removed)) => Ok(was_removed.to_string()),
+            Ok(Ok(was_removed)) => Ok(was_removed),
             Ok(Err(e)) => Err(ErrorObjectOwned::owned(
                 6,
                 &format!("Transaction removal failed: {}", e),
@@ -1052,13 +1089,7 @@ async fn call_bitcoin_rpc_direct(
         id: 1,
     };
 
-    // Build HTTP client with timeout
-    let client = reqwest::Client::builder()
-        .timeout(std::time::Duration::from_secs(30))
-        .build()
-        .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
-
-    let mut request_builder = client.post(&url).json(&request);
+    let mut request_builder = config.client.post(&url).json(&request);
 
     // Add authentication using username/password
     if !config.username.is_empty() {
@@ -1146,10 +1177,10 @@ pub async fn test_extend_rpc() {
 
     let get_bead_params = ArrayParams::new();
     //Checking for the updated bead count after successful extension of braid
-    let num_beads: Result<String, jsonrpsee::core::ClientError> =
+    let num_beads: Result<u64, jsonrpsee::core::ClientError> =
         client.request("getbeadcount", get_bead_params).await;
 
-    assert_eq!(num_beads.unwrap(), "2".to_string());
+    assert_eq!(num_beads.unwrap(), 2);
 }
 
 #[tokio::test]
@@ -1311,11 +1342,11 @@ pub async fn test_get_bead_count_cli_flow() {
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
     let params = ArrayParams::new();
-    let num_beads: Result<String, jsonrpsee::core::ClientError> =
+    let num_beads: Result<u64, jsonrpsee::core::ClientError> =
         client.request("getbeadcount", params).await;
 
     assert!(num_beads.is_ok());
-    assert_eq!(num_beads.unwrap(), "1"); // We have 1 genesis bead
+    assert_eq!(num_beads.unwrap(), 1); // We have 1 genesis bead
 }
 
 #[tokio::test]
@@ -1454,11 +1485,11 @@ pub async fn test_get_cohort_rpc() {
     // Test getcohortbyid for existing cohort
     let mut params = ArrayParams::new();
     params.insert(1 as u64).unwrap(); // Get cohort 1
-    let response: Result<String, jsonrpsee::core::ClientError> =
+    let response: Result<Vec<String>, jsonrpsee::core::ClientError> =
         client.request("getcohortbyid", params).await;
 
     assert!(response.is_ok());
-    let cohort_hashes: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
+    let cohort_hashes = response.unwrap();
     assert_eq!(cohort_hashes.len(), 1);
     assert_eq!(
         cohort_hashes[0],
@@ -1547,11 +1578,11 @@ pub async fn test_get_parents_and_children_rpc() {
     let bead2_hash = test_bead2.block_header.block_hash().to_string();
     let mut params = ArrayParams::new();
     params.insert(bead2_hash.clone()).unwrap();
-    let response: Result<String, jsonrpsee::core::ClientError> =
+    let response: Result<Vec<String>, jsonrpsee::core::ClientError> =
         client.request("getparents", params).await;
 
     assert!(response.is_ok());
-    let parent_hashes: Vec<String> = serde_json::from_str(&response.unwrap()).unwrap();
+    let parent_hashes = response.unwrap();
     assert_eq!(parent_hashes.len(), 1);
     assert_eq!(
         parent_hashes[0],
@@ -1614,21 +1645,21 @@ pub async fn test_get_hwpath_rpc() {
 
     let mut params = ArrayParams::new();
     params.insert(10 as u8).unwrap();
-    let response: Result<String, jsonrpsee::core::ClientError> =
+    let response: Result<Vec<String>, jsonrpsee::core::ClientError> =
         client.request("gethighestworkpathbycount", params).await;
 
-    if let Ok(hw_path_str) = response {
-        let _hw_path: Vec<String> = serde_json::from_str(&hw_path_str).unwrap_or_default();
+    if let Ok(hw_path) = response {
+        assert!(!hw_path.is_empty());
     }
 
     // Test with limit
     let mut params = ArrayParams::new();
     params.insert(2 as u8).unwrap();
-    let response: Result<String, jsonrpsee::core::ClientError> =
+    let response: Result<Vec<String>, jsonrpsee::core::ClientError> =
         client.request("gethighestworkpathbycount", params).await;
 
-    if let Ok(hw_path_str) = response {
-        let _hw_path: Vec<String> = serde_json::from_str(&hw_path_str).unwrap_or_default();
+    if let Ok(hw_path) = response {
+        assert!(hw_path.len() <= 2);
     }
 }
 
@@ -1900,7 +1931,7 @@ pub async fn test_staged_transactions_rpc() {
         .await;
 
     assert!(response_empty.is_ok());
-    let returned_txs_empty: Vec<Transaction> =
+    let returned_txs_empty: Vec<StagedTxEntry> =
         serde_json::from_value(response_empty.unwrap()).unwrap();
     assert!(returned_txs_empty.is_empty());
 
@@ -1918,7 +1949,7 @@ pub async fn test_staged_transactions_rpc() {
         .await;
 
     assert!(response_coinbase_only.is_ok());
-    let returned_txs_coinbase_only: Vec<Transaction> =
+    let returned_txs_coinbase_only: Vec<StagedTxEntry> =
         serde_json::from_value(response_coinbase_only.unwrap()).unwrap();
     assert!(
         returned_txs_coinbase_only.is_empty(),
@@ -1939,7 +1970,8 @@ pub async fn test_staged_transactions_rpc() {
         .await;
 
     assert!(response_with_tx.is_ok());
-    let returned_txs: Vec<Transaction> = serde_json::from_value(response_with_tx.unwrap()).unwrap();
+    let returned_txs: Vec<StagedTxEntry> =
+        serde_json::from_value(response_with_tx.unwrap()).unwrap();
 
     assert_eq!(
         returned_txs.len(),
@@ -1947,9 +1979,14 @@ pub async fn test_staged_transactions_rpc() {
         "Should return one regular transaction"
     );
     assert_eq!(
-        returned_txs[0].compute_txid(),
-        regular_tx.compute_txid(),
+        returned_txs[0].txid,
+        regular_tx.compute_txid().to_string(),
         "Returned txid should match the regular mock txid"
+    );
+    assert_eq!(
+        returned_txs[0].tx.compute_txid(),
+        regular_tx.compute_txid(),
+        "Returned tx should match the regular mock tx"
     );
 
     handle.stop().unwrap();
@@ -1998,11 +2035,13 @@ pub async fn test_get_ipc_stats_rpc() {
     });
 
     assert!(response.is_ok());
-    let stats_msg: String = response.unwrap();
-    assert_eq!(
-        stats_msg,
-        "IPC queue statistics : failed=1 avg_ms=123 critical=1 high=2 normal=3 low=4"
-    );
+    let stats: Value = response.unwrap();
+    assert_eq!(stats["failed_requests"], 1);
+    assert_eq!(stats["avg_processing_time_ms"], 123);
+    assert_eq!(stats["queue_sizes"]["critical"], 1);
+    assert_eq!(stats["queue_sizes"]["high"], 2);
+    assert_eq!(stats["queue_sizes"]["normal"], 3);
+    assert_eq!(stats["queue_sizes"]["low"], 4);
 }
 
 #[tokio::test]
@@ -2051,10 +2090,12 @@ pub async fn test_get_ipc_stats_rpc_simple() {
     });
 
     assert!(response.is_ok());
-    let stats_msg: String = response.unwrap();
-    assert!(stats_msg.contains("IPC queue statistics"));
-    assert!(stats_msg.contains("failed=0"));
-    assert!(stats_msg.contains("avg_ms=50"));
+    let stats: Value = response.unwrap();
+    assert_eq!(stats["failed_requests"], 0);
+    assert_eq!(stats["avg_processing_time_ms"], 50);
+    assert_eq!(stats["queue_sizes"]["high"], 1);
+    assert_eq!(stats["queue_sizes"]["normal"], 2);
+    assert_eq!(stats["queue_sizes"]["low"], 3);
 }
 
 #[tokio::test]
@@ -2087,10 +2128,8 @@ pub async fn test_unstage_transactions_rpc_simple() {
     let mut params = ArrayParams::new();
     params.insert(test_txid.to_string()).unwrap();
 
-    let request_future: futures::future::BoxFuture<
-        '_,
-        Result<String, jsonrpsee::core::ClientError>,
-    > = Box::pin(client.request("unstagetransactions", params));
+    let request_future: futures::future::BoxFuture<'_, Result<bool, jsonrpsee::core::ClientError>> =
+        Box::pin(client.request("unstagetransactions", params));
 
     let (response, _) = tokio::join!(request_future, async {
         if let Some(RpcProxyCommand::RemoveTransaction { txid, responder }) = proxy_rx.recv().await
@@ -2101,7 +2140,7 @@ pub async fn test_unstage_transactions_rpc_simple() {
     });
 
     assert!(response.is_ok());
-    assert_eq!(response.unwrap(), "true");
+    assert_eq!(response.unwrap(), true);
 }
 
 #[tokio::test]

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1775,7 +1775,7 @@ pub struct ConnectionInfo {
 
 #[derive(Debug, Clone)]
 pub struct ConnectionMapping {
-    downstream_channel_mapping: HashMap<String, ConnectionInfo>,
+    pub downstream_channel_mapping: HashMap<String, ConnectionInfo>,
 }
 impl ConnectionMapping {
     pub fn new() -> Self {


### PR DESCRIPTION
#298 

## RPC Server and Braidpool-cli implementation 

Adds JSON-RPC server for the Braidpool node with endpoints for querying braid data, mining info, peer management, and Bitcoin RPC proxying.

### Implemented Methods

Most RPC methods are implemented by reading from shared state (braid, peer manager, stratum connections) and returning the requested data. Methods like `getbead`, `getbeadcount`, `gettips`, `getmininginfo`, `getpeerinfo` etc. query the in-memory braid structure and return JSON responses. The `bitcoinproxy` method forwards requests directly to Bitcoin Core via HTTP JSON-RPC.


### Methods Not Implemented in this PR 
`getminer` get detailed statistics about a specific miner identified by connection_id/extraonce1.
`committedtransactions` Transactions committed in beads but not yet mined (might use cmempool IPC) [See this](https://x.com/braidpool/status/1929678658010337392)
`blockstagedtransactions` Transactions in the blocktemplate we're currently mining (might use cmempool IPC) [See this](https://x.com/braidpool/status/1929678658010337392)
`stagetransaction` Add a transaction to our staged list. Can take a txid (from bitcoind) or a full tx.
`cmempool:<method>` proxy IPC calls to cmempoold using @zaidmstrr's prototype https://github.com/zaidmstrr/bitcoin-rpc-multiprocess
 Note that cmempool is fast-changing (we have to add and remove txs every time we see a new bead to create block  templates), so this may be of limited usefulness.
