### PR TITLE
fix: resolve month dropdown visibility issue in beads explorer

### DIFF
--- a/dashboard/src/components/MinerDashboard/DateRangePicker.tsx
+++ b/dashboard/src/components/MinerDashboard/DateRangePicker.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 
-import { useState } from 'react';
+import { useState, useRef, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import { motion, AnimatePresence } from 'framer-motion';
 import { ChevronDown, Calendar } from 'lucide-react';
 
@@ -14,6 +15,46 @@ export default function DateRangePicker({
   setTimeRange: (range: string) => void;
 }) {
   const [isOpen, setIsOpen] = useState(false);
+  const buttonRef = useRef<HTMLButtonElement>(null);
+  const [menuPosition, setMenuPosition] = useState({ top: 0, left: 0 });
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const updatePosition = () => {
+      const rect = buttonRef.current?.getBoundingClientRect();
+      if (!rect) {
+        return;
+      }
+
+      const menuWidth = 192;
+      const margin = 8;
+      const scrollX = window.scrollX;
+      const scrollY = window.scrollY;
+
+      let left = rect.left + scrollX;
+      const maxLeft = window.innerWidth + scrollX - margin - menuWidth;
+      if (left > maxLeft) {
+        left = Math.max(margin + scrollX, maxLeft);
+      }
+
+      setMenuPosition({
+        top: rect.bottom + scrollY + margin,
+        left,
+      });
+    };
+
+    updatePosition();
+    window.addEventListener('scroll', updatePosition, true);
+    window.addEventListener('resize', updatePosition);
+
+    return () => {
+      window.removeEventListener('scroll', updatePosition, true);
+      window.removeEventListener('resize', updatePosition);
+    };
+  }, [isOpen]);
 
   const handleSelect = (range: string) => {
     setTimeRange(range);
@@ -21,8 +62,9 @@ export default function DateRangePicker({
   };
 
   return (
-    <div className="relative">
+    <div className="relative z-20">
       <button
+        ref={buttonRef}
         className="flex items-center gap-2 bg-gray-900/50 rounded-lg px-4 py-2 text-sm font-medium text-gray-200 hover:bg-gray-800/50 transition-colors"
         onClick={() => setIsOpen(!isOpen)}
       >
@@ -39,44 +81,49 @@ export default function DateRangePicker({
         </motion.div>
       </button>
 
-      <AnimatePresence>
-        {isOpen && (
-          <motion.div
-            className="absolute top-full left-0 mt-2 w-48 bg-gray-900/90 backdrop-blur-md border border-gray-800 rounded-lg shadow-lg z-50"
-            initial={{ opacity: 0, y: -10 }}
-            animate={{ opacity: 1, y: 0 }}
-            exit={{ opacity: 0, y: -10 }}
-            transition={{ duration: 0.2 }}
-          >
-            <div className="p-2">
-              {TIME_RANGES.map((range) => (
-                <button
-                  key={range.value}
-                  className={`w-full text-left px-3 py-2 rounded-md text-sm ${
-                    timeRange === range.value
-                      ? 'bg-blue-600/30 text-blue-200'
-                      : 'text-gray-300 hover:bg-gray-800/50'
-                  }`}
-                  onClick={() => handleSelect(range.value)}
-                >
-                  {range.label}
-                </button>
-              ))}
-              <div className="border-t border-gray-800 my-1 pt-1">
-                <button
-                  className="w-full text-left px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-gray-800/50"
-                  onClick={() => {
-                    // Custom date range functionality would go here
-                    setIsOpen(false);
-                  }}
-                >
-                  Custom Range...
-                </button>
-              </div>
-            </div>
-          </motion.div>
+      {typeof document !== 'undefined' &&
+        createPortal(
+          <AnimatePresence>
+            {isOpen && (
+              <motion.div
+                className="absolute w-48 bg-gray-900/90 backdrop-blur-md border border-gray-800 rounded-lg shadow-lg z-[9999]"
+                style={{ top: menuPosition.top, left: menuPosition.left }}
+                initial={{ opacity: 0, y: -10 }}
+                animate={{ opacity: 1, y: 0 }}
+                exit={{ opacity: 0, y: -10 }}
+                transition={{ duration: 0.2 }}
+              >
+                <div className="p-2">
+                  {TIME_RANGES.map((range) => (
+                    <button
+                      key={range.value}
+                      className={`w-full text-left px-3 py-2 rounded-md text-sm ${
+                        timeRange === range.value
+                          ? 'bg-blue-600/30 text-blue-200'
+                          : 'text-gray-300 hover:bg-gray-800/50'
+                      }`}
+                      onClick={() => handleSelect(range.value)}
+                    >
+                      {range.label}
+                    </button>
+                  ))}
+                  <div className="border-t border-gray-800 my-1 pt-1">
+                    <button
+                      className="w-full text-left px-3 py-2 rounded-md text-sm text-gray-300 hover:bg-gray-800/50"
+                      onClick={() => {
+                        // Custom date range functionality would go here
+                        setIsOpen(false);
+                      }}
+                    >
+                      Custom Range...
+                    </button>
+                  </div>
+                </div>
+              </motion.div>
+            )}
+          </AnimatePresence>,
+          document.body
         )}
-      </AnimatePresence>
     </div>
   );
 }

--- a/dashboard/src/components/MinerDashboard/MinedSharesExplorer.tsx
+++ b/dashboard/src/components/MinerDashboard/MinedSharesExplorer.tsx
@@ -85,7 +85,7 @@ export default function MinedSharesExplorer() {
   return (
     <div
       ref={containerRef}
-      className="min-h-screen bg-gradient-to-br from-gray-900 via-[#0a0b1e] to-black text-white overflow-hidden relative perspective-1000"
+      className="min-h-screen bg-gradient-to-br from-gray-900 via-[#0a0b1e] to-black text-white overflow-x-hidden overflow-y-visible relative perspective-1000"
     >
       {/* Main content container */}
       <div className="relative z-10 container mx-auto px-4 py-8">


### PR DESCRIPTION
## 🐛 Fix Month Dropdown Visibility in Beads Explorer Filters

### Description
This PR fixes a **UI bug** in the **Beads Explorer → Filters** section where the **Month dropdown options** were partially hidden or clipped by surrounding UI elements.

The issue made it difficult for users to clearly view and select different time ranges.

---

### Related Issue
Fixes #379 

---

### Changes Made
- Adjusted dropdown positioning to prevent clipping
- Resolved overflow issues in the parent container
- Ensured all dropdown options are fully visible and accessible

---

### Before
- Dropdown options were partially hidden
- Poor usability when selecting time range filters

---

### After
- Dropdown options are fully visible
- Smooth and clear interaction with filter controls

---

### Screenshots
**Before fix:**  
<img width="1901" height="915" alt="Screenshot 2026-02-10 231404" src="https://github.com/user-attachments/assets/c7294131-1e7f-4585-9eca-67a6ad401872" />

**After fix:**  
<img width="1878" height="976" alt="Screenshot 2026-02-10 231323" src="https://github.com/user-attachments/assets/a7349d73-0118-4282-8713-a37e0eb030c6" />

---

### Testing
- Tested locally on desktop
- Verified dropdown works across different time ranges
- Confirmed no UI regression in related components

---

### Checklist
- [x] UI tested locally
- [x] No breaking changes
- [x] Follows existing code style

---

### Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Documentation update
