### PR TITLE
feat: implement config file loading with CLI override priority

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -4,13 +4,17 @@ use std::path::PathBuf;
 #[derive(Parser, Debug, Clone)]
 #[command(name = "braid", about = "Braidpool Node CLI")]
 pub struct Cli {
+    /// Path to braidpool config file (TOML)
+    #[arg(long, default_value = concat!(env!("CARGO_MANIFEST_DIR"), "/src/default_braidpool_config.toml"))]
+    pub config: PathBuf,
+
     /// Braid data directory
-    #[arg(long, default_value = "~/.braidpool/")]
-    pub datadir: PathBuf,
+    #[arg(long)]
+    pub datadir: Option<PathBuf>,
 
     /// Bind to a given address and always listen on it
-    #[arg(long, default_value = "0.0.0.0:6680")]
-    pub bind: String,
+    #[arg(long)]
+    pub bind: Option<String>,
 
     /// Add a node to connect to and attempt to keep the connection open. This option can be
     /// specified multiple times
@@ -18,12 +22,12 @@ pub struct Cli {
     pub addnode: Option<Vec<String>>,
 
     /// Connect to this bitcoin node
-    #[arg(long, default_value = "0.0.0.0")]
-    pub bitcoin: String,
+    #[arg(long)]
+    pub bitcoin: Option<String>,
 
     /// Use this port for bitcoin RPC
-    #[arg(long, default_value = "8332")]
-    pub rpcport: u16,
+    #[arg(long)]
+    pub rpcport: Option<u16>,
 
     /// Use this username for bitcoin RPC
     #[arg(long)]
@@ -34,11 +38,11 @@ pub struct Cli {
     pub rpcpass: Option<String>,
 
     /// Which network to use. Valid options are mainnet, testnet4, signet, cpunet (preferred)
-    #[arg(long, default_value = "main")]
+    #[arg(long)]
     pub network: Option<String>,
 
     /// Use this cookie file for bitcoin RPC
-    #[arg(long, default_value = "~/.bitcoin/.cookie")]
+    #[arg(long)]
     pub rpccookie: Option<String>,
 
     /// Path to Bitcoin Core IPC socket

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -4,6 +4,22 @@ use serde::{Deserialize, Serialize};
 use std::fs;
 use std::path::PathBuf;
 
+// Default network configuration constants
+/// Default bind address for the braidpool node
+pub const DEFAULT_BIND_ADDRESS: &str = "0.0.0.0:6680";
+/// Default port for braidpool P2P communication
+pub const DEFAULT_P2P_PORT: u16 = 6680;
+/// Default Bitcoin RPC port (regtest)
+pub const DEFAULT_BITCOIN_RPC_PORT: u16 = 18443;
+/// Default braidpool RPC server address
+pub const DEFAULT_RPC_SERVER_ADDR: &str = "127.0.0.1:6682";
+/// Default data directory path
+pub const DEFAULT_DATA_DIR: &str = "~/.braidpool";
+/// Default Bitcoin cookie path
+pub const DEFAULT_COOKIE_PATH: &str = "~/.bitcoin/regtest/.cookie";
+/// Default pool identifier
+pub const DEFAULT_POOL_IDENTIFIER: &str = "Braidpool";
+
 #[derive(Deserialize, Serialize, Clone)]
 pub struct NetworkConfig {
     //Address to which the current braidpool node will bind to
@@ -11,6 +27,16 @@ pub struct NetworkConfig {
     //peer nodes to be added subscribed to the same topic
     pub peer_nodes: Vec<String>,
 }
+
+impl Default for NetworkConfig {
+    fn default() -> Self {
+        NetworkConfig {
+            listen_address: format!("/ip4/0.0.0.0/udp/{}/quic-v1", DEFAULT_P2P_PORT),
+            peer_nodes: Vec::new(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BitcoinConfig {
     pub network: bitcoin::Network,
@@ -21,14 +47,47 @@ pub struct BitcoinConfig {
     pub cookie_path: String,
     pub ipc_socket: Option<String>,
 }
+
+impl Default for BitcoinConfig {
+    fn default() -> Self {
+        BitcoinConfig {
+            network: Network::Regtest,
+            username: String::new(),
+            password: String::new(),
+            port: DEFAULT_BITCOIN_RPC_PORT.to_string(),
+            bitcoind_ip: "127.0.0.1".to_string(),
+            cookie_path: DEFAULT_COOKIE_PATH.to_string(),
+            ipc_socket: None,
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BraidDirectoryConfig {
     pub path: String,
 }
+
+impl Default for BraidDirectoryConfig {
+    fn default() -> Self {
+        BraidDirectoryConfig {
+            path: DEFAULT_DATA_DIR.to_string(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct MinerConfig {
     pub miner_pubkey: String,
 }
+
+impl Default for MinerConfig {
+    fn default() -> Self {
+        MinerConfig {
+            miner_pubkey: String::new(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BraidpoolConfig {
     pub braidnetwork_config: NetworkConfig,
@@ -37,6 +96,19 @@ pub struct BraidpoolConfig {
     pub miner_config: MinerConfig,
     pub braid_rpc_config: BraidRpcConfig,
 }
+
+impl Default for BraidpoolConfig {
+    fn default() -> Self {
+        BraidpoolConfig {
+            braidnetwork_config: NetworkConfig::default(),
+            bitcoin_config: BitcoinConfig::default(),
+            braid_directory: BraidDirectoryConfig::default(),
+            miner_config: MinerConfig::default(),
+            braid_rpc_config: BraidRpcConfig::default(),
+        }
+    }
+}
+
 #[derive(Serialize, Deserialize, Clone)]
 //Rpc server configuration
 pub struct BraidRpcConfig {
@@ -45,7 +117,7 @@ pub struct BraidRpcConfig {
 impl Default for BraidRpcConfig {
     fn default() -> Self {
         BraidRpcConfig {
-            rpc_server_addr: String::from("127.0.0.1:6682"),
+            rpc_server_addr: DEFAULT_RPC_SERVER_ADDR.to_string(),
         }
     }
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,7 +1,9 @@
 use bitcoin::Network;
-use core::panic;
+use libp2p::core::multiaddr::{Multiaddr, Protocol};
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::path::PathBuf;
+
 #[derive(Deserialize, Serialize, Clone)]
 pub struct NetworkConfig {
     //Address to which the current braidpool node will bind to
@@ -17,6 +19,7 @@ pub struct BitcoinConfig {
     pub port: String,
     pub bitcoind_ip: String,
     pub cookie_path: String,
+    pub ipc_socket: Option<String>,
 }
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BraidDirectoryConfig {
@@ -48,16 +51,13 @@ impl Default for BraidRpcConfig {
 }
 #[allow(dead_code)]
 impl BraidpoolConfig {
-    pub fn load_from_config_file(path: &str) -> BraidpoolConfig {
-        let contents = match fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(error) => {
-                panic!("An error occurred while reading the file {}", error);
-            }
-        };
-        let config: BraidpoolConfig = toml::from_str(&contents).unwrap();
+    pub fn load_from_config_file(
+        path: &str,
+    ) -> Result<BraidpoolConfig, Box<dyn std::error::Error>> {
+        let contents = fs::read_to_string(path)?;
+        let config: BraidpoolConfig = toml::from_str(&contents)?;
 
-        config
+        Ok(config)
     }
     pub fn with_listen_address(mut self, listen_address: String) -> Self {
         self.braidnetwork_config.listen_address = listen_address;
@@ -145,7 +145,7 @@ mod test {
             .unwrap()
             .join(Path::new("src/default_braidpool_config.toml"));
 
-        let from_file = BraidpoolConfig::load_from_config_file(cwd.to_str().unwrap());
+        let from_file = BraidpoolConfig::load_from_config_file(cwd.to_str().unwrap()).unwrap();
 
         let built = BraidpoolConfig {
             braidnetwork_config: NetworkConfig {
@@ -162,6 +162,7 @@ mod test {
                 port: "18443".to_string(),
                 bitcoind_ip: "0.0.0.0".to_string(),
                 cookie_path: "~/.bitcoin/regtest/.cookie".to_string(),
+                ipc_socket: None,
             },
             braid_directory: BraidDirectoryConfig {
                 path: "~/.braidpool".to_string(),
@@ -205,5 +206,48 @@ mod test {
             from_file.braid_rpc_config.rpc_server_addr,
             built.braid_rpc_config.rpc_server_addr
         );
+    }
+}
+
+pub fn expand_path(path: &str) -> PathBuf {
+    PathBuf::from(
+        shellexpand::full(path)
+            .expect(&format!("Failed to expand path: {}", path))
+            .into_owned(),
+    )
+}
+
+pub fn expand_pathbuf(path: &PathBuf) -> PathBuf {
+    expand_path(&path.to_string_lossy())
+}
+
+pub fn parse_network_arg(network_name: &str) -> Option<Network> {
+    match network_name {
+        "main" | "mainnet" => Some(Network::Bitcoin),
+        "testnet" | "testnet4" => Some(Network::Testnet(bitcoin::TestnetVersion::V4)),
+        "signet" => Some(Network::Signet),
+        "regtest" => Some(Network::Regtest),
+        "cpunet" => Some(Network::CPUNet),
+        _ => None,
+    }
+}
+
+pub fn socket_from_multiaddr(address: &str) -> Option<String> {
+    let multiaddr: Multiaddr = address.parse().ok()?;
+    let mut ip = None;
+    let mut port = None;
+
+    for protocol in multiaddr.into_iter() {
+        match protocol {
+            Protocol::Ip4(ipv4) => ip = Some(ipv4.to_string()),
+            Protocol::Ip6(ipv6) => ip = Some(ipv6.to_string()),
+            Protocol::Tcp(p) | Protocol::Udp(p) => port = Some(p),
+            _ => {}
+        }
+    }
+
+    match (ip, port) {
+        (Some(ip), Some(port)) => Some(format!("{ip}:{port}")),
+        _ => None,
     }
 }

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -19,7 +19,6 @@ pub const DEFAULT_DATA_DIR: &str = "~/.braidpool";
 pub const DEFAULT_COOKIE_PATH: &str = "~/.bitcoin/regtest/.cookie";
 /// Default pool identifier
 pub const DEFAULT_POOL_IDENTIFIER: &str = "Braidpool";
-
 #[derive(Deserialize, Serialize, Clone)]
 pub struct NetworkConfig {
     //Address to which the current braidpool node will bind to

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,8 +1,10 @@
 use bitcoin::Network;
 use libp2p::core::multiaddr::{Multiaddr, Protocol};
 use serde::{Deserialize, Serialize};
+use std::error::Error;
 use std::fs;
 use std::path::PathBuf;
+use tracing::{error, info};
 
 // Default network configuration constants
 /// Default bind address for the braidpool node
@@ -119,6 +121,148 @@ impl Default for BraidRpcConfig {
             rpc_server_addr: DEFAULT_RPC_SERVER_ADDR.to_string(),
         }
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct RuntimeConfig {
+    pub datadir: PathBuf,
+    pub bind_addr: String,
+    pub peer_nodes: Vec<String>,
+    pub network: Network,
+    pub ipc_socket: String,
+    pub rpc_server_addr: String,
+}
+
+pub fn load_runtime_config(args: &crate::cli::Cli) -> Result<RuntimeConfig, Box<dyn Error>> {
+    let config_path = expand_pathbuf(&args.config);
+    if !config_path.exists() {
+        error!(path = %config_path.display(), "Config file not found");
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Config file not found at {}", config_path.display()),
+        )
+        .into());
+    }
+
+    info!(path = %config_path.display(), "Loading braidpool config");
+    let braidpool_config = match BraidpoolConfig::load_from_config_file(
+        config_path
+            .to_str()
+            .expect("Failed to convert config path to string"),
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(error = %e, path = %config_path.display(), "Invalid configuration file");
+            return Err(e);
+        }
+    };
+
+    let datadir = match args.datadir.as_ref() {
+        Some(path) => expand_pathbuf(path),
+        None => expand_path(&braidpool_config.braid_directory.path),
+    };
+
+    let bind_addr = args
+        .bind
+        .clone()
+        .or_else(|| socket_from_multiaddr(&braidpool_config.braidnetwork_config.listen_address))
+        .unwrap_or_else(|| DEFAULT_BIND_ADDRESS.to_string());
+
+    let mut peer_nodes = braidpool_config.braidnetwork_config.peer_nodes.clone();
+    if let Some(nodes) = args.addnode.clone() {
+        peer_nodes.extend(nodes);
+    }
+
+    let network = match args.network.as_deref() {
+        Some(network_name) => match parse_network_arg(network_name) {
+            Some(parsed) => parsed,
+            None => {
+                error!(
+                    network = %network_name,
+                    valid_networks = "main, testnet, testnet4, signet, regtest, cpunet",
+                    "Invalid network specified, falling back to config value"
+                );
+                braidpool_config.bitcoin_config.network
+            }
+        },
+        None => braidpool_config.bitcoin_config.network,
+    };
+
+    let ipc_socket = braidpool_config
+        .bitcoin_config
+        .ipc_socket
+        .clone()
+        .unwrap_or(args.ipc_socket.clone());
+
+    let rpc_server_addr = braidpool_config.braid_rpc_config.rpc_server_addr.clone();
+
+    let bitcoin_node = args
+        .bitcoin
+        .clone()
+        .unwrap_or_else(|| braidpool_config.bitcoin_config.bitcoind_ip.clone());
+
+    let rpc_port = args
+        .rpcport
+        .or_else(|| {
+            braidpool_config
+                .bitcoin_config
+                .port
+                .parse::<u16>()
+                .map_err(|e| {
+                    error!("Invalid port number in config: {}", e);
+                    e
+                })
+                .ok()
+        })
+        .unwrap_or(DEFAULT_BITCOIN_RPC_PORT);
+
+    let rpc_user = args
+        .rpcuser
+        .clone()
+        .unwrap_or_else(|| braidpool_config.bitcoin_config.username.clone());
+
+    let _rpc_pass = args
+        .rpcpass
+        .clone()
+        .unwrap_or_else(|| braidpool_config.bitcoin_config.password.clone());
+
+    let _rpc_cookie = args
+        .rpccookie
+        .clone()
+        .map(|p| expand_path(&p))
+        .or_else(|| Some(expand_path(&braidpool_config.bitcoin_config.cookie_path)));
+
+    info!(
+        bitcoin_node = %bitcoin_node,
+        rpc_port = %rpc_port,
+        rpc_user = %rpc_user,
+        "Bitcoin RPC configuration loaded"
+    );
+
+    match fs::metadata(&datadir) {
+        Ok(m) => {
+            if !m.is_dir() {
+                error!(
+                    datadir = %datadir.display(),
+                    "Data directory exists but is not a directory"
+                );
+            }
+            info!(datadir = %datadir.display(), "Using existing data directory");
+        }
+        Err(_) => {
+            info!(datadir = %datadir.display(), "Creating data directory");
+            fs::create_dir_all(&datadir)?;
+        }
+    }
+
+    Ok(RuntimeConfig {
+        datadir,
+        bind_addr,
+        peer_nodes,
+        network,
+        ipc_socket,
+        rpc_server_addr,
+    })
 }
 #[allow(dead_code)]
 impl BraidpoolConfig {

--- a/node/src/default_braidpool_config.toml
+++ b/node/src/default_braidpool_config.toml
@@ -25,6 +25,8 @@ cookie_path="~/.bitcoin/regtest/.cookie"
 port="18443"
 #ip of the bitcoind node
 bitcoind_ip = "0.0.0.0"
+#path to the bitcoin ipc socket
+ipc_socket = "/tmp/bitcoin-cpunet.sock"
 
 #rpc server configuration
 [braid_rpc_config]

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -13,9 +13,7 @@ use libp2p::{
     swarm::SwarmEvent,
     PeerId,
 };
-use node::config::{
-    BraidpoolConfig, DEFAULT_BIND_ADDRESS, DEFAULT_BITCOIN_RPC_PORT, DEFAULT_P2P_PORT,
-};
+use node::config::{RuntimeConfig, DEFAULT_P2P_PORT};
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
@@ -203,135 +201,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let main_task_token = CancellationToken::new();
     let ipc_task_token = main_task_token.clone();
     let args = cli::Cli::parse();
-
-    let config_path = node::config::expand_pathbuf(&args.config);
-    if !config_path.exists() {
-        error!(path = %config_path.display(), "Config file not found");
-        return Err(std::io::Error::new(
-            std::io::ErrorKind::NotFound,
-            format!("Config file not found at {}", config_path.display()),
-        )
-        .into());
-    }
-    info!(path = %config_path.display(), "Loading braidpool config");
-    let braidpool_config = match BraidpoolConfig::load_from_config_file(
-        config_path
-            .to_str()
-            .expect("Failed to convert config path to string"),
-    ) {
-        Ok(c) => c,
-        Err(e) => {
-            error!(error = %e, path = %config_path.display(), "Invalid configuration file");
-            return Err(e);
-        }
-    };
-
-    let datadir = match args.datadir.as_ref() {
-        Some(path) => node::config::expand_pathbuf(path),
-        None => node::config::expand_path(&braidpool_config.braid_directory.path),
-    };
-
-    let bind_addr = args
-        .bind
-        .clone()
-        .or_else(|| {
-            node::config::socket_from_multiaddr(
-                &braidpool_config.braidnetwork_config.listen_address,
-            )
-        })
-        .unwrap_or_else(|| DEFAULT_BIND_ADDRESS.to_string());
-
-    let mut peer_nodes = braidpool_config.braidnetwork_config.peer_nodes.clone();
-    if let Some(nodes) = args.addnode.clone() {
-        peer_nodes.extend(nodes);
-    }
-
-    let network = match args.network.as_deref() {
-        Some(network_name) => match node::config::parse_network_arg(network_name) {
-            Some(parsed) => parsed,
-            None => {
-                error!(
-                    network = %network_name,
-                    valid_networks = "main, testnet, testnet4, signet, regtest, cpunet",
-                    "Invalid network specified, falling back to config value"
-                );
-                braidpool_config.bitcoin_config.network
-            }
-        },
-        None => braidpool_config.bitcoin_config.network,
-    };
-
-    let ipc_socket = braidpool_config
-        .bitcoin_config
-        .ipc_socket
-        .clone()
-        .unwrap_or(args.ipc_socket.clone());
-
-    let rpc_server_addr = braidpool_config.braid_rpc_config.rpc_server_addr.clone();
-
-    // Parse Bitcoin RPC configuration from args or config
-    let bitcoin_node = args
-        .bitcoin
-        .clone()
-        .unwrap_or_else(|| braidpool_config.bitcoin_config.bitcoind_ip.clone());
-
-    let rpc_port = args
-        .rpcport
-        .or_else(|| {
-            braidpool_config
-                .bitcoin_config
-                .port
-                .parse::<u16>()
-                .map_err(|e| {
-                    error!("Invalid port number in config: {}", e);
-                    e
-                })
-                .ok()
-        })
-        .unwrap_or(DEFAULT_BITCOIN_RPC_PORT);
-
-    let rpc_user = args
-        .rpcuser
-        .clone()
-        .unwrap_or_else(|| braidpool_config.bitcoin_config.username.clone());
-
-    let _rpc_pass = args
-        .rpcpass
-        .clone()
-        .unwrap_or_else(|| braidpool_config.bitcoin_config.password.clone());
-
-    let _rpc_cookie = args
-        .rpccookie
-        .clone()
-        .map(|p| node::config::expand_path(&p))
-        .or_else(|| {
-            Some(node::config::expand_path(
-                &braidpool_config.bitcoin_config.cookie_path,
-            ))
-        });
-
-    info!(
-        bitcoin_node = %bitcoin_node,
-        rpc_port = %rpc_port,
-        rpc_user = %rpc_user,
-        "Bitcoin RPC configuration loaded"
-    );
-
-    match fs::metadata(&datadir) {
-        Ok(m) => {
-            if !m.is_dir() {
-                error!(
-                    datadir = %datadir.display(),
-                    "Data directory exists but is not a directory"
-                );
-            }
-            info!(datadir = %datadir.display(), "Using existing data directory");
-        }
-        Err(_) => {
-            info!(datadir = %datadir.display(), "Creating data directory");
-            fs::create_dir_all(&datadir)?;
-        }
-    }
+    let RuntimeConfig {
+        datadir,
+        bind_addr,
+        peer_nodes,
+        network,
+        ipc_socket,
+        rpc_server_addr,
+    } = node::config::load_runtime_config(&args)?;
 
     let datadir_path = datadir.as_path();
     let keystore_path = datadir_path.join("keystore");

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -477,20 +477,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
     // peer_manager_arc is created above and shared between swarm and RPC server
     //spawning the rpc server
-    let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
     let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args).unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     });
-    let server_join = tokio::spawn(run_rpc_server(
-        Arc::clone(&braid),
-        rpc_addr,
-        peer_manager_arc.clone(),
-        connection_mapping_for_rpc.clone(),
-        latest_template.clone(),
-        rpc_proxy_tx,
-        bitcoin_rpc_config,
-    ));
+    let rpc_server_addr_clone = rpc_server_addr.clone();
+    let braid_for_rpc = Arc::clone(&braid);
+    let peer_manager_for_rpc = peer_manager_arc.clone();
+    let connection_mapping_for_rpc_clone = connection_mapping_for_rpc.clone();
+    let latest_template_for_rpc = latest_template.clone();
+    let server_join = tokio::spawn(async move {
+        run_rpc_server(
+            braid_for_rpc,
+            &rpc_server_addr_clone,
+            peer_manager_for_rpc,
+            connection_mapping_for_rpc_clone,
+            latest_template_for_rpc,
+            rpc_proxy_tx,
+            bitcoin_rpc_config,
+        )
+        .await
+    });
     match server_join.await {
         Ok(Ok(_addr)) => {}
         Ok(Err(())) => {

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -13,7 +13,9 @@ use libp2p::{
     swarm::SwarmEvent,
     PeerId,
 };
-use node::config::BraidpoolConfig;
+use node::config::{
+    BraidpoolConfig, DEFAULT_BIND_ADDRESS, DEFAULT_BITCOIN_RPC_PORT, DEFAULT_P2P_PORT,
+};
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
@@ -237,7 +239,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 &braidpool_config.braidnetwork_config.listen_address,
             )
         })
-        .unwrap_or_else(|| "0.0.0.0:6680".to_string());
+        .unwrap_or_else(|| DEFAULT_BIND_ADDRESS.to_string());
 
     let mut peer_nodes = braidpool_config.braidnetwork_config.peer_nodes.clone();
     if let Some(nodes) = args.addnode.clone() {
@@ -286,7 +288,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 })
                 .ok()
         })
-        .unwrap_or(18443);
+        .unwrap_or(DEFAULT_BITCOIN_RPC_PORT);
 
     let rpc_user = args
         .rpcuser
@@ -402,12 +404,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         .build();
     let socket_addr: std::net::SocketAddr = match bind_addr.parse() {
         Ok(addr) => addr,
-        Err(_) => format!("{}:6680", bind_addr).parse().map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Failed to parse bind address: {}", e),
-            )
-        })?,
+        Err(_) => format!("{}:{}", bind_addr, DEFAULT_P2P_PORT)
+            .parse()
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Failed to parse bind address: {}", e),
+                )
+            })?,
     };
     let multi_addr: Multiaddr = format!(
         "/ip4/{}/udp/{}/quic-v1",

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,4 @@
 use bitcoin::consensus::encode::deserialize;
-use bitcoin::Network;
 use clap::Parser;
 use futures::lock::Mutex;
 use futures::StreamExt;
@@ -14,6 +13,7 @@ use libp2p::{
     swarm::SwarmEvent,
     PeerId,
 };
+use node::config::BraidpoolConfig;
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
@@ -33,7 +33,6 @@ use node::{
 };
 use std::collections::HashSet;
 use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{SystemTime, UNIX_EPOCH};
@@ -54,10 +53,12 @@ const SEED_DNS: &str = "/dnsaddr/french.braidpool.net";
 //combined addr for dns resolution and dialing of boot for peer discovery
 const ADDR_REFRENCE: &str =
     "/dnsaddr/french.braidpool.net/p2p/12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3";
+
 use tokio::sync::{
     mpsc::{self},
     RwLock,
 };
+
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize tracing with colors and module prefixes
@@ -200,32 +201,137 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let main_task_token = CancellationToken::new();
     let ipc_task_token = main_task_token.clone();
     let args = cli::Cli::parse();
-    let datadir_str = args.datadir.to_str().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Invalid datadir path encoding",
+
+    let config_path = node::config::expand_pathbuf(&args.config);
+    if !config_path.exists() {
+        error!(path = %config_path.display(), "Config file not found");
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("Config file not found at {}", config_path.display()),
         )
-    })?;
-    let datadir = shellexpand::full(datadir_str).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Shell expansion failed: {}", e),
-        )
-    })?;
-    match fs::metadata(&*datadir) {
+        .into());
+    }
+    info!(path = %config_path.display(), "Loading braidpool config");
+    let braidpool_config = match BraidpoolConfig::load_from_config_file(
+        config_path
+            .to_str()
+            .expect("Failed to convert config path to string"),
+    ) {
+        Ok(c) => c,
+        Err(e) => {
+            error!(error = %e, path = %config_path.display(), "Invalid configuration file");
+            return Err(e);
+        }
+    };
+
+    let datadir = match args.datadir.as_ref() {
+        Some(path) => node::config::expand_pathbuf(path),
+        None => node::config::expand_path(&braidpool_config.braid_directory.path),
+    };
+
+    let bind_addr = args
+        .bind
+        .clone()
+        .or_else(|| {
+            node::config::socket_from_multiaddr(
+                &braidpool_config.braidnetwork_config.listen_address,
+            )
+        })
+        .unwrap_or_else(|| "0.0.0.0:6680".to_string());
+
+    let mut peer_nodes = braidpool_config.braidnetwork_config.peer_nodes.clone();
+    if let Some(nodes) = args.addnode.clone() {
+        peer_nodes.extend(nodes);
+    }
+
+    let network = match args.network.as_deref() {
+        Some(network_name) => match node::config::parse_network_arg(network_name) {
+            Some(parsed) => parsed,
+            None => {
+                error!(
+                    network = %network_name,
+                    valid_networks = "main, testnet, testnet4, signet, regtest, cpunet",
+                    "Invalid network specified, falling back to config value"
+                );
+                braidpool_config.bitcoin_config.network
+            }
+        },
+        None => braidpool_config.bitcoin_config.network,
+    };
+
+    let ipc_socket = braidpool_config
+        .bitcoin_config
+        .ipc_socket
+        .clone()
+        .unwrap_or(args.ipc_socket.clone());
+
+    let rpc_server_addr = braidpool_config.braid_rpc_config.rpc_server_addr.clone();
+
+    // Parse Bitcoin RPC configuration from args or config
+    let bitcoin_node = args
+        .bitcoin
+        .clone()
+        .unwrap_or_else(|| braidpool_config.bitcoin_config.bitcoind_ip.clone());
+
+    let rpc_port = args
+        .rpcport
+        .or_else(|| {
+            braidpool_config
+                .bitcoin_config
+                .port
+                .parse::<u16>()
+                .map_err(|e| {
+                    error!("Invalid port number in config: {}", e);
+                    e
+                })
+                .ok()
+        })
+        .unwrap_or(18443);
+
+    let rpc_user = args
+        .rpcuser
+        .clone()
+        .unwrap_or_else(|| braidpool_config.bitcoin_config.username.clone());
+
+    let _rpc_pass = args
+        .rpcpass
+        .clone()
+        .unwrap_or_else(|| braidpool_config.bitcoin_config.password.clone());
+
+    let _rpc_cookie = args
+        .rpccookie
+        .clone()
+        .map(|p| node::config::expand_path(&p))
+        .or_else(|| {
+            Some(node::config::expand_path(
+                &braidpool_config.bitcoin_config.cookie_path,
+            ))
+        });
+
+    info!(
+        bitcoin_node = %bitcoin_node,
+        rpc_port = %rpc_port,
+        rpc_user = %rpc_user,
+        "Bitcoin RPC configuration loaded"
+    );
+
+    match fs::metadata(&datadir) {
         Ok(m) => {
             if !m.is_dir() {
-                error!(datadir = %datadir, "Data directory exists but is not a directory");
+                error!(
+                    datadir = %datadir.display(),
+                    "Data directory exists but is not a directory"
+                );
             }
-            info!(datadir = %datadir, "Using existing data directory");
+            info!(datadir = %datadir.display(), "Using existing data directory");
         }
         Err(_) => {
-            info!(datadir = %datadir, "Creating data directory");
-            fs::create_dir_all(&*datadir)?;
+            info!(datadir = %datadir.display(), "Creating data directory");
+            fs::create_dir_all(&datadir)?;
         }
     }
 
-    let datadir_path = Path::new(&*datadir);
+    let datadir_path = datadir.as_path();
     let keystore_path = datadir_path.join("keystore");
     #[cfg(unix)]
     {
@@ -294,9 +400,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
         })?
         .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
         .build();
-    let socket_addr: std::net::SocketAddr = match args.bind.parse() {
+    let socket_addr: std::net::SocketAddr = match bind_addr.parse() {
         Ok(addr) => addr,
-        Err(_) => format!("{}:6680", args.bind).parse().map_err(|e| {
+        Err(_) => format!("{}:6680", bind_addr).parse().map_err(|e| {
             std::io::Error::new(
                 std::io::ErrorKind::InvalidInput,
                 format!("Failed to parse bind address: {}", e),
@@ -355,31 +461,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     swarm.dial(boot_addr)?;
     info!(address = %ADDR_REFRENCE, "Dialed boot node");
     //IPC(inter process communication) based `getblocktemplate` and `notification` to send to the downstream via the `cmempoold` architecture
-    info!(socket = %args.ipc_socket, "IPC socket path");
+    info!(socket = %ipc_socket, "IPC socket path");
+    info!(network = ?network, "Network selected");
 
-    let network = if let Some(network_name) = &args.network {
-        info!(network = %network_name, "Network selected");
-        match network_name.as_str() {
-            "main" | "mainnet" => Network::Bitcoin,
-            "testnet" | "testnet4" => Network::Testnet(bitcoin::TestnetVersion::V4),
-            "signet" => Network::Signet,
-            "regtest" => Network::Regtest,
-            "cpunet" => Network::CPUNet,
-            _ => {
-                error!(
-                    network = %network_name,
-                    valid_networks = "main, testnet, testnet4, signet, regtest, cpunet",
-                    "Invalid network specified"
-                );
-                info!(fallback = "regtest", "Using fallback network");
-                Network::Regtest
-            }
-        }
-    } else {
-        Network::Bitcoin
-    };
-
-    let ipc_socket_path_for_blocking = args.ipc_socket.clone();
+    let ipc_socket_path_for_blocking = ipc_socket.clone();
     let notification_tx_for_ipc = notification_tx.clone();
     let latest_template_for_ipc = latest_template.clone();
     let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
@@ -503,8 +588,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         });
     });
 
-    if let Some(addnode) = args.addnode {
-        for node in addnode.iter() {
+    if !peer_nodes.is_empty() {
+        for node in peer_nodes.iter() {
             let node_multiaddr: Multiaddr = match node.parse() {
                 Ok(addr) => addr,
                 Err(e) => {

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -1213,9 +1213,9 @@ pub async fn test_same_bead_extend() {
         },
         None, // No Bitcoin RPC config for tests
     );
+    let addr = server.local_addr().unwrap();
     let _handle = server.start(rpc_impl.into_rpc());
 
-    let addr = server.local_addr().unwrap();
     let target_uri = format!("http://{}", addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
@@ -1268,9 +1268,9 @@ pub async fn test_cohort_count_rpc() {
         },
         None, // No Bitcoin RPC config for tests
     );
+    let addr = server.local_addr().unwrap();
     let _handle = server.start(rpc_impl.into_rpc());
 
-    let addr = server.local_addr().unwrap();
     let target_uri = format!("http://{}", addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -223,7 +223,9 @@ impl BitcoinRpcConfig {
                 .bitcoin
                 .clone()
                 .unwrap_or_else(|| "127.0.0.1".to_string()),
-            port: args.rpcport.unwrap_or(crate::config::DEFAULT_BITCOIN_RPC_PORT),
+            port: args
+                .rpcport
+                .unwrap_or(crate::config::DEFAULT_BITCOIN_RPC_PORT),
             username: username.clone(),
             password: password.clone(),
             client,

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -219,8 +219,11 @@ impl BitcoinRpcConfig {
             .map_err(|e| format!("Failed to create HTTP client: {}", e))?;
 
         Ok(Some(Self {
-            host: args.bitcoin.clone(),
-            port: args.rpcport,
+            host: args
+                .bitcoin
+                .clone()
+                .unwrap_or_else(|| "127.0.0.1".to_string()),
+            port: args.rpcport.unwrap_or(crate::config::DEFAULT_BITCOIN_RPC_PORT),
             username: username.clone(),
             password: password.clone(),
             client,

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -1194,7 +1194,7 @@ pub async fn test_same_bead_extend() {
         jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
     let server = jsonrpsee::server::Server::builder()
         .set_rpc_middleware(rpc_middleware)
-        .build("127.0.0.1:8889")
+        .build("127.0.0.1:0")
         .await
         .unwrap();
     let rpc_impl = RpcServerImpl::new(
@@ -1210,8 +1210,8 @@ pub async fn test_same_bead_extend() {
     );
     let _handle = server.start(rpc_impl.into_rpc());
 
-    let server_addr = "127.0.0.1:8889";
-    let target_uri = format!("http://{}", server_addr);
+    let addr = server.local_addr().unwrap();
+    let target_uri = format!("http://{}", addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
     let new_bead = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
@@ -1249,7 +1249,7 @@ pub async fn test_cohort_count_rpc() {
         jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
     let server = jsonrpsee::server::Server::builder()
         .set_rpc_middleware(rpc_middleware)
-        .build("127.0.0.1:9000")
+        .build("127.0.0.1:0")
         .await
         .unwrap();
     let rpc_impl = RpcServerImpl::new(
@@ -1265,8 +1265,8 @@ pub async fn test_cohort_count_rpc() {
     );
     let _handle = server.start(rpc_impl.into_rpc());
 
-    let server_addr = "127.0.0.1:9000";
-    let target_uri = format!("http://{}", server_addr);
+    let addr = server.local_addr().unwrap();
+    let target_uri = format!("http://{}", addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
     let test_bead_2_json_str =


### PR DESCRIPTION
#327 
- Update `node/src/main.rs` to parse the TOML config file specified by the `--config` flag.
- Implement merging strategy: CLI arguments take precedence over config file values, falling back to defaults if neither are present.
- Ensure `BraidpoolConfig` is actively used to drive node settings (RPC, network, bind address).
- Enable active usage of `default_braidpool_config.tomlfeat: implement config file loading with CLI override priority

- Update `node/src/main.rs` to parse the TOML config file specified by the `--config` flag.
- Implement merging strategy: CLI arguments take precedence over config file values, falling back to defaults if neither are present.
- Ensure `BraidpoolConfig` is actively used to drive node settings (RPC, network, bind address).
- Enable active usage of `default_braidpool_config.toml