### PR TITLE
docs: add contributing section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,19 @@ Read the
 [Overview](https://github.com/braidpool/braidpool/blob/master/docs/overview.md)
 for [General Considerations for Decentralized Mining Pools](https://github.com/braidpool/braidpool/blob/master/docs/general_considerations.md), or [Braidpool Spec](https://github.com/braidpool/braidpool/blob/master/docs/braidpool_spec.md) in increasing levels of complexity. You may also be interested in our [Roadmap](https://github.com/braidpool/braidpool/blob/master/docs/roadmap.md)
 
+## Contributing
+
+Contributions are welcome and appreciated.
+
+If you are interested in contributing to Braidpool, please read
+[CONTRIBUTING.md](CONTRIBUTING.md) for detailed guidelines on:
+
+1. setting up the development environment.
+2. understanding the project structure.
+3. development workflow and conventions.
+4. creating branches and submitting pull requests.
+
+
 The goals of the pool are:
 
 1. Lower variance for independent miners, even when large miners join the pool.


### PR DESCRIPTION
### Summary
Add a dedicated **Contributing** section to the README that links to the existing `CONTRIBUTING.md`.

### Motivation
The repository already includes detailed contribution guidelines, but they are not currently referenced from the README. Adding this section improves discoverability and reduces friction for first-time contributors.

### Changes
1.  Add a Contributing section to README.md with a clear link to CONTRIBUTING.md
