### PR TITLE
Fix Node Health layout to use full width 

### DIFF
--- a/dashboard/src/components/NodeHealth/Mempool.tsx
+++ b/dashboard/src/components/NodeHealth/Mempool.tsx
@@ -5,7 +5,7 @@ export default function MempoolPanel({ mempool }: { mempool: MempoolInfo }) {
   const mempoolUsage = (mempool.usage / mempool.maxmempool) * 100;
 
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 gap-6 w-full">
       {/* Stats Card */}
       <div className="bg-[#1e1e1e] border border-gray-700 rounded-lg p-6 backdrop-blur-sm">
         <div className="mb-4">

--- a/dashboard/src/components/NodeHealth/Mempool.tsx
+++ b/dashboard/src/components/NodeHealth/Mempool.tsx
@@ -5,7 +5,7 @@ export default function MempoolPanel({ mempool }: { mempool: MempoolInfo }) {
   const mempoolUsage = (mempool.usage / mempool.maxmempool) * 100;
 
   return (
-    <div className="grid grid-cols-1 gap-6 max-w-6xl mx-auto px-4 w-full">
+    <div className="grid grid-cols-1 gap-6 px-4 w-full">
       {/* Stats Card */}
       <div className="bg-[#1e1e1e] border border-gray-700 rounded-lg p-6 backdrop-blur-sm">
         <div className="mb-4">

--- a/dashboard/src/components/NodeHealth/Mempool.tsx
+++ b/dashboard/src/components/NodeHealth/Mempool.tsx
@@ -5,7 +5,7 @@ export default function MempoolPanel({ mempool }: { mempool: MempoolInfo }) {
   const mempoolUsage = (mempool.usage / mempool.maxmempool) * 100;
 
   return (
-    <div className="grid grid-cols-1 gap-6 w-full">
+    <div className="grid grid-cols-1 gap-6 max-w-6xl mx-auto px-4 w-full">
       {/* Stats Card */}
       <div className="bg-[#1e1e1e] border border-gray-700 rounded-lg p-6 backdrop-blur-sm">
         <div className="mb-4">

--- a/dashboard/src/components/NodeHealth/Mempool.tsx
+++ b/dashboard/src/components/NodeHealth/Mempool.tsx
@@ -29,14 +29,14 @@ export default function MempoolPanel({ mempool }: { mempool: MempoolInfo }) {
             </div>
           </div>
 
-          <div className="grid grid-cols-2 gap-4">
+          <div className="flex justify-between">
             <div>
               <p className="text-sm font-medium text-gray-300">Transactions</p>
               <p className="text-2xl font-bold text-white">
                 {mempool.size.toLocaleString()}
               </p>
             </div>
-            <div>
+            <div className="text-right">
               <p className="text-sm font-medium text-gray-300">Min Fee Rate</p>
               <p className="font-mono text-white">
                 {mempool.mempoolminfee.toFixed(8)} BTC/kvB

--- a/dashboard/src/components/NodeHealth/Network.tsx
+++ b/dashboard/src/components/NodeHealth/Network.tsx
@@ -2,7 +2,7 @@ import { NetworkPanelProps } from './Types';
 
 export default function NetworkPanel({ network }: NetworkPanelProps) {
   return (
-    <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+    <div className="grid grid-cols-1 gap-6 px-4 w-full">
       <div className="bg-[#1e1e1e] border border-gray-700 rounded-xl backdrop-blur-sm p-6">
         <h2 className="text-white text-lg font-semibold mb-4">
           Network Status

--- a/dashboard/src/components/NodeHealth/NodeHealth.tsx
+++ b/dashboard/src/components/NodeHealth/NodeHealth.tsx
@@ -286,7 +286,7 @@ const NodeHealth: React.FC = () => {
           {TABS.map((tab) => (
             <button
               key={tab.value}
-              className={`py-2 border-b-2 ${activeTab === tab.value ? 'text-white border-blue-900' : 'text-gray-500 border-transparent'}`}
+              className={`py-2 border-b-2 ${activeTab === tab.value ? 'text-white border-blue-900' : 'text-gray-500 cursor-pointer border-transparent'}`}
               onClick={() => setActiveTab(tab.value)}
             >
               {tab.label}
@@ -298,7 +298,7 @@ const NodeHealth: React.FC = () => {
       {/* Tab Content */}
       <div className="mt-6">
         {activeTab === 'blockchain' && blockchainInfo && (
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
+          <div className="grid grid-cols-1 gap-6 px-3 w-full">
             <div className="rounded-xl border border-gray-700 p-4">
               <h3 className="text-base md:text-lg text-white font-semibold text-center mb-4">
                 Blockchain Information


### PR DESCRIPTION
## Description

This PR resolves layout issues in the Node Health tab where the Blockchain, Mempool, and Network sections were not utilizing the full available container width.

Each section was constrained by restrictive max-width utility classes, resulting in unused empty space on the right side and an unbalanced layout.

## Changes Made

- Removed unnecessary `max-w-*` and centering utility classes.
- Ensured sections use `w-full` to span the full available width.
- Maintained consistent padding and spacing with the rest of the dashboard.

## Result

- Blockchain, Mempool, and Network sections now span the full container width.
- Improved visual balance and readability.
- Consistent layout behavior across all Node Health tabs.

## Related Issues

Closes #366  
Closes #367  
Closes #368
