### PR TITLE
Adding task_manager for managing tasks and shutdown

### DIFF
--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -4,6 +4,7 @@ use crate::{
     bead::Bead,
     db::{init_db::init_db, BraidpoolDBTypes, InsertTupleTypes},
     error::DBErrors,
+    task_manager::TaskManager,
     utils::BeadHash,
 };
 use bitcoin::{
@@ -162,50 +163,71 @@ impl DBHandler {
         Ok(())
     }
     //Individual insertion operations
-    pub async fn insert_query_handler(&mut self) {
-        debug!("Query handler task started");
-        while let Some(query_request) = self.receiver.recv().await {
-            match query_request {
-                BraidpoolDBTypes::InsertTupleTypes { query } => match query {
-                    InsertTupleTypes::InsertBeadSequentially {
-                        bead_to_insert,
-                        txs_json,
-                        relative_json,
-                        parent_timestamp_json,
-                        bead_id,
-                    } => {
-                        let bead_hash = bead_to_insert.block_header.block_hash();
-                        match self
-                            .insert_bead(
-                                bead_to_insert,
-                                txs_json,
-                                relative_json,
-                                parent_timestamp_json,
-                                &bead_id,
-                            )
-                            .await
-                        {
-                            Ok(_) => {
-                                debug!(
-                                    bead_id = bead_id,
-                                    bead_hash = %bead_hash,
-                                    "Bead inserted successfully"
-                                );
-                            }
-                            Err(error) => {
-                                error!(
-                                    error = ?error,
-                                    bead_id = bead_id,
-                                    bead_hash = %bead_hash,
-                                    "Failed to insert bead"
-                                );
-                                continue;
-                            }
+    pub async fn insert_query_handler(
+        mut self,
+        shutdown_tx: tokio::sync::mpsc::Sender<()>,
+        cancellation_token: tokio_util::sync::CancellationToken,
+        task_manager: Arc<TaskManager>,
+    ) {
+        task_manager.spawn(async move {
+            loop {
+                tokio::select! {
+                    query_request = self.receiver.recv() => {
+                        let Some(query_request) = query_request else {
+                            warn!("INVALID REQUEST BEING RECEIVED !");
+                            break;
                         };
+                        match query_request {
+                    BraidpoolDBTypes::InsertTupleTypes { query } => match query {
+                        InsertTupleTypes::InsertBeadSequentially {
+                            bead_to_insert,
+                            txs_json,
+                            relative_json,
+                            parent_timestamp_json,
+                            bead_id,
+                        } => {
+                            let bead_hash = bead_to_insert.block_header.block_hash();
+                            match self
+                                .insert_bead(
+                                    bead_to_insert,
+                                    txs_json,
+                                    relative_json,
+                                    parent_timestamp_json,
+                                    &bead_id,
+                                )
+                                .await
+                            {
+                                Ok(_) => {
+                                    debug!(
+                                        bead_id = bead_id,
+                                        bead_hash = %bead_hash,
+                                        "Bead inserted successfully"
+                                    );
+                                }
+                                Err(error) => {
+                                    error!(
+                                        error = ?error,
+                                        bead_id = bead_id,
+                                        bead_hash = %bead_hash,
+                                        "Failed to insert bead"
+                                    );
+                                    continue;
+                                }
+                            };
+                        }
+                    },
+                        }
                     }
-                },
+                    _ = cancellation_token.cancelled() => {
+                        debug!(component = "db_handler", "Shutdown signal received, exiting gracefully");
+                        break;
+                    }
+                }
             }
-        }
+            drop(shutdown_tx);
+            info!("db handler loop exited");
+        });
+        debug!("Query handler task started");
     }
 }
 pub fn prepare_bead_tuple_data(
@@ -298,148 +320,156 @@ pub async fn fetch_beads_in_batch(
     let num_batches = (total_rows + batch_size - 1) / batch_size;
 
     for batch_num in 0..num_batches {
-        let offset = batch_num * batch_size;
-        let rows = sqlx::query("SELECT * FROM BEAD LIMIT ? OFFSET ?")
-            .bind(batch_size)
-            .bind(offset)
-            .fetch_all(&conn)
-            .await
-            .map_err(|e| DBErrors::TupleNotFetched {
-                error: e.to_string(),
-            })?;
-        for row in rows {
-            let mut bead = Bead::default();
-
-            bead.block_header.version = BlockVersion::from_consensus(row.get::<i32, _>("nVersion"));
-            bead.block_header.bits = CompactTarget::from_consensus(row.get::<u32, _>("nBits"));
-            bead.block_header.time = BlockTime::from_u32(row.get::<u32, _>("nTime"));
-            bead.block_header.nonce = row.get::<u32, _>("nNonce");
-
-            let prev_bytes: Vec<u8> = row.get("hashPrevBlock");
-            bead.block_header.prev_blockhash =
-                BlockHash::from_byte_array(prev_bytes.try_into().map_err(|_| {
-                    DBErrors::TupleAttributeParsingError {
-                        error: "Invalid prev block hash length".into(),
-                        attribute: "hashPrevBlock".into(),
-                    }
-                })?);
-
-            let merkle_bytes: Vec<u8> = row.get("hashMerkleRoot");
-            bead.block_header.merkle_root =
-                TxMerkleNode::from_byte_array(merkle_bytes.try_into().map_err(|_| {
-                    DBErrors::TupleAttributeParsingError {
-                        error: "Invalid merkle root length".into(),
-                        attribute: "hashMerkleRoot".into(),
-                    }
-                })?);
-
-            bead.committed_metadata.payout_address =
-                String::from_utf8(row.get::<Vec<u8>, _>("payout_address")).map_err(|_| {
-                    DBErrors::TupleAttributeParsingError {
-                        error: "Invalid payout_address UTF-8".into(),
-                        attribute: "payout_address".into(),
-                    }
-                })?;
-
-            bead.committed_metadata.comm_pub_key =
-                PublicKey::from_slice(&row.get::<Vec<u8>, _>("comm_pub_key")).map_err(|_| {
-                    DBErrors::TupleAttributeParsingError {
-                        error: "Invalid comm_pub_key".into(),
-                        attribute: "comm_pub_key".into(),
-                    }
-                })?;
-
-            bead.committed_metadata.min_target =
-                CompactTarget::from_consensus(row.get::<u32, _>("min_target"));
-            bead.committed_metadata.weak_target =
-                CompactTarget::from_consensus(row.get::<u32, _>("weak_target"));
-            bead.committed_metadata.miner_ip = row.get("miner_ip");
-
-            bead.committed_metadata.start_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("start_timestamp")).unwrap();
-
-            bead.uncommitted_metadata.broadcast_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("broadcast_timestamp")).unwrap();
-
-            bead.uncommitted_metadata.extra_nonce_1 =
-                u32::from_str_radix(&row.get::<String, _>("extranonce1"), 16).unwrap();
-            bead.uncommitted_metadata.extra_nonce_2 =
-                u32::from_str_radix(&row.get::<String, _>("extranonce2"), 16).unwrap();
-
-            bead.uncommitted_metadata.signature =
-                Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).unwrap();
-
-            let current_bead_id = row.get::<i32, _>("id");
-
-            let tx_rows = sqlx::query("SELECT txid as txid FROM Transactions WHERE bead_id = ?")
-                .bind(current_bead_id)
+        if conn.is_closed() {
+            warn!("Connection to DB closed fetching beads loop exited !");
+            break;
+        } else {
+            let offset = batch_num * batch_size;
+            let rows = sqlx::query("SELECT * FROM BEAD LIMIT ? OFFSET ?")
+                .bind(batch_size)
+                .bind(offset)
                 .fetch_all(&conn)
                 .await
                 .map_err(|e| DBErrors::TupleNotFetched {
                     error: e.to_string(),
                 })?;
+            for row in rows {
+                let mut bead = Bead::default();
 
-            for tx in tx_rows {
-                let tx_bytes: Vec<u8> = tx.get("txid");
-                let arr: [u8; 32] =
-                    tx_bytes
-                        .try_into()
-                        .map_err(|_| DBErrors::TupleAttributeParsingError {
-                            error: "Invalid Txid length".into(),
-                            attribute: "txid".into(),
+                bead.block_header.version =
+                    BlockVersion::from_consensus(row.get::<i32, _>("nVersion"));
+                bead.block_header.bits = CompactTarget::from_consensus(row.get::<u32, _>("nBits"));
+                bead.block_header.time = BlockTime::from_u32(row.get::<u32, _>("nTime"));
+                bead.block_header.nonce = row.get::<u32, _>("nNonce");
+
+                let prev_bytes: Vec<u8> = row.get("hashPrevBlock");
+                bead.block_header.prev_blockhash =
+                    BlockHash::from_byte_array(prev_bytes.try_into().map_err(|_| {
+                        DBErrors::TupleAttributeParsingError {
+                            error: "Invalid prev block hash length".into(),
+                            attribute: "hashPrevBlock".into(),
+                        }
+                    })?);
+
+                let merkle_bytes: Vec<u8> = row.get("hashMerkleRoot");
+                bead.block_header.merkle_root =
+                    TxMerkleNode::from_byte_array(merkle_bytes.try_into().map_err(|_| {
+                        DBErrors::TupleAttributeParsingError {
+                            error: "Invalid merkle root length".into(),
+                            attribute: "hashMerkleRoot".into(),
+                        }
+                    })?);
+
+                bead.committed_metadata.payout_address =
+                    String::from_utf8(row.get::<Vec<u8>, _>("payout_address")).map_err(|_| {
+                        DBErrors::TupleAttributeParsingError {
+                            error: "Invalid payout_address UTF-8".into(),
+                            attribute: "payout_address".into(),
+                        }
+                    })?;
+
+                bead.committed_metadata.comm_pub_key = PublicKey::from_slice(
+                    &row.get::<Vec<u8>, _>("comm_pub_key"),
+                )
+                .map_err(|_| DBErrors::TupleAttributeParsingError {
+                    error: "Invalid comm_pub_key".into(),
+                    attribute: "comm_pub_key".into(),
+                })?;
+
+                bead.committed_metadata.min_target =
+                    CompactTarget::from_consensus(row.get::<u32, _>("min_target"));
+                bead.committed_metadata.weak_target =
+                    CompactTarget::from_consensus(row.get::<u32, _>("weak_target"));
+                bead.committed_metadata.miner_ip = row.get("miner_ip");
+
+                bead.committed_metadata.start_timestamp =
+                    MedianTimePast::from_u32(row.get::<u32, _>("start_timestamp")).unwrap();
+
+                bead.uncommitted_metadata.broadcast_timestamp =
+                    MedianTimePast::from_u32(row.get::<u32, _>("broadcast_timestamp")).unwrap();
+
+                bead.uncommitted_metadata.extra_nonce_1 =
+                    u32::from_str_radix(&row.get::<String, _>("extranonce1"), 16).unwrap();
+                bead.uncommitted_metadata.extra_nonce_2 =
+                    u32::from_str_radix(&row.get::<String, _>("extranonce2"), 16).unwrap();
+
+                bead.uncommitted_metadata.signature =
+                    Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).unwrap();
+
+                let current_bead_id = row.get::<i32, _>("id");
+
+                let tx_rows =
+                    sqlx::query("SELECT txid as txid FROM Transactions WHERE bead_id = ?")
+                        .bind(current_bead_id)
+                        .fetch_all(&conn)
+                        .await
+                        .map_err(|e| DBErrors::TupleNotFetched {
+                            error: e.to_string(),
                         })?;
-                bead.committed_metadata
-                    .transaction_ids
-                    .0
-                    .push(Txid::from_byte_array(arr));
+
+                for tx in tx_rows {
+                    let tx_bytes: Vec<u8> = tx.get("txid");
+                    let arr: [u8; 32] =
+                        tx_bytes
+                            .try_into()
+                            .map_err(|_| DBErrors::TupleAttributeParsingError {
+                                error: "Invalid Txid length".into(),
+                                attribute: "txid".into(),
+                            })?;
+                    bead.committed_metadata
+                        .transaction_ids
+                        .0
+                        .push(Txid::from_byte_array(arr));
+                }
+
+                let parent_rows =
+                    sqlx::query("SELECT parent, timestamp FROM ParentTimestamps WHERE child = ?")
+                        .bind(current_bead_id)
+                        .fetch_all(&conn)
+                        .await
+                        .map_err(|e| DBErrors::TupleNotFetched {
+                            error: e.to_string(),
+                        })?;
+
+                for parent in parent_rows {
+                    let parent_id = parent.get::<i64, _>("parent");
+                    let timestamp = parent.get::<i32, _>("timestamp");
+
+                    let parent_hash_row = sqlx::query("SELECT hash FROM BEAD WHERE id = ?")
+                        .bind(parent_id)
+                        .fetch_one(&conn)
+                        .await
+                        .map_err(|e| DBErrors::TupleNotFetched {
+                            error: e.to_string(),
+                        })?;
+
+                    match parent_hash_row.get::<Vec<u8>, _>("hash").try_into() {
+                        Ok(arr) => {
+                            bead.committed_metadata
+                                .parents
+                                .insert(BlockHash::from_byte_array(arr));
+                        }
+                        Err(_) => {
+                            return Err(DBErrors::TupleAttributeParsingError {
+                                error: "Invalid hash length".to_string(),
+                                attribute: "Parent bead hash".to_string(),
+                            });
+                        }
+                    };
+
+                    bead.committed_metadata
+                        .parent_bead_timestamps
+                        .0
+                        .push(MedianTimePast::from_u32(timestamp as u32).unwrap());
+                }
+
+                fetched_beads.push(bead);
             }
-
-            let parent_rows =
-                sqlx::query("SELECT parent, timestamp FROM ParentTimestamps WHERE child = ?")
-                    .bind(current_bead_id)
-                    .fetch_all(&conn)
-                    .await
-                    .map_err(|e| DBErrors::TupleNotFetched {
-                        error: e.to_string(),
-                    })?;
-
-            for parent in parent_rows {
-                let parent_id = parent.get::<i64, _>("parent");
-                let timestamp = parent.get::<i32, _>("timestamp");
-
-                let parent_hash_row = sqlx::query("SELECT hash FROM BEAD WHERE id = ?")
-                    .bind(parent_id)
-                    .fetch_one(&conn)
-                    .await
-                    .map_err(|e| DBErrors::TupleNotFetched {
-                        error: e.to_string(),
-                    })?;
-
-                match parent_hash_row.get::<Vec<u8>, _>("hash").try_into() {
-                    Ok(arr) => {
-                        bead.committed_metadata
-                            .parents
-                            .insert(BlockHash::from_byte_array(arr));
-                    }
-                    Err(_) => {
-                        return Err(DBErrors::TupleAttributeParsingError {
-                            error: "Invalid hash length".to_string(),
-                            attribute: "Parent bead hash".to_string(),
-                        });
-                    }
-                };
-
-                bead.committed_metadata
-                    .parent_bead_timestamps
-                    .0
-                    .push(MedianTimePast::from_u32(timestamp as u32).unwrap());
-            }
-
-            fetched_beads.push(bead);
         }
-    }
 
-    Ok(fetched_beads)
+        return Ok(fetched_beads);
+    }
+    Ok(Vec::new())
 }
 //Fetching single bead
 pub async fn fetch_bead_by_bead_hash(

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -4,6 +4,7 @@ use crate::{
     bead::Bead,
     db::{init_db::init_db, BraidpoolDBTypes, InsertTupleTypes},
     error::DBErrors,
+    status::{handle_error, ShutdownMessage, Status, StatusSender, TaskError},
     task_manager::TaskManager,
     utils::BeadHash,
 };
@@ -168,13 +169,20 @@ impl DBHandler {
         shutdown_tx: tokio::sync::mpsc::Sender<()>,
         cancellation_token: tokio_util::sync::CancellationToken,
         task_manager: Arc<TaskManager>,
+        status_tx: tokio::sync::mpsc::UnboundedSender<Status>,
+        mut shutdown_rx: tokio::sync::broadcast::Receiver<ShutdownMessage>,
     ) {
         task_manager.spawn(async move {
             loop {
                 tokio::select! {
                     query_request = self.receiver.recv() => {
                         let Some(query_request) = query_request else {
-                            warn!("INVALID REQUEST BEING RECEIVED !");
+                            error!("DB query receiver channel closed");
+                            let status_sender = StatusSender::DatabaseHandler(status_tx.clone());
+                            let complete_shutdown_or_not = handle_error(&status_sender, TaskError::DatabaseError { error: "Query receiver channel closed".to_string() }).await;
+                            if complete_shutdown_or_not {
+                                warn!("DB handler channel closed, initiating shutdown");
+                            }
                             break;
                         };
                         match query_request {
@@ -211,11 +219,32 @@ impl DBHandler {
                                         bead_hash = %bead_hash,
                                         "Failed to insert bead"
                                     );
+                                    let status_sender = StatusSender::DatabaseHandler(status_tx.clone());
+                                    let _ = handle_error(&status_sender, TaskError::from_db_error(error)).await;
                                     continue;
                                 }
                             };
                         }
                     },
+                        }
+                    }
+                    shutdown_msg = shutdown_rx.recv() => {
+                        match shutdown_msg {
+                            Ok(msg) => {
+                                match msg {
+                                    ShutdownMessage::ShutdownAll => {
+                                        info!("DB handler received shutdown signal, stopping handler");
+                                        break;
+                                    }
+                                    _ => {
+                                        debug!("DB handler received shutdown variant: {:?}, continuing operation", msg);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                error!(error = ?e, "Error receiving shutdown signal in DB handler");
+                                break;
+                            }
                         }
                     }
                     _ = cancellation_token.cancelled() => {

--- a/node/src/ibd_manager/mod.rs
+++ b/node/src/ibd_manager/mod.rs
@@ -1,9 +1,9 @@
-use std::{collections::HashMap, u64};
-
 use libp2p::PeerId;
+use std::{collections::HashMap, u64};
 use tokio::task::JoinHandle;
+use tracing::warn;
 
-use crate::utils::BeadHash;
+use crate::{task_manager::TaskManager, utils::BeadHash};
 pub const IBD_BATCH_SIZE: usize = 500;
 pub const MAX_IBD_RETRIES: u64 = 10;
 pub const IBD_TRIGGER_AFTER: u64 = 20;
@@ -118,8 +118,19 @@ impl IBDManager {
             ibd_tx,
         )
     }
-    pub async fn run_ibd_handler(&mut self) {
-        while let Some(ibd_command) = self.command_receiver.recv().await {
+    pub async fn run_ibd_handler(
+        mut self,
+        shutdown_tx: tokio::sync::mpsc::Sender<()>,
+        cancellation_token: tokio_util::sync::CancellationToken,
+        task_manager: std::sync::Arc<TaskManager>,
+    ) {
+        task_manager.spawn(async move {
+            loop {
+            tokio::select! {
+                ibd_command = self.command_receiver.recv() => {
+                    let Some(ibd_command) = ibd_command else {
+                        break;
+                    };
             match ibd_command {
                 IBDCommands::UpdateAndFetchBatchOffset {
                     peer_id,
@@ -308,7 +319,16 @@ impl IBDManager {
                         incoming_mapping.1 = None;
                     };
                 }
+                    }
+                }
+                _ = cancellation_token.cancelled() => {
+                    tracing::info!(component = "ibd_handler", "Shutdown signal received, exiting gracefully");
+                    break;
+                }
             }
         }
+        drop(shutdown_tx);
+        warn!("IBD manager loop exited");
+        });
     }
 }

--- a/node/src/ibd_manager/mod.rs
+++ b/node/src/ibd_manager/mod.rs
@@ -3,7 +3,11 @@ use std::{collections::HashMap, u64};
 use tokio::task::JoinHandle;
 use tracing::warn;
 
-use crate::{task_manager::TaskManager, utils::BeadHash};
+use crate::{
+    status::{ShutdownMessage, Status},
+    task_manager::TaskManager,
+    utils::BeadHash,
+};
 pub const IBD_BATCH_SIZE: usize = 500;
 pub const MAX_IBD_RETRIES: u64 = 10;
 pub const IBD_TRIGGER_AFTER: u64 = 20;
@@ -123,6 +127,8 @@ impl IBDManager {
         shutdown_tx: tokio::sync::mpsc::Sender<()>,
         cancellation_token: tokio_util::sync::CancellationToken,
         task_manager: std::sync::Arc<TaskManager>,
+        _status_tx: tokio::sync::mpsc::UnboundedSender<Status>,
+        _shutdown_rx: tokio::sync::broadcast::Receiver<ShutdownMessage>,
     ) {
         task_manager.spawn(async move {
             loop {

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -49,7 +49,9 @@ pub mod ibd_manager;
 pub mod ipc;
 pub mod peer_manager;
 pub mod rpc_server;
+pub mod status;
 pub mod stratum;
+pub mod task_manager;
 pub mod template_creator;
 pub mod uncommitted_metadata;
 pub mod utils;
@@ -128,7 +130,7 @@ pub const EXTRANONCE_SEPARATOR: [u8; EXTRANONCE1_SIZE + EXTRANONCE2_SIZE] =
 /// * `Err(IPCtemplateError)` - If an unrecoverable IPC template handling error occurs.
 pub async fn ipc_template_consumer(
     mut template_rx: mpsc::Receiver<Arc<crate::ipc::client::BlockTemplate>>,
-    notifier_tx: mpsc::Sender<NotifyCmd>,
+    notifier_tx: mpsc::UnboundedSender<NotifyCmd>,
     latest_template_arc: &mut Arc<Mutex<BlockTemplate>>,
     latest_template_merkle_branch_arc: &mut Arc<Mutex<Vec<Vec<u8>>>>,
     template_cache: Arc<
@@ -226,13 +228,11 @@ pub async fn ipc_template_consumer(
                 "New block template"
             );
 
-            let notification_sent_or_not = notifier_tx
-                .send(NotifyCmd::SendToAll {
-                    template: template,
-                    merkle_branch_coinbase,
-                    template_id,
-                })
-                .await;
+            let notification_sent_or_not = notifier_tx.send(NotifyCmd::SendToAll {
+                template: template,
+                merkle_branch_coinbase,
+                template_id,
+            });
             match notification_sent_or_not {
                 Ok(_) => {
                     debug!(template_id = %template_id, "Template sent to notifier");

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -16,6 +16,7 @@ use libp2p::{
 };
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
+use node::task_manager::TaskManager;
 use node::utils::BeadHash;
 use node::SwarmHandler;
 use node::{
@@ -62,13 +63,23 @@ use tokio::sync::{
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
-    let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
+    //Shutdown channel being shared that will be dropped as soon as all the sub-ordinate tasks have shutdown
+    let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+    //Main task token that will be shared across to trigger the hierarichal shudown of tasks
+    let main_task_token = CancellationToken::new();
+    //Instance of local task manager being shared across different tasks
+    let task_manager = Arc::new(TaskManager::new());
+    let (ibd_manager, ibd_command_tx) = IBDManager::new();
     //IBD cache handler
-    let _ibd_handler = tokio::spawn(async move {
-        ibd_manager.run_ibd_handler().await;
-    });
+    ibd_manager
+        .run_ibd_handler(
+            shutdown_complete_tx.clone(),
+            main_task_token.clone(),
+            task_manager.clone(),
+        )
+        .await;
     //False if not under ibd otherwise true at start will be in IBD by default
-    let ibd_or_not: AtomicBool = AtomicBool::new(true);
+    let ibd_or_not: AtomicBool = AtomicBool::new(false);
     let ibd_spinlock = Arc::new(ibd_or_not);
     // Initializing the braid object with read write lock
     //for supporting concurrent readers and single writer
@@ -86,9 +97,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let braid_ref = braid.clone();
     // FIXME instead we should look 144 blocks back from the bitcoin tip (1 day) and load beads
     // starting from that block as genesis
-    let initial_bead_fetch_handle = tokio::spawn(async move {
-        let mut guard = braid_ref.write().await;
+    {
         let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000).await?;
+        let mut guard = braid_ref.write().await;
         for bead in &fetched_beads {
             let curr_bead_status = guard.extend(&bead);
             debug!(
@@ -98,36 +109,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
             );
         }
         info!(beads = fetched_beads.len(), "Beads loaded from DB");
-        Ok::<(), node::error::DBErrors>(())
-    });
-    match initial_bead_fetch_handle.await {
-        Ok(Ok(())) => {
-            info!("Initial bead fetch completed successfully");
-        }
-        Ok(Err(e)) => {
-            error!(error = ?e, "Failed to fetch beads from DB during startup");
-            return Err(format!("Database bead fetch failed: {:?}", e).into());
-        }
-        Err(e) => {
-            error!(error = ?e, "Initial bead fetch task panicked");
-            return Err(format!("Initial bead fetch task panicked: {}", e).into());
-        }
     }
+    //Lock is dropped here
     let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
     let latest_template_id_for_notifier = latest_template_id.clone();
     let latest_template_id_for_consumer = latest_template_id.clone();
     //Starting the `query_handler` task
-    tokio::spawn(async move {
-        let _res = _db_handler.insert_query_handler().await;
-    });
+    _db_handler
+        .insert_query_handler(
+            shutdown_complete_tx.clone(),
+            main_task_token.clone(),
+            task_manager.clone(),
+        )
+        .await;
     //latest available template to be cached for the newest connection until new job is received
     let latest_template = Arc::new(Mutex::new(BlockTemplate::default()));
     //latest available template merkle branch
     let latest_template_merkle_branch = Arc::new(Mutex::new(Vec::new()));
-    let mut latest_template_ref = latest_template.clone();
-    let mut latest_template_merkle_branch_ref = latest_template_merkle_branch.clone();
+    let latest_template_ref = latest_template.clone();
+    let latest_template_merkle_branch_ref = latest_template_merkle_branch.clone();
     //One will go into the IPC and the other will go to the `notifier`
-    let (notification_tx, notification_rx) = mpsc::channel::<NotifyCmd>(1024);
+    let (notification_tx, notification_rx) = mpsc::unbounded_channel::<NotifyCmd>();
     //Communication bridge between stratum and network swarm and swarm commands also, for communicating share population and propogating them further
     let (swarm_handler, mut swarm_command_receiver) =
         SwarmHandler::new(Arc::clone(&braid), db_tx.clone());
@@ -141,61 +143,64 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //Mining job map keeping all the jobs provided to the downstream
     let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
     //Intializing `notifier` for mining.notify
-    let mut notifier: Notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
+    let notifier: Notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
     //Stratum configuration initialization
     let stratum_config: StratumServerConfig = StratumServerConfig::default();
     let (block_submission_tx, block_submission_rx) =
         tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
     //IBD notifier task after peer_discovery
     let swarm_command_sender_ref = swarm_command_sender.clone();
-    let _ibd_trigger_handler = tokio::spawn(async move {
+    let _ibd_trigger_handler = task_manager.spawn(async move {
         tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
         //Sending IBD initiating command
-        match swarm_command_sender_ref
-            .send(SwarmCommand::InitiateIBD)
-            .await
-        {
-            Ok(_) => {
-                info!("IBD trigger sent");
-            }
-            Err(error) => {
-                error!(error=?error,"An error occurred while initiating IBD after waiting for peer discovery - ");
-            }
-        };
+        if !swarm_command_sender_ref.is_closed(){
+            match swarm_command_sender_ref
+                .send(SwarmCommand::InitiateIBD)
+                .await
+            {
+                Ok(_) => {
+                    info!("IBD trigger sent");
+                }
+                Err(error) => {
+                    error!(error=?error.to_string(),"An error occurred while initiating IBD after waiting for peer discovery - ");
+                }
+            };
+        }
+        else{
+            warn!("IBD trigger handler dropped !");
+        }
     });
     //Initializing stratum server
-    let mut stratum_server = Server::new(
+    let stratum_server = Server::new(
         stratum_config,
         connection_mapping.clone(),
         Some(block_submission_tx),
     );
     //Running the notification service
-    tokio::spawn(async move {
-        let _res = notifier
-            .run_notifier(
-                connection_mapping.clone(),
-                &mut latest_template_ref,
-                &mut latest_template_merkle_branch_ref,
-                latest_template_id_for_notifier,
-            )
-            .await;
-    });
+    notifier
+        .run_notifier(
+            connection_mapping.clone(),
+            latest_template_ref,
+            latest_template_merkle_branch_ref,
+            latest_template_id_for_notifier,
+            shutdown_complete_tx.clone(),
+            main_task_token.clone(),
+            task_manager.clone(),
+        )
+        .await;
     //Running the stratum service
-    let spin_lock_ref = ibd_spinlock.clone();
-    tokio::spawn(async move {
-        let _res = stratum_server
-            .run_stratum_service(
-                mining_job_map,
-                notification_tx_clone,
-                swarm_handler_arc.clone(),
-                spin_lock_ref,
-            )
-            .await;
-    });
+    stratum_server
+        .run_stratum_service(
+            mining_job_map,
+            notification_tx_clone,
+            swarm_handler_arc.clone(),
+            ibd_spinlock.clone(),
+            main_task_token.clone(),
+            shutdown_complete_tx.clone(),
+            task_manager.clone(),
+        )
+        .await;
 
-    let (main_shutdown_tx, _main_shutdown_rx) =
-        mpsc::channel::<tokio::signal::unix::SignalKind>(32);
-    let main_task_token = CancellationToken::new();
     let ipc_task_token = main_task_token.clone();
     let args = cli::Cli::parse();
     let datadir_str = args.datadir.to_str().ok_or_else(|| {
@@ -267,27 +272,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
     };
     //spawning the rpc server
     let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
-    if let Some(rpc_command) = args.command {
-        let server_address = tokio::spawn(run_rpc_server(Arc::clone(&braid), rpc_addr));
-        let socket_address = server_address
-            .await
-            .map_err(|e| {
-                std::io::Error::new(
-                    std::io::ErrorKind::Other,
-                    format!("RPC server task failed: {}", e),
-                )
-            })?
-            .map_err(|_| {
-                std::io::Error::new(std::io::ErrorKind::Other, "RPC server startup failed")
-            })?;
-        let _parsing_handle =
-            tokio::spawn(parse_arguments(rpc_command, socket_address.clone())).await;
-    } else {
-        //running the rpc server and updating the reference counter
-        //for shared ownership
-        let _server_handler = tokio::spawn(run_rpc_server(Arc::clone(&braid), rpc_addr)).await;
-    }
-    // load beads from db (if present) and insert in braid here
+    let task_manager_clone = task_manager.clone();
+    let braid_ref = Arc::clone(&braid);
+    let rpc_command_or_not = args.command;
+
+    task_manager_clone.spawn(async move {
+        let socket_address = run_rpc_server(braid_ref, rpc_addr).await;
+
+        match socket_address {
+            Ok(addr) => {
+                info!(address = %addr, "RPC server started");
+
+                if let Some(rpc_command) = rpc_command_or_not {
+                    parse_arguments(rpc_command, addr).await;
+                }
+            }
+            Err(_) => {
+                error!("Failed to start RPC server");
+            }
+        }
+    });
     // Initializing the peer manager
     let mut peer_manager = PeerManager::new(8);
     //For local testing uncomment this keypair peer since it running to process will
@@ -378,7 +382,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     info!(address = %ADDR_REFRENCE, "Dialed boot node");
     //IPC(inter process communication) based `getblocktemplate` and `notification` to send to the downstream via the `cmempoold` architecture
     info!(socket = %args.ipc_socket, "IPC socket path");
-
     let network = if let Some(network_name) = &args.network {
         info!(network = %network_name, "Network selected");
         match network_name.as_str() {
@@ -504,7 +507,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
             info!(address = %node_multiaddr, "Dialed peer node");
         }
     };
-    let swarm_handle = tokio::spawn(async move {
+    let swarm_task_token = main_task_token.clone();
+    //Required for child tasks shutdown spawned insided swarm loop
+    let child_token = main_task_token.clone();
+    let task_manager_ref = task_manager.clone();
+    task_manager_ref.spawn(async move {
         let braid = std::sync::Arc::clone(&braid);
         loop {
             tokio::select! {
@@ -1370,21 +1377,23 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         let peer_ids = peer_manager.get_top_k_peers_for_propagation(1);
                         if peer_ids.len() == 0 {
                             warn!("No peer available for syncing to take place");
-                                tokio::spawn({
+                            let ibd_retry_token = child_token.clone();
+                                task_manager.spawn({
                                     let swarm_command_sender = swarm_command_sender.clone();
                                     //Retrying at fixed interval in case of no sync peers being available
                                     async move {
-                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
-                                            Ok(_) => {
-                                                info!("Retrying IBD when no sync peers are available");
+                                        tokio::select! {
+                                            _ = ibd_retry_token.cancelled() => {
+                                                info!("Retry IBD task cancelled");
+                                                return;}
+                                            _ = tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)) => {
+                                                if let Err(error) =
+                                                    swarm_command_sender.send(SwarmCommand::InitiateIBD).await
+                                                {
+                                                    debug!(error=?error, "Swarm handler gone, stopping retry task");
+                                                }
                                             }
-                                            Err(error) => {
-                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
-                                            }
-                                        }
-                                    }
-                                });
+                                        }}});
                         }
                         else{
                             let mut sync_request_sent = false;
@@ -1448,7 +1457,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             }
                             else{
                                 warn!("Retry count for all the available sync peers exceeded waiting for new peer connections");
-                                tokio::spawn({
+                                task_manager.spawn({
                                     let swarm_command_sender = swarm_command_sender.clone();
                                     //Retrying at fixed interval in case of all available sync peer retry count has exceeded
                                     //Probe at fixed interval for any new peer
@@ -1469,10 +1478,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                      }
                  }
              }
-
-
-
-
+               _ = swarm_task_token.cancelled() => {
+                    info!(" Main swarm network handler task shutting down - cancellation token triggered");
+                    break;
+                }
             }
         }
     });
@@ -1481,30 +1490,28 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let shutdown_signal = tokio::signal::ctrl_c().await;
     match shutdown_signal {
         Ok(_) => {
+            //Cancelling the main token and notifying sub-ordinate tasks to shut gracefully
+            main_task_token.cancel();
+            drop(shutdown_complete_tx);
             info!(component = "database", "Closing connection pool");
             let pool = db_connection_pool.lock().await;
             //Closing all the existing connections to pool and committing from .db-wal to .db
             pool.close().await;
             info!(component = "database", "Connections closed");
-            info!(component = "swarm", "Shutting down network swarm");
-            swarm_handle.abort();
-            tokio::time::sleep(Duration::from_millis(1)).await;
-            #[allow(unused)]
-            let shutdown_sub_tasks = match main_shutdown_tx
-                .send(tokio::signal::unix::SignalKind::interrupt())
-                .await
-            {
-                Ok(_) => {
-                    info!(
-                        component = "shutdown",
-                        "Sub-tasks interrupted - waiting for graceful shutdown"
-                    );
-                    main_task_token.cancel();
+            info!("Waiting for shutdown completion signals from subsystems...");
+            let shutdown_timeout = tokio::time::Duration::from_secs(5);
+            tokio::select! {
+                _ = shutdown_complete_rx.recv() => {
+                    info!("All subsystems reported shutdown complete.");
                 }
-                Err(error) => {
-                    error!(error = ?error, "Failed to send interrupt signal to sub-tasks");
+                _ = tokio::time::sleep(shutdown_timeout) => {
+                    warn!("Graceful shutdown timed out after {shutdown_timeout:?} — forcing shutdown.");
+                    task_manager_ref.abort_all().await;
                 }
-            };
+            }
+            info!("Joining remaining tasks...");
+            task_manager_ref.join_all().await;
+            info!("Braidpool shutdown complete.");
         }
         Err(error) => {
             error!(

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -16,6 +16,7 @@ use libp2p::{
 };
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
+use node::status::{ShutdownMessage, Status};
 use node::task_manager::TaskManager;
 use node::utils::BeadHash;
 use node::SwarmHandler;
@@ -47,6 +48,8 @@ use tracing::{debug, error, info, trace, warn};
 use behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent};
 
 use crate::behaviour::KADPROTOCOLNAME;
+//Broadcast channel capacity required to avoid lagged state while broadcast
+const BROADCAST_CHANNEL_CAPACITY: usize = 1024 * 10;
 const LATENCY_ALPHA: u64 = 10; // seconds
                                //boot nodes peerIds
 const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
@@ -63,6 +66,14 @@ use tokio::sync::{
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
+
+    // Status reporting channel - tasks send status updates to main loop
+    let (status_tx, mut status_rx) = mpsc::unbounded_channel::<Status>();
+
+    // Shutdown broadcast channel - main loop broadcasts shutdown signals to all tasks
+    let (shutdown_notify_tx, _shutdown_notify_rx) =
+        tokio::sync::broadcast::channel::<ShutdownMessage>(BROADCAST_CHANNEL_CAPACITY);
+
     //Shutdown channel being shared that will be dropped as soon as all the sub-ordinate tasks have shutdown
     let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
     //Main task token that will be shared across to trigger the hierarichal shudown of tasks
@@ -71,11 +82,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let task_manager = Arc::new(TaskManager::new());
     let (ibd_manager, ibd_command_tx) = IBDManager::new();
     //IBD cache handler
+    let ibd_status_tx = status_tx.clone();
+    let ibd_shutdown_rx = shutdown_notify_tx.subscribe();
     ibd_manager
         .run_ibd_handler(
             shutdown_complete_tx.clone(),
             main_task_token.clone(),
             task_manager.clone(),
+            ibd_status_tx,
+            ibd_shutdown_rx,
         )
         .await;
     //False if not under ibd otherwise true at start will be in IBD by default
@@ -98,7 +113,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // FIXME instead we should look 144 blocks back from the bitcoin tip (1 day) and load beads
     // starting from that block as genesis
     {
-        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000).await?;
+        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000).await.unwrap();
         let mut guard = braid_ref.write().await;
         for bead in &fetched_beads {
             let curr_bead_status = guard.extend(&bead);
@@ -115,11 +130,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let latest_template_id_for_notifier = latest_template_id.clone();
     let latest_template_id_for_consumer = latest_template_id.clone();
     //Starting the `query_handler` task
+    let db_status_tx = status_tx.clone();
+    let db_shutdown_rx = shutdown_notify_tx.subscribe();
     _db_handler
         .insert_query_handler(
             shutdown_complete_tx.clone(),
             main_task_token.clone(),
             task_manager.clone(),
+            db_status_tx,
+            db_shutdown_rx,
         )
         .await;
     //latest available template to be cached for the newest connection until new job is received
@@ -177,6 +196,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Some(block_submission_tx),
     );
     //Running the notification service
+    let notifier_status_tx = status_tx.clone();
+    let notifier_shutdown_rx = shutdown_notify_tx.subscribe();
     notifier
         .run_notifier(
             connection_mapping.clone(),
@@ -186,9 +207,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
             shutdown_complete_tx.clone(),
             main_task_token.clone(),
             task_manager.clone(),
+            notifier_status_tx,
+            notifier_shutdown_rx,
         )
         .await;
     //Running the stratum service
+    let stratum_status_tx = status_tx.clone();
+    let stratum_shutdown_rx = shutdown_notify_tx.subscribe();
     stratum_server
         .run_stratum_service(
             mining_job_map,
@@ -198,6 +223,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
             main_task_token.clone(),
             shutdown_complete_tx.clone(),
             task_manager.clone(),
+            stratum_status_tx,
+            stratum_shutdown_rx,
         )
         .await;
 
@@ -408,6 +435,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let notification_tx_for_ipc = notification_tx.clone();
     let latest_template_for_ipc = latest_template.clone();
     let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
+    let _ipc_status_tx = status_tx.clone();
+    let _ipc_shutdown_rx = shutdown_notify_tx.subscribe();
 
     // Spawn IPC handler
     let _ipc_handler = tokio::task::spawn_blocking(move || {
@@ -511,6 +540,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //Required for child tasks shutdown spawned insided swarm loop
     let child_token = main_task_token.clone();
     let task_manager_ref = task_manager.clone();
+    let swarm_status_tx = status_tx.clone();
+    let mut swarm_shutdown_rx = shutdown_notify_tx.subscribe();
     task_manager_ref.spawn(async move {
         let braid = std::sync::Arc::clone(&braid);
         loop {
@@ -1479,47 +1510,155 @@ async fn main() -> Result<(), Box<dyn Error>> {
                  }
              }
                _ = swarm_task_token.cancelled() => {
-                    info!(" Main swarm network handler task shutting down - cancellation token triggered");
+                    info!("Main swarm network handler task shutting down - cancellation token triggered");
                     break;
+                }
+                shutdown_msg = swarm_shutdown_rx.recv() => {
+                    match shutdown_msg {
+                        Ok(ShutdownMessage::ShutdownAll) => {
+                            info!("Swarm task received shutdown signal");
+                            break;
+                        }
+                        _ => {}
+                    }
                 }
             }
         }
     });
 
-    //graceful shutdown via `Cancellation token`
-    let shutdown_signal = tokio::signal::ctrl_c().await;
-    match shutdown_signal {
-        Ok(_) => {
-            //Cancelling the main token and notifying sub-ordinate tasks to shut gracefully
-            main_task_token.cancel();
-            drop(shutdown_complete_tx);
-            info!(component = "database", "Closing connection pool");
-            let pool = db_connection_pool.lock().await;
-            //Closing all the existing connections to pool and committing from .db-wal to .db
-            pool.close().await;
-            info!(component = "database", "Connections closed");
-            info!("Waiting for shutdown completion signals from subsystems...");
-            let shutdown_timeout = tokio::time::Duration::from_secs(5);
-            tokio::select! {
-                _ = shutdown_complete_rx.recv() => {
-                    info!("All subsystems reported shutdown complete.");
-                }
-                _ = tokio::time::sleep(shutdown_timeout) => {
-                    warn!("Graceful shutdown timed out after {shutdown_timeout:?} — forcing shutdown.");
-                    task_manager_ref.abort_all().await;
+    //Status monitoring and graceful shutdown loop
+    let mut shutdown_initiated = false;
+
+    loop {
+        tokio::select! {
+            Some(status) = status_rx.recv() => {
+                use node::status::State;
+
+                match status.state {
+                    State::Error { component, error, timestamp } => {
+                        error!(
+                            component = %component,
+                            error = ?error,
+                            timestamp = ?timestamp,
+                            "Component error"
+                        );
+
+                        // Check if this is a critical error requiring shutdown
+                        if node::status::determine_action(&error) == node::status::ErrorAction::Shutdown {
+                            warn!(
+                                component = %component,
+                                "Critical error detected, initiating shutdown"
+                            );
+                            if let Err(e) = shutdown_notify_tx.send(ShutdownMessage::ShutdownAll) {
+                                error!(error = ?e, "Failed to broadcast shutdown signal");
+                            }
+                            shutdown_initiated = true;
+                            break;
+                        }
+                    }
+                    State::DownstreamShutdown { connection_id, peer_addr, reason } => {
+                        info!(
+                            connection_id = connection_id,
+                            peer = %peer_addr,
+                            reason = ?reason,
+                            "Downstream connection closed"
+                        );
+                        // Send targeted shutdown for this specific downstream
+                        if let Err(e) = shutdown_notify_tx.send(ShutdownMessage::DownstreamShutdown(peer_addr.to_string())) {
+                            warn!(error = ?e, connection_id = connection_id, "Failed to send downstream shutdown");
+                        }
+                    }
+                    State::StratumServerShutdown { reason } => {
+                        error!(reason = ?reason, "Stratum server shutdown");
+                        if let Err(e) = shutdown_notify_tx.send(ShutdownMessage::ShutdownAll) {
+                            error!(error = ?e, "Failed to broadcast shutdown signal");
+                        }
+                        shutdown_initiated = true;
+                        break;
+                    }
+                    State::StratumNotifierShutdown { reason } => {
+                        error!(reason = ?reason, "Stratum notifier shutdown");
+                        if let Err(e) = shutdown_notify_tx.send(ShutdownMessage::ShutdownAll) {
+                            error!(error = ?e, "Failed to broadcast shutdown signal");
+                        }
+                        shutdown_initiated = true;
+                        break;
+                    }
+                    State::SwarmShutdown { reason } => {
+                        warn!(reason = ?reason, "Swarm handler shutdown");
+                        // Swarm shutdown is typically a fallback, not necessarily critical
+                    }
+                    State::PeerManagerShutdown { reason } => {
+                        warn!(reason = ?reason, "Peer manager shutdown");
+                    }
+                    State::IBDManagerShutdown { reason } => {
+                        warn!(reason = ?reason, "IBD manager shutdown");
+                    }
+                    State::DatabaseShutdown { reason } => {
+                        error!(reason = ?reason, "Database handler shutdown - CRITICAL");
+                        if let Err(e) = shutdown_notify_tx.send(ShutdownMessage::ShutdownAll) {
+                            error!(error = ?e, "Failed to broadcast shutdown signal");
+                        }
+                        shutdown_initiated = true;
+                        break;
+                    }
+                    State::IPCTaskShutdown { reason } => {
+                        error!(reason = ?reason, "IPC task shutdown");
+                        if let Err(e) = shutdown_notify_tx.send(ShutdownMessage::ShutdownAll) {
+                            error!(error = ?e, "Failed to broadcast shutdown signal");
+                        }
+                        shutdown_initiated = true;
+                        break;
+                    }
+                    State::RPCServerShutdown { reason } => {
+                        warn!(reason = ?reason, "RPC server shutdown");
+                    }
                 }
             }
-            info!("Joining remaining tasks...");
-            task_manager_ref.join_all().await;
-            info!("Braidpool shutdown complete.");
+
+            // Handle Ctrl-C graceful shutdown
+            _ = tokio::signal::ctrl_c() => {
+                info!("Ctrl-C received, initiating graceful shutdown");
+
+                // Broadcast shutdown to all tasks
+                if let Err(e) = shutdown_notify_tx.send(ShutdownMessage::ShutdownAll) {
+                    error!(error = ?e, "Failed to broadcast shutdown signal");
+                }
+                shutdown_initiated = true;
+                break;
+            }
         }
-        Err(error) => {
-            error!(
-                error = ?error,
-                component = "shutdown",
-                "Shutdown signal error"
-            );
+    }
+
+    // Graceful shutdown sequence
+    if shutdown_initiated {
+        info!("Shutdown sequence initiated");
+
+        // Cancel all tasks via cancellation token
+        main_task_token.cancel();
+        drop(shutdown_complete_tx);
+
+        info!(component = "database", "Closing connection pool");
+        let pool = db_connection_pool.lock().await;
+        //Closing all the existing connections to pool and committing from .db-wal to .db
+        pool.close().await;
+        info!(component = "database", "Connections closed");
+
+        info!("Waiting for shutdown completion signals from subsystems...");
+        let shutdown_timeout = tokio::time::Duration::from_secs(5);
+        tokio::select! {
+            _ = shutdown_complete_rx.recv() => {
+                info!("All subsystems reported shutdown complete.");
+            }
+            _ = tokio::time::sleep(shutdown_timeout) => {
+                warn!("Graceful shutdown timed out after {shutdown_timeout:?} — forcing shutdown.");
+                task_manager_ref.abort_all().await;
+            }
         }
+
+        info!("Joining remaining tasks...");
+        task_manager_ref.join_all().await;
+        info!("Braidpool shutdown complete.");
     }
 
     Ok(())

--- a/node/src/status.rs
+++ b/node/src/status.rs
@@ -1,0 +1,354 @@
+use std::net::SocketAddr;
+use std::time::SystemTime;
+use tokio::sync::mpsc;
+use tracing::{debug, error, warn};
+
+use crate::error::{DBErrors, StratumErrors};
+
+/// Identifies the component that originated a [`Status`] update.
+///
+/// Each variant contains a channel to the main coordinator, and optionally a component ID
+/// (e.g. a downstream connection ID or peer ID).
+///This will basically sense the originator of error and notify further
+#[derive(Debug, Clone)]
+pub enum StatusSender {
+    /// A specific downstream miner connection in the Stratum server.
+    DownstreamMiner {
+        connection_id: u32,
+        peer_addr: SocketAddr,
+        tx: mpsc::UnboundedSender<Status>,
+    },
+    /// The Stratum server listener.
+    StratumServer(mpsc::UnboundedSender<Status>),
+    /// The Stratum notifier task (mining.notify).
+    StratumNotifier(mpsc::UnboundedSender<Status>),
+    /// The P2P network swarm handler.
+    SwarmHandler(mpsc::UnboundedSender<Status>),
+    /// The peer manager subsystem.
+    PeerManager(mpsc::UnboundedSender<Status>),
+    /// The IBD (Initial Block Download) manager.
+    IBDManager(mpsc::UnboundedSender<Status>),
+    /// The database query handler.
+    DatabaseHandler(mpsc::UnboundedSender<Status>),
+    //IPC error handler
+    IPCHandler(mpsc::UnboundedSender<Status>),
+    // /// The IPC (Inter-Process Communication) listener for Bitcoin Core.
+    // IPCListener(mpsc::UnboundedSender<Status>),
+    // /// The IPC template consumer.
+    // IPCConsumer(mpsc::UnboundedSender<Status>),
+    /// The RPC server.
+    RPCServer(mpsc::UnboundedSender<Status>),
+}
+//Sending the status received to the main task that will further trigger the corresponding notification of shutdown
+impl StatusSender {
+    /// Sends a [`Status`] update to the main coordinator.
+    ///
+    /// Returns an error if the channel is closed (main loop has exited).
+    pub async fn send(&self, status: Status) -> Result<(), mpsc::error::SendError<Status>> {
+        match self {
+            Self::DownstreamMiner {
+                connection_id,
+                peer_addr,
+                tx,
+            } => {
+                debug!(
+                    connection_id = connection_id,
+                    peer = %peer_addr,
+                    state = ?status.state,
+                    "Sending status from DownstreamMiner"
+                );
+                tx.send(status)
+            }
+            Self::StratumServer(tx) => {
+                debug!(state = ?status.state, "Sending status from StratumServer");
+                tx.send(status)
+            }
+            Self::StratumNotifier(tx) => {
+                debug!(state = ?status.state, "Sending status from StratumNotifier");
+                tx.send(status)
+            }
+            Self::SwarmHandler(tx) => {
+                debug!(state = ?status.state, "Sending status from SwarmHandler");
+                tx.send(status)
+            }
+            Self::PeerManager(tx) => {
+                debug!(state = ?status.state, "Sending status from PeerManager");
+                tx.send(status)
+            }
+            Self::IBDManager(tx) => {
+                debug!(state = ?status.state, "Sending status from IBDManager");
+                tx.send(status)
+            }
+            Self::DatabaseHandler(tx) => {
+                debug!(state = ?status.state, "Sending status from DatabaseHandler");
+                tx.send(status)
+            }
+            // Self::IPCListener(tx) => {
+            //     debug!(state = ?status.state, "Sending status from IPCListener");
+            //     tx.send(status)
+            // }
+            // Self::IPCConsumer(tx) => {
+            //     debug!(state = ?status.state, "Sending status from IPCConsumer");
+            //     tx.send(status)
+            // }
+            Self::IPCHandler(tx) => {
+                debug!(state = ?status.state, "Sending status from IPCHandler");
+                tx.send(status)
+            }
+            Self::RPCServer(tx) => {
+                debug!(state = ?status.state, "Sending status from RPCServer");
+                tx.send(status)
+            }
+        }
+    }
+
+    /// Returns a human-readable name for this sender component.
+    pub fn component_name(&self) -> &'static str {
+        match self {
+            Self::DownstreamMiner { .. } => "DownstreamMiner",
+            Self::StratumServer(_) => "StratumServer",
+            Self::StratumNotifier(_) => "StratumNotifier",
+            Self::SwarmHandler(_) => "SwarmHandler",
+            Self::PeerManager(_) => "PeerManager",
+            Self::IBDManager(_) => "IBDManager",
+            Self::DatabaseHandler(_) => "DatabaseHandler",
+            Self::RPCServer(_) => "RPCServer",
+            Self::IPCHandler(_) => "IPCHandler",
+        }
+    }
+}
+
+/// The type of event or error being reported by a component.
+#[derive(Debug, Clone)]
+pub enum State {
+    /// Component encountered a non-fatal error.
+    Error {
+        component: String,
+        error: TaskError,
+        timestamp: SystemTime,
+    },
+    /// Downstream miner disconnected or encountered an error.
+    DownstreamShutdown {
+        connection_id: u32,
+        peer_addr: SocketAddr,
+        reason: TaskError,
+    },
+    /// Stratum server listener shut down.
+    StratumServerShutdown { reason: TaskError },
+    /// Stratum notifier shut down.
+    StratumNotifierShutdown { reason: TaskError },
+    /// P2P swarm handler shut down.
+    SwarmShutdown { reason: TaskError },
+    /// Peer manager shut down.
+    PeerManagerShutdown { reason: TaskError },
+    /// IBD manager shut down.
+    IBDManagerShutdown { reason: TaskError },
+    /// Database handler shut down.
+    DatabaseShutdown { reason: TaskError },
+    /// RPC server shut down.
+    RPCServerShutdown { reason: TaskError },
+    /// IPC error occurred.
+    IPCTaskShutdown { reason: TaskError },
+}
+
+/// Categories of errors that tasks can report.
+#[derive(Debug, Clone)]
+pub enum TaskError {
+    /// A downstream miner connection error this will not be specific to all.
+    DownstreamDisconnected {
+        connection_id: u32,
+        peer_addr: SocketAddr,
+        details: String,
+    },
+    /// Stratum server error rigid error (shutdownAll).
+    StratumServerError {
+        error: String,
+    },
+    /// Database operation error rigid error (shutdownAll).
+    DatabaseError {
+        error: String,
+    },
+    /// P2P network error.
+    NetworkError {
+        details: String,
+    },
+    /// IPC communication error with Bitcoin Core rigid error (shutdownAll).
+    IPCError {
+        details: String,
+    },
+    /// IBD (Initial Block Download) error.
+    IBDError {
+        details: String,
+    },
+    /// RPC server error .
+    RPCError {
+        details: String,
+    },
+    //Notifier error
+    StratumNotifierError {
+        details: String,
+    },
+    //Peer manager error
+    PeerManagerError {
+        details: String,
+    },
+}
+//Since we have different error types we will have to have functions in place to convert them into TaskError
+//Which will then be wrapped in Status and sent to main task and the notifiying tasks on the basis of Status received
+impl TaskError {
+    /// Creates a `TaskError` from a `StratumErrors`.
+    pub fn from_stratum_error(error: StratumErrors) -> Self {
+        Self::StratumServerError {
+            error: error.to_string(),
+        }
+    }
+
+    /// Creates a `TaskError` from a `DBErrors`.
+    pub fn from_db_error(error: DBErrors) -> Self {
+        Self::DatabaseError {
+            error: error.to_string(),
+        }
+    }
+}
+
+/// A message reporting the current [`State`] of a component.
+#[derive(Debug, Clone)]
+pub struct Status {
+    pub state: State,
+}
+/// Represents a message that can trigger shutdown of various system components.
+#[derive(Debug, Clone)]
+pub enum ShutdownMessage {
+    /// Shutdown all components immediately
+    ShutdownAll,
+    /// Shutdown all downstream connections
+    DownstreamShutdownAll,
+    /// Shutdown a specific downstream connection by ID
+    DownstreamShutdown(u32),
+}
+
+/// Action to take in response to an error.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ErrorAction {
+    /// Disconnect the specific downstream connection.
+    DisconnectDownstream,
+    /// Attempt to reconnect or fallback to alternative.
+    Fallback,
+    /// Initiate system-wide shutdown.
+    Shutdown,
+}
+/// Determines the appropriate action for a given task error.
+pub fn determine_action(error: &TaskError) -> ErrorAction {
+    match error {
+        //Only miner specific error for cleaning is required
+        TaskError::DownstreamDisconnected { .. } => ErrorAction::DisconnectDownstream,
+        //Complete shutdown is required
+        TaskError::DatabaseError { .. } => ErrorAction::Shutdown,
+        TaskError::IPCError { .. } => ErrorAction::Shutdown,
+        TaskError::StratumServerError { .. } => ErrorAction::Shutdown,
+        TaskError::StratumNotifierError { .. } => ErrorAction::Shutdown,
+        //Fallback or some local shutdown of task maybe required definitely not complete shutdown though
+        TaskError::NetworkError { .. } => ErrorAction::Fallback,
+        TaskError::IBDError { .. } => ErrorAction::Fallback,
+        TaskError::RPCError { .. } => ErrorAction::Fallback,
+        TaskError::PeerManagerError { .. } => ErrorAction::Fallback,
+    }
+}
+
+/// Sends a status update based on the error and determined action.
+///
+/// Returns `true` if the error requires component shutdown, `false` otherwise.
+async fn send_status(sender: &StatusSender, error: TaskError) -> bool {
+    let action = determine_action(&error);
+
+    match action {
+        ErrorAction::DisconnectDownstream => {
+            if let TaskError::DownstreamDisconnected {
+                connection_id,
+                peer_addr,
+                details,
+            } = error
+            {
+                let state = State::DownstreamShutdown {
+                    connection_id,
+                    peer_addr,
+                    reason: TaskError::DownstreamDisconnected {
+                        connection_id,
+                        peer_addr,
+                        details,
+                    },
+                };
+
+                if let Err(e) = sender.send(Status { state }).await {
+                    error!(
+                        "Failed to send downstream shutdown status from {:?}: {:?}",
+                        sender, e
+                    );
+                }
+                matches!(sender, StatusSender::DownstreamMiner { .. })
+            } else {
+                warn!(
+                    "DisconnectDownstream action for non-downstream error: {:?}",
+                    error
+                );
+                false
+            }
+        }
+
+        ErrorAction::Fallback => {
+            warn!(
+                "Fallback action triggered from {:?} due to error: {:?}",
+                sender, error
+            );
+            let state = match sender {
+                StatusSender::SwarmHandler(_) => State::SwarmShutdown { reason: error },
+                StatusSender::PeerManager(_) => State::PeerManagerShutdown { reason: error },
+                StatusSender::IBDManager(_) => State::IBDManagerShutdown { reason: error },
+                StatusSender::RPCServer(_) => State::RPCServerShutdown { reason: error },
+                _ => State::Error {
+                    component: sender.component_name().to_string(),
+                    error,
+                    timestamp: SystemTime::now(),
+                },
+            };
+
+            if let Err(e) = sender.send(Status { state }).await {
+                error!("Failed to send fallback status from {:?}: {:?}", sender, e);
+            }
+            false
+        }
+
+        ErrorAction::Shutdown => {
+            error!(
+                "Shutdown action triggered from {:?} due to critical error: {:?}",
+                sender, error
+            );
+
+            let state = match sender {
+                StatusSender::StratumServer(_) => State::StratumServerShutdown { reason: error },
+                StatusSender::StratumNotifier(_) => {
+                    State::StratumNotifierShutdown { reason: error }
+                }
+                StatusSender::DatabaseHandler(_) => State::DatabaseShutdown { reason: error },
+                // StatusSender::IPCListener(_) => State::IPCListenerShutdown { reason: error },
+                // StatusSender::IPCConsumer(_) => State::IPCConsumerShutdown { reason: error },
+                StatusSender::IPCHandler(_) => State::IPCTaskShutdown { reason: error },
+                _ => State::Error {
+                    component: sender.component_name().to_string(),
+                    error,
+                    timestamp: SystemTime::now(),
+                },
+            };
+
+            if let Err(e) = sender.send(Status { state }).await {
+                error!("Failed to send shutdown status from {:?}: {:?}", sender, e);
+                // If we can't send shutdown signal, abort immediately
+                std::process::abort();
+            }
+            true
+        }
+    }
+}
+pub async fn handle_error(sender: &StatusSender, error: TaskError) -> bool {
+    send_status(sender, error).await
+}

--- a/node/src/status.rs
+++ b/node/src/status.rs
@@ -224,7 +224,9 @@ pub enum ShutdownMessage {
     /// Shutdown all downstream connections
     DownstreamShutdownAll,
     /// Shutdown a specific downstream connection by ID
-    DownstreamShutdown(u32),
+    DownstreamShutdown(String),
+    ///Fallback in case of status sender reporting an error can be resumed
+    ComponentFallback,
 }
 
 /// Action to take in response to an error.
@@ -286,6 +288,7 @@ async fn send_status(sender: &StatusSender, error: TaskError) -> bool {
                     );
                 }
                 matches!(sender, StatusSender::DownstreamMiner { .. })
+                    || matches!(sender, StatusSender::StratumNotifier { .. })
             } else {
                 warn!(
                     "DisconnectDownstream action for non-downstream error: {:?}",

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1,4 +1,5 @@
 use crate::error::StratumErrors;
+use crate::status::{handle_error, ShutdownMessage, State, Status, StatusSender, TaskError};
 use crate::task_manager::TaskManager;
 use crate::template_creator::calculate_merkle_root;
 use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
@@ -1489,6 +1490,8 @@ impl Notifier {
         shutdown_tx: tokio::sync::mpsc::Sender<()>,
         cancellation_token: tokio_util::sync::CancellationToken,
         task_manager: Arc<TaskManager>,
+        status_tx: tokio::sync::mpsc::UnboundedSender<Status>,
+        mut shutdown_rx: tokio::sync::broadcast::Receiver<ShutdownMessage>,
     ) {
         debug!("Stratum notifier task started");
         task_manager.spawn(async move{
@@ -1497,6 +1500,11 @@ impl Notifier {
                     notification_command = self.notification_receiver.recv()=>{
                         let Some(notification_command) = notification_command else {
                             error!("An error occurred while receiving notification");
+                            let status_sender = StatusSender::StratumNotifier(status_tx.clone());
+                            let complete_shutdown_or_not = handle_error(&status_sender, TaskError::StratumServerError { error: "Notification receiver channel closed".to_string() }).await;
+                            if complete_shutdown_or_not {
+                                warn!("Stratum notifier channel closed, initiating shutdown");
+                            }
                             break;
                         };
                         match notification_command {
@@ -1527,7 +1535,11 @@ impl Notifier {
                                                 peer = %peer_adr,
                                                 "Peer not found in connection mapping during job notification - skipping notification"
                                             );
-                                            continue;
+                                        //Closing connection with downstream peer because this is possible deadlock which has occurred hence initiating complete shutdown of braid-node 
+                                        let status_sender = StatusSender::StratumNotifier(status_tx.clone());
+                                        let _ = handle_error(&status_sender,TaskError::StratumNotifierError { details: format!("Possible deadlock occurred since peer is connected but yet not      found in connection mapping") }
+                                        ).await;
+                                        continue;
                                         }
                                     };
                                     let connection_id_hex = format!("{:x}", connection_info.connection_id);
@@ -1622,6 +1634,14 @@ impl Notifier {
                                 error = %e,
                                 "Failed to send job to peer"
                             );
+                                        //Closing connection with downstream peer if error is there wrt sender channel
+                                        let peer_socket_addr: SocketAddr = peer_adr.parse().unwrap_or_else(|_| "0.0.0.0:0".parse().unwrap());
+                                        let status_sender = StatusSender::StratumNotifier(status_tx.clone());
+                                        let _ = handle_error(&status_sender, TaskError::DownstreamDisconnected { 
+                                            connection_id: connection_info.connection_id, 
+                                            peer_addr: peer_socket_addr, 
+                                            details: format!("Failed to send job: {}", e) 
+                                        }).await;
                         } else {
                             trace!(
                                 connection_id = %connection_id_hex,
@@ -1648,6 +1668,10 @@ impl Notifier {
                                     Some(entry) => entry,
                                     None => {
                                         error!(peer = %new_downstream_addr, "Mining peer not found in connection mapping");
+                                        //Closing connection with downstream peer because this is possible deadlock which has occurred hence initiating complete shutdown of braid-node 
+                                        let status_sender = StatusSender::StratumNotifier(status_tx.clone());
+                                        let _ = handle_error(&status_sender,TaskError::StratumNotifierError { details: format!("Possible deadlock occurred since peer is connected but yet not      found in connection mapping") }
+                                        ).await;
                                         continue;
                                     }
                                 };
@@ -1764,12 +1788,42 @@ impl Notifier {
                                     }
                                     Err(error) => {
                                         error!("An error occurred while sending the notification via downstream sender channel {}",error.to_string());
+                                        //Closing connection with downstream peer if error is there wrt sender channel
+                                        let peer_socket_addr: SocketAddr = new_downstream_addr.parse().unwrap_or_else(|_| "0.0.0.0:0".parse().unwrap());
+                                        let status_sender = StatusSender::StratumNotifier(status_tx.clone());
+                                        let _ = handle_error(&status_sender, TaskError::DownstreamDisconnected { 
+                                            connection_id: connection_entry.connection_id, 
+                                            peer_addr: peer_socket_addr, 
+                                            details: format!("Failed to send initial job upon connection: {}", error.to_string()) 
+                                        }).await;
                                         continue;
                                     }
                                 };
                             }
                         }
 
+                    }
+                    shutdown_msg = shutdown_rx.recv() => {
+                        match shutdown_msg {
+                            Ok(msg) => {
+                                match msg {
+                                    ShutdownMessage::ShutdownAll => {
+                                        info!(message = ?msg, "Stratum notifier received shutdown signal, stopping notifier");
+                                        break;
+                                    }
+                                    ShutdownMessage::DownstreamShutdownAll => {
+                                        debug!("Notifier received downstream shutdown signal, but notifier continues running");
+                                    }
+                                    _ => {
+                                        debug!("Notifier received shutdown variant: {:?}", msg);
+                                    }
+                                }
+                            }
+                            Err(e) => {
+                                error!(error = ?e, "Error receiving shutdown signal in stratum notifier");
+                                break;
+                            }
+                        }
                     }
                     _ = cancellation_token.cancelled() => {
                         debug!(component = "notification_task", "Shutdown signal received, exiting gracefully");
@@ -1851,6 +1905,8 @@ impl Server {
         cancellation_token: CancellationToken,
         shutdown_completion_tx: tokio::sync::mpsc::Sender<()>,
         task_manager: Arc<TaskManager>,
+        status_tx: tokio::sync::mpsc::UnboundedSender<crate::status::Status>,
+        mut shutdown_rx: tokio::sync::broadcast::Receiver<crate::status::ShutdownMessage>,
     ) {
         debug!("Starting stratum server");
         let bind_address = format!(
@@ -1861,6 +1917,18 @@ impl Server {
             Ok(listener) => listener,
             Err(e) => {
                 error!(address = %bind_address, error = %e, "Failed to bind stratum server");
+                let status_sender = StatusSender::StratumServer(status_tx.clone());
+                let complete_shutdown_or_not = handle_error(
+                    &status_sender,
+                    TaskError::StratumServerError {
+                        error: e.to_string(),
+                    },
+                )
+                .await;
+                if complete_shutdown_or_not {
+                    warn!("Stratum server failed to start, initiating shutdown");
+                }
+
                 return;
             }
         };
@@ -1927,47 +1995,101 @@ impl Server {
                             );
                             let cancellation_token_ref = cancellation_token.clone();
                             let shutdown_complete_tx_ref = shutdown_completion_tx.clone();self_.downstream_ip = peer_addr.to_string();
-                            let connection_mapping_clone = Arc::clone(&self.downstream_connection_mapping);
-                            let mining_job_map_clone = Arc::clone(&mining_job_map);
-                            let peer_addr_string = peer_addr.to_string();
+                            let status_clone_downstream = status_tx.clone();
+                            let shutdown_notify_downstream = shutdown_rx.resubscribe();
                          // Catering each new connection as seperate process
                          task_manager_ref.spawn(async move{
-                             let _=  Self::handle_downstream_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref,cancellation_token_ref,shutdown_complete_tx_ref).await;
+                             let _=  Self::handle_downstream_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref,cancellation_token_ref,shutdown_complete_tx_ref,status_clone_downstream,shutdown_notify_downstream).await;
 
-                              debug!(
-                                    connection_id = %connection_id_hex,
-                                    peer = %peer_addr_string,
-                                    "Cleaning up disconnected miner"
-                                );
-
-                             // Cleanup after connection closes, remove from connection mapping
-                             connection_mapping_clone
-                                     .lock()
-                                     .await
-                                     .downstream_channel_mapping
-                                     .remove(&peer_addr_string);
-
-                             // Remove from job mapping
-                                 mining_job_map_clone
-                                     .lock()
-                                     .await
-                                     .remove(&peer_addr_string);
-
-                                    debug!(
-                                        connection_id = %connection_id_hex,
-                                        peer = %peer_addr_string,
-                                        "Miner cleanup complete"
-                                    );
 
                                 });
                             }
                             Err(error)=>{
-                                info!(
+                                error!(
                                     connection_id = %connection_id_hex,
                                     error = ?error,
                                     "Connection failed"
                                 );
+                                  let status_sender = StatusSender::StratumServer(status_tx.clone());
+                                  let complete_shutdown_or_not =  handle_error(&status_sender,TaskError::StratumServerError { error: error.to_string() }).await;
+                                  if complete_shutdown_or_not{
+                                    warn!("Stratum server encountered an error accepting connections, initiating shutdown");
+                                  }
+                                  break;
                             }
+                        }
+                    }
+                }
+                shutdown_msg = shutdown_rx.recv() => {
+                    match shutdown_msg {
+                        Ok(msg) => {
+                            match msg{
+                                // Cleanup all downstream connections and shutting stratum service
+                                ShutdownMessage::ShutdownAll=>{
+                                    debug!(message = ?msg, "Stratum service received shutdown signal for downstream connections, disconnecting all miners");
+                                    let mut conn_map = self.downstream_connection_mapping.lock().await;
+                                    let peer_addrs: Vec<String> = conn_map.downstream_channel_mapping.keys().cloned().collect();
+                                    
+                                    for peer_addr in peer_addrs {
+                                        debug!(peer = %peer_addr, "Disconnecting miner due to shutdown");
+                                        conn_map.downstream_channel_mapping.remove(&peer_addr);
+                                        mining_job_map.lock().await.remove(&peer_addr);
+                                    }
+                                    
+                                    info!("All miners disconnected, and stopping the stratum service");
+                                    break;
+                                },
+                                // Cleanup all downstream connections but not shutting stratum service
+                                ShutdownMessage::DownstreamShutdownAll=>{
+                                    debug!(message = ?msg, "Stratum service received shutdown signal for downstream connections, disconnecting all miners");
+                                    // Cleanup all downstream connections
+                                    let mut conn_map = self.downstream_connection_mapping.lock().await;
+                                    let peer_addrs: Vec<String> = conn_map.downstream_channel_mapping.keys().cloned().collect();
+                                    
+                                    for peer_addr in peer_addrs {
+                                        debug!(peer = %peer_addr, "Disconnecting miner due to shutdown");
+                                        conn_map.downstream_channel_mapping.remove(&peer_addr);
+                                        mining_job_map.lock().await.remove(&peer_addr);
+                                    }
+                                    
+                                    info!("All miners disconnected, but stratum service still runnning ");
+                                },
+                                //Cleaning up specific peer channel 
+                                ShutdownMessage::DownstreamShutdown(disconnected_peer_addr)=>{
+                                    let connection_mapping_clone = Arc::clone(&self.downstream_connection_mapping);
+                                    let mining_job_map_clone = Arc::clone(&mining_job_map);
+                                    //Removing the specific peer connection from connection mapping and job mapping                                        
+                                    debug!(
+                                        peer = %disconnected_peer_addr,
+                                        "Cleaning up disconnected miner"
+                                    );
+                                    // Cleanup after connection closes, remove from connection mapping
+                                    connection_mapping_clone
+                                            .lock()
+                                            .await
+                                            .downstream_channel_mapping
+                                            .remove(&disconnected_peer_addr);
+
+                                    // Remove from job mapping
+                                        mining_job_map_clone
+                                            .lock()
+                                            .await
+                                            .remove(&disconnected_peer_addr);
+
+                                        debug!(
+                                            peer = %disconnected_peer_addr,
+                                            "Miner cleanup complete"
+                                        );
+                                },
+                                _=>{
+                                    info!("Received fallback notification from status sender");
+                                }
+
+                            }
+                        }
+                        Err(e) => {
+                            error!(error = ?e, "Error receiving shutdown signal in stratum service");
+                            break;
                         }
                     }
                 }
@@ -2017,6 +2139,8 @@ impl Server {
         //per peer specific task shutdown and cancellation token
         cancellation_token: CancellationToken,
         shutdown_completion_tx: tokio::sync::mpsc::Sender<()>,
+        status_tx: tokio::sync::mpsc::UnboundedSender<Status>,
+        mut shutdown_rx: tokio::sync::broadcast::Receiver<ShutdownMessage>,
     ) {
         const MAX_LINE_LENGTH: usize = 2_usize.pow(16);
         //It can be excessively inefficient to work directly with a AsyncRead instance. A BufReader performs large, infrequent reads on the underlying AsyncRead and maintains an in-memory buffer of the results.
@@ -2029,7 +2153,6 @@ impl Server {
             peer = %peer_addr,
             "Handling new connection"
         );
-
         loop {
             tokio::select! {
                 Some(message) = downstream_receiver.recv()=>{
@@ -2057,6 +2180,14 @@ impl Server {
                                 peer = %peer_addr,
                                 "Failed to write to stream"
                             );
+                            let task_error_type = TaskError::DownstreamDisconnected { connection_id: downstream_client.connection_id, peer_addr, details: error.to_string() };
+                            let shutdown_status = Status{state:State::DownstreamShutdown { connection_id: downstream_client.connection_id, peer_addr, reason: task_error_type }};
+                            match status_tx.send(shutdown_status){
+                                Ok(_)=>{},
+                                Err(error)=>{
+                                    error!("Sending shutdown signal to status sender failed due to an error {:?}",error);
+                                }
+                            };
                             break;
                         }
                     }
@@ -2091,7 +2222,15 @@ impl Server {
                                                     error_type = "reader_task",
                                                     "Failed to process JSON request for downstream"
                                                 );
-                                                break;
+                                            let task_error_type = TaskError::from_stratum_error(error);
+                                            let shutdown_status = Status{state:State::DownstreamShutdown { connection_id: downstream_client.connection_id, peer_addr, reason: task_error_type }};
+                                            match status_tx.send(shutdown_status){
+                                                Ok(_)=>{},
+                                                Err(error)=>{
+                                                    error!("Sending shutdown signal to status sender failed due to an error {:?}",error);
+                                                }
+                                            };
+                                            break;
                                         }
                                     }
                                 }
@@ -2104,6 +2243,14 @@ impl Server {
                                             error_type = "json_parse",
                                             "Failed to parse JSON request"
                                         );
+                                        let task_error_type = TaskError::DownstreamDisconnected { connection_id: downstream_client.connection_id, peer_addr, details: e.to_string() };
+                                        let shutdown_status = Status{state:State::DownstreamShutdown { connection_id: downstream_client.connection_id, peer_addr, reason: task_error_type }};
+                                        match status_tx.send(shutdown_status){
+                                            Ok(_)=>{},
+                                            Err(error)=>{
+                                                error!("Sending shutdown signal to status sender failed due to an error {:?}",error);
+                                            }
+                                        };
                                         break;
                                     }
                                 }
@@ -2116,6 +2263,14 @@ impl Server {
                                 fatal = true,
                                 "Fatal error reading from stream closing connection with downstream"
                             );
+                            let task_error_type = TaskError::DownstreamDisconnected { connection_id: downstream_client.connection_id, peer_addr, details: e.to_string() };
+                            let shutdown_status = Status{state:State::DownstreamShutdown { connection_id: downstream_client.connection_id, peer_addr, reason: task_error_type }};
+                            match status_tx.send(shutdown_status){
+                                Ok(_)=>{},
+                                Err(error)=>{
+                                    error!("Sending shutdown signal to status sender failed due to an error {:?}",error);
+                                }
+                            };
                             break;
                         }
                         None => {
@@ -2124,6 +2279,23 @@ impl Server {
                                 peer = %peer_addr,
                                 "Connection closed by client"
                             );
+                            let task_error_type = TaskError::DownstreamDisconnected { connection_id: downstream_client.connection_id, peer_addr, details: "Downstream closed the connection !".to_string() };
+                            let shutdown_status = Status{state:State::DownstreamShutdown { connection_id: downstream_client.connection_id, peer_addr, reason: task_error_type }};
+                            match status_tx.send(shutdown_status){
+                                Ok(_)=>{},
+                                Err(error)=>{
+                                    error!("Sending shutdown signal to status sender failed due to an error {:?}",error);
+                                }
+                            };
+
+                            break;
+                        }
+                    }
+                }
+                shutdown_msg = shutdown_rx.recv()=>{
+                    match shutdown_msg{
+                        _=>{
+                            warn!("Received a shutdown signal from status sender shutting down new downstream connections !");
                             break;
                         }
                     }
@@ -2185,6 +2357,8 @@ mod test {
         let test_task_manager = Arc::new(TaskManager::new());
         let test_token = CancellationToken::new();
         let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        let (test_status_tx, _test_status_rx) = mpsc::unbounded_channel();
+        let (test_shutdown_tx, test_shutdown_rx) = tokio::sync::broadcast::channel(32);
         server
             .run_stratum_service(
                 mining_job_map,
@@ -2194,6 +2368,8 @@ mod test {
                 test_token.clone(),
                 shutdown_complete_tx.clone(),
                 test_task_manager.clone(),
+                test_status_tx,
+                test_shutdown_rx,
             )
             .await;
 
@@ -2254,6 +2430,8 @@ mod test {
         let test_task_manager = Arc::new(TaskManager::new());
         let test_token = CancellationToken::new();
         let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        let (test_status_tx, _test_status_rx) = mpsc::unbounded_channel();
+        let (test_shutdown_tx, test_shutdown_rx) = tokio::sync::broadcast::channel(32);
         server
             .run_stratum_service(
                 mining_job_map,
@@ -2263,6 +2441,8 @@ mod test {
                 test_token.clone(),
                 shutdown_complete_tx.clone(),
                 test_task_manager.clone(),
+                test_status_tx,
+                test_shutdown_rx,
             )
             .await;
 
@@ -2307,6 +2487,8 @@ mod test {
         let test_task_manager = Arc::new(TaskManager::new());
         let test_token = CancellationToken::new();
         let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        let (test_status_tx, _test_status_rx) = mpsc::unbounded_channel();
+        let (test_shutdown_tx, test_shutdown_rx) = tokio::sync::broadcast::channel(32);
         server
             .run_stratum_service(
                 mining_job_map,
@@ -2316,6 +2498,8 @@ mod test {
                 test_token.clone(),
                 shutdown_complete_tx.clone(),
                 test_task_manager.clone(),
+                test_status_tx,
+                test_shutdown_rx,
             )
             .await;
 
@@ -2361,6 +2545,8 @@ mod test {
         let test_task_manager = Arc::new(TaskManager::new());
         let test_token = CancellationToken::new();
         let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        let (test_status_tx, _test_status_rx) = mpsc::unbounded_channel();
+        let (test_shutdown_tx, test_shutdown_rx) = tokio::sync::broadcast::channel(32);
         server
             .run_stratum_service(
                 mining_job_map,
@@ -2370,6 +2556,8 @@ mod test {
                 test_token.clone(),
                 shutdown_complete_tx.clone(),
                 test_task_manager.clone(),
+                test_status_tx,
+                test_shutdown_rx,
             )
             .await;
         tokio::time::sleep(Duration::from_millis(300)).await;
@@ -2411,6 +2599,8 @@ mod test {
         let test_task_manager = Arc::new(TaskManager::new());
         let test_token = CancellationToken::new();
         let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        let (test_status_tx, _test_status_rx) = mpsc::unbounded_channel();
+        let (test_shutdown_tx, test_shutdown_rx) = tokio::sync::broadcast::channel(32);
         server
             .run_stratum_service(
                 mining_job_map,
@@ -2420,6 +2610,8 @@ mod test {
                 test_token.clone(),
                 shutdown_complete_tx.clone(),
                 test_task_manager.clone(),
+                test_status_tx,
+                test_shutdown_rx,
             )
             .await;
 

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1,4 +1,5 @@
 use crate::error::StratumErrors;
+use crate::task_manager::TaskManager;
 use crate::template_creator::calculate_merkle_root;
 use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
 use bitcoin::block::HeaderExt;
@@ -24,6 +25,7 @@ use tokio::{
 };
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
+use tokio_util::sync::CancellationToken;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 
@@ -240,7 +242,7 @@ impl DownstreamClient {
         client_request: StandardRequest,
         mining_job_map: Arc<Mutex<MiningJobMap>>,
         response_message_sender: mpsc::Sender<String>,
-        notification_sender: mpsc::Sender<NotifyCmd>,
+        notification_sender: mpsc::UnboundedSender<NotifyCmd>,
         peer_addr: String,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
     ) -> Result<StratumResponses, StratumErrors> {
@@ -319,11 +321,10 @@ impl DownstreamClient {
                     // && self.suggest_difficulty_done == true
                     && method != "mining.submit"
                 {
-                    let notification_sent_res = notification_sender
-                        .send(NotifyCmd::SendLatestTemplateToNewDownstream {
+                    let notification_sent_res =
+                        notification_sender.send(NotifyCmd::SendLatestTemplateToNewDownstream {
                             new_downstream_addr: peer_addr.clone(),
-                        })
-                        .await;
+                        });
                     match notification_sent_res {
                         Ok(_) => {
                             debug!(
@@ -339,6 +340,7 @@ impl DownstreamClient {
                                 peer_addr = %peer_addr,
                                 "Failed to request latest template for new downstream"
                             );
+                            panic!("BREAK EVERYTHING");
                         }
                     }
                 }
@@ -1031,8 +1033,8 @@ impl DownstreamClient {
             };
             //Intersecting with the bits provided by the pool and miner's suggested one
             let final_rollable_version_bits = u32::from_be_bytes(mask_bytes) & 0x1FFFE000;
-            // `0x1FFFE000` is a reasonable default as it allows all 16 version bits to be used
-            let hex_str = u32::to_string(&final_rollable_version_bits);
+            // `0x1FFFE000` is a reasonable default as it allows all 16 version bits to be used in `hex`
+            let hex_str = hex::encode(final_rollable_version_bits.to_be_bytes());
             self.version_rolling_mask = Some(hex_str);
         }
         if let Some(min_bit_count_value) = version_rolling_min_bit_count {
@@ -1299,7 +1301,7 @@ impl MiningJobMap {
 ///
 pub struct Notifier {
     ///`IpcGBT` notification receiver whenever new `template` is fethced or tip is updated .
-    notification_receiver: mpsc::Receiver<NotifyCmd>,
+    notification_receiver: mpsc::UnboundedReceiver<NotifyCmd>,
     ///`JobMap` associated with each `peer_addr` and the jobs associated with it .
     pub job_map_arc: Arc<Mutex<HashMap<String, Arc<Mutex<MiningJobMap>>>>>,
 }
@@ -1334,7 +1336,7 @@ pub fn reverse_four_byte_chunks(hash_hex: &str) -> Result<String, StratumErrors>
 impl Notifier {
     ///Spawning a new notifier instance .
     pub fn new(
-        notification_rx: mpsc::Receiver<NotifyCmd>,
+        notification_rx: mpsc::UnboundedReceiver<NotifyCmd>,
         job_map_arc: Arc<Mutex<HashMap<String, Arc<Mutex<MiningJobMap>>>>>,
     ) -> Self {
         Self {
@@ -1351,7 +1353,7 @@ impl Notifier {
     ///
     /// **Generation transaction (part 1)**. The miner inserts ExtraNonce1 and ExtraNonce2 after this section of the transaction data.
     ///
-    /// **Generation transaction (part 2)**. The mine10-3-2025-Forwarding-shares-to-peersr appends this after the first part of the transaction data and the two ExtraNonce values.
+    /// **Generation transaction (part 2)**. The miner appends this after the first part of the transaction data and the two ExtraNonce values.
     ///
     /// **List of merkle branches**. The generation transaction is hashed against the merkle branches to build the final merkle root.
     ///
@@ -1479,85 +1481,94 @@ impl Notifier {
     /// * `Err(StratumErrors)` if an error occurs while constructing or sending a job notification.
     ///
     pub async fn run_notifier(
-        &mut self,
+        mut self,
         downstream_connection_map: Arc<Mutex<ConnectionMapping>>,
-        latest_template_arc: &mut Arc<Mutex<BlockTemplate>>,
-        latest_template_merkle_branch_arc: &mut Arc<Mutex<Vec<Vec<u8>>>>,
+        latest_template_arc: Arc<Mutex<BlockTemplate>>,
+        latest_template_merkle_branch_arc: Arc<Mutex<Vec<Vec<u8>>>>,
         latest_template_id: Arc<Mutex<TemplateId>>,
-    ) -> Result<(), StratumErrors> {
+        shutdown_tx: tokio::sync::mpsc::Sender<()>,
+        cancellation_token: tokio_util::sync::CancellationToken,
+        task_manager: Arc<TaskManager>,
+    ) {
         debug!("Stratum notifier task started");
-        while let Some(notification_command) = self.notification_receiver.recv().await {
-            match notification_command {
-                //Whenever a new template is received it is broadcasted across all the downstream nodes connected .
-                NotifyCmd::SendToAll {
-                    template,
-                    merkle_branch_coinbase,
-                    template_id,
-                } => {
-                    debug!(
-                        template_id = %template_id,
-                        "Received new block template"
-                    );
-                    let connection_snapshot = downstream_connection_map
-                        .lock()
-                        .await
-                        .downstream_channel_mapping
-                        .clone();
-                    //We will receive the template from the IPC channel and construct a valid job
-                    //from the provided template and pass onto the message_reciver in the handle connection for
-                    // downstream communication to take place.
-                    for (peer_adr, mining_job_arc) in self.job_map_arc.lock().await.iter() {
-                        let connection_info = match connection_snapshot.get(peer_adr) {
-                            Some(info) => info,
-                            None => {
-                                warn!(
-                                    template_id = %template_id,
-                                    peer = %peer_adr,
-                                    "Peer not found in connection mapping during job notification - skipping notification"
-                                );
-                                continue;
-                            }
+        task_manager.spawn(async move{
+            loop{
+                tokio::select! {
+                    notification_command = self.notification_receiver.recv()=>{
+                        let Some(notification_command) = notification_command else {
+                            error!("An error occurred while receiving notification");
+                            break;
                         };
-                        let connection_id_hex = format!("{:x}", connection_info.connection_id);
-                        let mut template_for_job = template.clone();
-                        template_for_job.transactions.remove(0);
+                        match notification_command {
+                            //Whenever a new template is received it is broadcasted across all the downstream nodes connected .
+                            NotifyCmd::SendToAll {
+                                template,
+                                merkle_branch_coinbase,
+                                template_id,
+                            } => {
+                                debug!(
+                                    template_id = %template_id,
+                                    "Received new block template"
+                                );
+                                let connection_snapshot = downstream_connection_map
+                                    .lock()
+                                    .await
+                                    .downstream_channel_mapping
+                                    .clone();
+                                //We will receive the template from the IPC channel and construct a valid job
+                                //from the provided template and pass onto the message_reciver in the handle connection for
+                                // downstream communication to take place per channel mapping.
+                                for (peer_adr, mining_job_arc) in self.job_map_arc.lock().await.iter() {
+                                    let connection_info = match connection_snapshot.get(peer_adr) {
+                                        Some(info) => info,
+                                        None => {
+                                            warn!(
+                                                template_id = %template_id,
+                                                peer = %peer_adr,
+                                                "Peer not found in connection mapping during job notification - skipping notification"
+                                            );
+                                            continue;
+                                        }
+                                    };
+                                    let connection_id_hex = format!("{:x}", connection_info.connection_id);
+                                    let mut template_for_job = template.clone();
+                                    template_for_job.transactions.remove(0);
 
-                        let mut curr_peer_mining_job_map = mining_job_arc.lock().await;
-                        // Clean Jobs. If true, miners should abort their current work and immediately use the new job,
-                        // even if it degrades hashrate in the short term. If false, they can still use the current job,
-                        // but should move to the new one as soon as possible without impacting hashrate.
-                        let clean_job = false;
-                        let job_notification = match Self::construct_job_notification(
-                            clean_job,
-                            template.clone(),
-                            template_id,
-                            merkle_branch_coinbase.clone(),
-                        )
-                        .await
-                        {
-                            Ok(job) => job,
-                            Err(e) => {
-                                error!(
-                                    connection_id = %connection_id_hex,
-                                    template_id = %template_id,
-                                    peer = %peer_adr,
-                                    error = %e,
-                                    reason = "job_construction_failed",
-                                    "Failed to construct job for peer"
-                                );
-                                continue; // Skip this peer but continue with others
-                            }
-                        };
-                        let current_system_time = std::time::SystemTime::now();
-                        let duration_since_epoch =
-                            match current_system_time.duration_since(UNIX_EPOCH) {
-                                Ok(duration) => duration,
-                                Err(error) => {
-                                    return Err(StratumErrors::ErrorFetchingCurrentUNIXTimestamp {
-                                        error: error.to_string(),
-                                    })
-                                }
-                            };
+                                    let mut curr_peer_mining_job_map = mining_job_arc.lock().await;
+                                    // Clean Jobs. If true, miners should abort their current work and immediately use the new job,
+                                    // even if it degrades hashrate in the short term. If false, they can still use the current job,
+                                    // but should move to the new one as soon as possible without impacting hashrate.
+                                    let clean_job = false;
+                                    let job_notification = match Self::construct_job_notification(
+                                        clean_job,
+                                        template.clone(),
+                                        template_id,
+                                        merkle_branch_coinbase.clone(),
+                                    )
+                                    .await
+                                    {
+                                        Ok(job) => job,
+                                        Err(e) => {
+                                            error!(
+                                                connection_id = %connection_id_hex,
+                                                template_id = %template_id,
+                                                peer = %peer_adr,
+                                                error = %e,
+                                                reason = "job_construction_failed",
+                                                "Failed to construct job for peer"
+                                            );
+                                            continue; // Skip this peer but continue with others
+                                        }
+                                    };
+                                    let current_system_time = std::time::SystemTime::now();
+                                    let duration_since_epoch =
+                                        match current_system_time.duration_since(UNIX_EPOCH) {
+                                            Ok(duration) => duration,
+                                            Err(error) => {
+                                                error!("An error occured while sending notification to downstream client - {} - {}",peer_adr,error.to_string());
+                                                continue;
+                                            }
+                                        };
 
                         let unix_timestamp = match duration_since_epoch.as_secs().to_u32() {
                             Some(ts) => ts,
@@ -1567,34 +1578,34 @@ impl Notifier {
                             }
                         };
 
-                        let job_details = JobDetails {
-                            blocktemplate: template_for_job,
-                            coinbase1: job_notification.coinbase1.clone(),
-                            coinbase2: job_notification.coinbase2.clone(),
-                            coinbase_merkle_path: job_notification.merkle_branches.clone(),
-                            coinbase_witness_commitment: job_notification
-                                .coinbase_witness_commitment,
-                            job_sent_time: unix_timestamp,
-                        };
+                                    let job_details = JobDetails {
+                                        blocktemplate: template_for_job,
+                                        coinbase1: job_notification.coinbase1.clone(),
+                                        coinbase2: job_notification.coinbase2.clone(),
+                                        coinbase_merkle_path: job_notification.merkle_branches.clone(),
+                                        coinbase_witness_commitment: job_notification
+                                            .coinbase_witness_commitment,
+                                        job_sent_time: unix_timestamp,
+                                    };
 
-                        let numeric_job_id = curr_peer_mining_job_map
-                            .insert_mining_job(template_id, job_details)
-                            .await;
+                                    let numeric_job_id = curr_peer_mining_job_map
+                                        .insert_mining_job(template_id, job_details)
+                                        .await;
 
-                        let job_notification_response = JobNotificationResponse {
-                            method: "mining.notify".to_string(),
-                            params: json!([
-                                numeric_job_id.to_string(),
-                                job_notification.prevhash,
-                                job_notification.coinbase1,
-                                job_notification.coinbase2,
-                                job_notification.merkle_branches,
-                                job_notification.version,
-                                job_notification.nbits,
-                                job_notification.ntime,
-                                job_notification.clean_jobs
-                            ]),
-                        };
+                                    let job_notification_response = JobNotificationResponse {
+                                        method: "mining.notify".to_string(),
+                                        params: json!([
+                                            numeric_job_id.to_string(),
+                                            job_notification.prevhash,
+                                            job_notification.coinbase1,
+                                            job_notification.coinbase2,
+                                            job_notification.merkle_branches,
+                                            job_notification.version,
+                                            job_notification.nbits,
+                                            job_notification.ntime,
+                                            job_notification.clean_jobs
+                                        ]),
+                                    };
 
                         let job_notification_json =
                             match serde_json::to_string(&job_notification_response) {
@@ -1622,35 +1633,33 @@ impl Notifier {
                     }
                 }
 
-                NotifyCmd::SendLatestTemplateToNewDownstream {
-                    new_downstream_addr,
-                } => {
-                    let current_template_id = *latest_template_id.lock().await;
-                    let connection_entry = {
-                        let current_downstream_mapping = downstream_connection_map.lock().await;
-                        current_downstream_mapping
-                            .downstream_channel_mapping
-                            .get(&new_downstream_addr)
-                            .cloned()
-                    };
-                    let connection_entry = match connection_entry {
-                        Some(entry) => entry,
-                        None => {
-                            error!(peer = %new_downstream_addr, "Mining peer not found in connection mapping");
-                            return Err(StratumErrors::PeerNotFoundInConnectionMapping {
-                                peer_addr: new_downstream_addr,
-                            });
-                        }
-                    };
-                    let connection_id_hex = format!("{:x}", connection_entry.connection_id);
+                            NotifyCmd::SendLatestTemplateToNewDownstream {
+                                new_downstream_addr,
+                            } => {
+                                let current_template_id = *latest_template_id.lock().await;
+                                let connection_entry = {
+                                    let current_downstream_mapping = downstream_connection_map.lock().await;
+                                    current_downstream_mapping
+                                        .downstream_channel_mapping
+                                        .get(&new_downstream_addr)
+                                        .cloned()
+                                };
+                                let connection_entry = match connection_entry {
+                                    Some(entry) => entry,
+                                    None => {
+                                        error!(peer = %new_downstream_addr, "Mining peer not found in connection mapping");
+                                        continue;
+                                    }
+                                };
+                                let connection_id_hex = format!("{:x}", connection_entry.connection_id);
 
-                    if current_template_id == 0 {
-                        warn!(
-                            connection_id = %connection_id_hex,
-                            "No templates generated yet for new miner"
-                        );
-                        continue; // Skip but keep notifier running
-                    }
+                                if current_template_id == 0 {
+                                    warn!(
+                                        connection_id = %connection_id_hex,
+                                        "No templates generated yet for new miner"
+                                    );
+                                    continue; // Skip but keep notifier running
+                                }
 
                     let latest_template = latest_template_arc.lock().await.to_owned();
                     let latest_template_merkle_branch =
@@ -1671,99 +1680,107 @@ impl Notifier {
                         };
                     let mut curr_peer_mining_job_map = current_peer_mining_job_map_arc.lock().await;
 
-                    // Clean Jobs. If true, miners should abort their current work and immediately use the new job, even if it degrades hashrate in the short term.
-                    // If false, they can still use the current job, but should move to the new one as soon as possible without impacting hashrate.
-                    let clean_job = false;
-                    let job_notification = Self::construct_job_notification(
-                        clean_job,
-                        latest_template.clone(),
-                        current_template_id,
-                        latest_template_merkle_branch,
-                    )
-                    .await;
-                    let current_system_time = std::time::SystemTime::now();
-                    let duration_since_epoch = match current_system_time.duration_since(UNIX_EPOCH)
-                    {
-                        Ok(duration) => duration,
-                        Err(error) => {
-                            return Err(StratumErrors::ErrorFetchingCurrentUNIXTimestamp {
-                                error: error.to_string(),
-                            })
-                        }
-                    };
+                                // Clean Jobs. If true, miners should abort their current work and immediately use the new job, even if it degrades hashrate in the short term.
+                                // If false, they can still use the current job, but should move to the new one as soon as possible without impacting hashrate.
+                                let clean_job = false;
+                                let job_notification = Self::construct_job_notification(
+                                    clean_job,
+                                    latest_template.clone(),
+                                    current_template_id,
+                                    latest_template_merkle_branch,
+                                )
+                                .await;
+                                let current_system_time = std::time::SystemTime::now();
+                                let duration_since_epoch = match current_system_time.duration_since(UNIX_EPOCH)
+                                {
+                                    Ok(duration) => duration,
+                                    Err(error) => {
+                                        error!("An error occured while sending notification to downstream client - {} - {}",new_downstream_addr,error.to_string());
+                                        continue;
+                                    }
+                                };
 
-                    let unix_timestamp = match duration_since_epoch.as_secs().to_u32() {
+                                let unix_timestamp = match duration_since_epoch.as_secs().to_u32() {
                         Some(ts) => ts,
                         None => {
                             error!("System timestamp overflow for new miner notification");
                             continue;
                         }
                     };
-                    let serialized_notification: Result<String, StratumErrors> =
-                        match job_notification {
-                            Ok(job) => {
-                                //Updating the existing `JobMap` with the new job constructed from the newly generated
-                                //template received from IPC .
-                                //Removing stale coinbase
-                                let mut latest_template_ref = latest_template.clone();
-                                latest_template_ref.transactions.remove(0);
-                                let job_details = JobDetails {
-                                    blocktemplate: latest_template_ref,
-                                    coinbase1: job.coinbase1.clone(),
-                                    coinbase2: job.coinbase2.clone(),
-                                    coinbase_merkle_path: job.merkle_branches.clone(),
-                                    coinbase_witness_commitment: job.coinbase_witness_commitment,
-                                    job_sent_time: unix_timestamp,
-                                };
-                                let numeric_job_id = curr_peer_mining_job_map
-                                    .insert_mining_job(current_template_id, job_details)
-                                    .await;
-                                let job_notification_response = JobNotificationResponse {
-                                    method: "mining.notify".to_string(),
-                                    params: json!([
-                                        numeric_job_id.to_string(),
-                                        job.prevhash,
-                                        job.coinbase1,
-                                        job.coinbase2,
-                                        job.merkle_branches,
-                                        job.version,
-                                        job.nbits,
-                                        job.ntime,
-                                        job.clean_jobs
-                                    ]),
-                                };
-                                serde_json::to_string(&job_notification_response).map_err(|_| {
+                                let serialized_notification: Result<String, StratumErrors> =
+                                    match job_notification {
+                                        Ok(job) => {
+                                            //Updating the existing `JobMap` with the new job constructed from the newly generated
+                                            //template received from IPC .
+                                            //Removing stale coinbase
+                                            let mut latest_template_ref = latest_template.clone();
+                                            latest_template_ref.transactions.remove(0);
+                                            let job_details = JobDetails {
+                                                blocktemplate: latest_template_ref,
+                                                coinbase1: job.coinbase1.clone(),
+                                                coinbase2: job.coinbase2.clone(),
+                                                coinbase_merkle_path: job.merkle_branches.clone(),
+                                                coinbase_witness_commitment: job.coinbase_witness_commitment,
+                                                job_sent_time: unix_timestamp,
+                                            };
+                                            let numeric_job_id = curr_peer_mining_job_map
+                                                .insert_mining_job(current_template_id, job_details)
+                                                .await;
+                                            let job_notification_response = JobNotificationResponse {
+                                                method: "mining.notify".to_string(),
+                                                params: json!([
+                                                    numeric_job_id.to_string(),
+                                                    job.prevhash,
+                                                    job.coinbase1,
+                                                    job.coinbase2,
+                                                    job.merkle_branches,
+                                                    job.version,
+                                                    job.nbits,
+                                                    job.ntime,
+                                                    job.clean_jobs
+                                                ]),
+                                            };
+                                            serde_json::to_string(&job_notification_response).map_err(|_| {
                                     StratumErrors::JobNotificationNotConstructed {
                                         job_template: latest_template.clone(),
                                     }
                                 })
+                                        }
+                                        Err(error) => Err(error),
+                                    };
+                                let job_notification = match serialized_notification {
+                                    Ok(job) => job,
+                                    Err(error) => {
+                                        error!(
+                                            error = %error,
+                                            "Error occurred while fetching the job notification"
+                                        );
+                                        continue;
+                                    }
+                                };
+                                match connection_entry.sender.send(job_notification).await {
+                                    Ok(_) => {
+                                        info!("Latest available job template sent to downstream miner upon connection !");
+                                    }
+                                    Err(error) => {
+                                        error!("An error occurred while sending the notification via downstream sender channel {}",error.to_string());
+                                        continue;
+                                    }
+                                };
                             }
-                            Err(error) => Err(error),
-                        };
-                    let job_notification = match serialized_notification {
-                        Ok(job) => job,
-                        Err(error) => {
-                            error!(
-                                error = %error,
-                                "Error occurred while fetching the job notification"
-                            );
-                            return Err(error);
                         }
-                    };
-                    match connection_entry.sender.send(job_notification).await {
-                        Ok(_) => {}
-                        Err(error) => {
-                            return Err(StratumErrors::NotifyMessageNotSent {
-                                error: error.to_string(),
-                                msg: error.0,
-                                msg_type: "LatestTemplateSent".to_string(),
-                            })
-                        }
-                    };
+
+                    }
+                    _ = cancellation_token.cancelled() => {
+                        debug!(component = "notification_task", "Shutdown signal received, exiting gracefully");
+                        break;
+                    }
                 }
+
             }
-        }
-        Ok(())
+            drop(shutdown_tx);
+            drop(self.notification_receiver);
+        });
     }
 }
 ///Connection information associated with each downstream peer associated along with the mapped `Sender_channel` for sending downstream responses and communication.
@@ -1825,12 +1842,16 @@ impl Server {
     /// * `Ok(())` – Runs indefinitely; returns only if the listener loop is broken or an unrecoverable error occurs.
     /// * `Err(Box<std::io::Error>)` – If binding to the server address fails.
     pub async fn run_stratum_service(
-        &mut self,
+        self,
+        //This should be server owned
         mining_job_map: Arc<Mutex<HashMap<String, Arc<Mutex<MiningJobMap>>>>>,
-        notification_sender: mpsc::Sender<NotifyCmd>,
+        notification_sender: mpsc::UnboundedSender<NotifyCmd>,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
         ibd_or_not: Arc<AtomicBool>,
-    ) -> Result<(), Box<std::io::Error>> {
+        cancellation_token: CancellationToken,
+        shutdown_completion_tx: tokio::sync::mpsc::Sender<()>,
+        task_manager: Arc<TaskManager>,
+    ) {
         debug!("Starting stratum server");
         let bind_address = format!(
             "{}:{}",
@@ -1840,7 +1861,7 @@ impl Server {
             Ok(listener) => listener,
             Err(e) => {
                 error!(address = %bind_address, error = %e, "Failed to bind stratum server");
-                return Err(Box::new(e));
+                return;
             }
         };
 
@@ -1860,26 +1881,28 @@ impl Server {
                 info!(endpoint = %endpoint, "Stratum server is listening");
             }
         }
+        let task_manager_ref = task_manager.clone();
+        task_manager.spawn(async move{
         loop {
             tokio::select! {
-                    event = listener.accept()=>{
-                        //Currently we do not accept connections from downstream during IBD wrt to sync nodes
-                        if ibd_or_not.load(std::sync::atomic::Ordering::SeqCst) == true{
-                        warn!("Braid node not synced and is under IBD thus skipping the connection from downstream.");
-                            continue;
-                        }
-                        else{
-                 //shared ownership across all tasks and spawning a seperate downstream for each new connection
-                 let self_ = Arc::new(Mutex::new(DownstreamClient::default()));
-                        let (connection_id, connection_id_hex) = {
-                            let mut client = self_.lock().await;
+                event = listener.accept()=>{
+                //Currently we do not accept connections from downstream during IBD wrt to sync nodes
+                if ibd_or_not.load(std::sync::atomic::Ordering::SeqCst) == true{
+                warn!("Braid node not synced and is under IBD thus skipping the connection from downstream.");
+                    continue;
+                }
+                else
+                {
+                    //shared ownership across all tasks and spawning a seperate downstream for each new connection
+                 let mut self_ = DownstreamClient::default();
+                 let (connection_id, connection_id_hex) = {
                     if let Some(ref submission_tx) = self.block_submission_tx {
-                         client.block_submission_tx = Some(submission_tx.clone());
+                         self_.block_submission_tx = Some(submission_tx.clone());
                      }
-                            let id = client.connection_id;
-                            (id, format!("{:x}", id))
-                        };
-                 //downstream miner mapping for associated jobs for a specific channel for downstream
+                            let id = self_.connection_id;
+                        (id, format!("{:x}", id))
+                    };
+                    //downstream miner mapping for associated jobs for a specific channel for downstream
                  let self_mining_map = Arc::new(Mutex::new(MiningJobMap::new()));
                  match event{
                      Ok((stream,peer_addr))=>{
@@ -1898,26 +1921,26 @@ impl Server {
                                     .await
                                     .new_connection(peer_addr.to_string(), connection_id, downstream_tx.clone());
                          info!(
+                            connection_id = %connection_id_hex,
+                            peer = %peer_addr,
+                            "Miner connected"
+                            );
+                            let cancellation_token_ref = cancellation_token.clone();
+                            let shutdown_complete_tx_ref = shutdown_completion_tx.clone();self_.downstream_ip = peer_addr.to_string();
+                            let connection_mapping_clone = Arc::clone(&self.downstream_connection_mapping);
+                            let mining_job_map_clone = Arc::clone(&mining_job_map);
+                            let peer_addr_string = peer_addr.to_string();
+                         // Catering each new connection as seperate process
+                         task_manager_ref.spawn(async move{
+                             let _=  Self::handle_downstream_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref,cancellation_token_ref,shutdown_complete_tx_ref).await;
+
+                              debug!(
                                     connection_id = %connection_id_hex,
-                                    peer = %peer_addr,
-                                    "Miner connected"
+                                    peer = %peer_addr_string,
+                                    "Cleaning up disconnected miner"
                                 );
-                         self_.lock().await.downstream_ip = peer_addr.to_string();
 
-                         let connection_mapping_clone = Arc::clone(&self.downstream_connection_mapping);
-                         let mining_job_map_clone = Arc::clone(&mining_job_map);
-                         let peer_addr_string = peer_addr.to_string();
-
-                         // catering each new connection as seperate process
-                         tokio::spawn(async move{
-                             let _=  Self::handle_connection(self_.clone(),peer_addr,reader,writer,&mut downstream_rx,self_mining_map.clone(),downstream_tx,notification_sender,swarm_handler_arc_ref).await;
-                             debug!(
-                                        connection_id = %connection_id_hex,
-                                        peer = %peer_addr_string,
-                                        "Cleaning up disconnected miner"
-                                    );
-
-                             // cleanup after connection closes, remove from connection mapping
+                             // Cleanup after connection closes, remove from connection mapping
                              connection_mapping_clone
                                      .lock()
                                      .await
@@ -1948,8 +1971,12 @@ impl Server {
                         }
                     }
                 }
-            }
+                _ = cancellation_token.cancelled() => {
+                        debug!(component = "stratum_service", "Shutdown signal received, exiting gracefully");
+                        break;}}
         }
+            drop(shutdown_completion_tx);
+        });
     }
     /// Handles an individual downstream miner connection over TCP.
     ///
@@ -1969,26 +1996,34 @@ impl Server {
     /// * `Ok(())` – Connection terminated normally (client closed the connection).
     /// * `Err(Box<StratumErrors>)` – On stream reading/writing errors or if the request handling fails.
     ///
-    pub async fn handle_connection(
-        downstream_client: Arc<Mutex<DownstreamClient>>,
+    pub async fn handle_downstream_connection(
+        //per peer
+        mut downstream_client: DownstreamClient,
+        //per peer
         peer_addr: SocketAddr,
+        //per peer
         stream_reader: OwnedReadHalf,
         mut stream_writer: OwnedWriteHalf,
+        //per peer
         downstream_receiver: &mut mpsc::Receiver<String>,
+        //per peer jobs mapping
         mining_job_map: Arc<Mutex<MiningJobMap>>,
+        //per peer sender to be provided as reponse of a request from client2server
         downstream_message_sender: mpsc::Sender<String>,
-        notification_sender: mpsc::Sender<NotifyCmd>,
+        //per peer notification sender providing latest template upon connection establishment after authorization
+        notification_sender: mpsc::UnboundedSender<NotifyCmd>,
+        //common swarm_handler this lock is not required because at granular level the lock is already there
         swarm_handler: Arc<Mutex<SwarmHandler>>,
-    ) -> Result<(), Box<StratumErrors>> {
+        //per peer specific task shutdown and cancellation token
+        cancellation_token: CancellationToken,
+        shutdown_completion_tx: tokio::sync::mpsc::Sender<()>,
+    ) {
         const MAX_LINE_LENGTH: usize = 2_usize.pow(16);
         //It can be excessively inefficient to work directly with a AsyncRead instance. A BufReader performs large, infrequent reads on the underlying AsyncRead and maintains an in-memory buffer of the results.
         let reader = BufReader::new(stream_reader);
         //reading incoming stream frame by frame
         let mut framed = FramedRead::new(reader, LinesCodec::new_with_max_length(MAX_LINE_LENGTH));
-        let connection_id_hex = {
-            let client = downstream_client.lock().await;
-            format!("{:x}", client.connection_id)
-        };
+        let connection_id_hex = { format!("{:x}", downstream_client.connection_id) };
         debug!(
             connection_id = %connection_id_hex,
             peer = %peer_addr,
@@ -1998,7 +2033,7 @@ impl Server {
         loop {
             tokio::select! {
                 Some(message) = downstream_receiver.recv()=>{
-                    trace!(
+                    debug!(
                         connection_id = %connection_id_hex,
                         message = ?message,
                         peer = %peer_addr,
@@ -2008,7 +2043,7 @@ impl Server {
                     let write_or_not = stream_writer.write_all(format!("{}\n",message).as_bytes()).await;
                     match write_or_not{
                         Ok(_)=>{
-                            trace!(
+                            debug!(
                                 connection_id = %connection_id_hex,
                                 peer = %peer_addr,
                                 "Response written to stream"
@@ -2022,6 +2057,7 @@ impl Server {
                                 peer = %peer_addr,
                                 "Failed to write to stream"
                             );
+                            break;
                         }
                     }
                 }
@@ -2040,30 +2076,37 @@ impl Server {
                         //Parsing the lines read from buffer to find out whether they are valid JSON request type to be server as per
                         //stratum or not .
                         match serde_json::from_str::<StandardRequest>(&line) {
-                                Ok(request) => {
-                         let server_request_res:Result<StratumResponses, StratumErrors> = downstream_client.lock().await.handle_client_to_server_request(request,mining_job_map.clone(),downstream_message_sender.clone(),notification_sender.clone(),peer_addr.to_string(),swarm_handler.clone()).await;
-                         match server_request_res{
-                            Ok(_)=>{
-
-                            },
-                            Err(error)=>{
-                                return Err(Box::new(error))
-                            }
-                         }
+                            Ok(parsed_request) => {
+                                let server_request_res:Result<StratumResponses, StratumErrors> = downstream_client.handle_client_to_server_request(parsed_request,mining_job_map.clone(),downstream_message_sender.clone(),notification_sender.clone(),peer_addr.to_string(),swarm_handler.clone()).await;
+                                    match server_request_res{
+                                        Ok(response_received)=>{
+                                            debug!("Response received succesfully  - {:?} ",response_received);
+                                        },
+                                        Err(error)=>{
+                                            error!(
+                                                    connection_id = %connection_id_hex,
+                                                    peer = %peer_addr,
+                                                    error = %error,
+                                                    line = %line,
+                                                    error_type = "reader_task",
+                                                    "Failed to process JSON request for downstream"
+                                                );
+                                                break;
+                                        }
+                                    }
                                 }
-                                Err(e) => {
-                                    error!(
-                                        connection_id = %connection_id_hex,
-                                        peer = %peer_addr,
-                                        error = %e,
-                                        line = %line,
-                                        error_type = "json_parse",
-                                        "Failed to parse JSON request"
-                                    );
+                                    Err(e) => {
+                                        error!(
+                                            connection_id = %connection_id_hex,
+                                            peer = %peer_addr,
+                                            error = %e,
+                                            line = %line,
+                                            error_type = "json_parse",
+                                            "Failed to parse JSON request"
+                                        );
+                                        break;
+                                    }
                                 }
-                            }
-
-
                         }
                         Some(Err(e)) => {
                             error!(
@@ -2071,9 +2114,9 @@ impl Server {
                                 error = %e,
                                 peer = %peer_addr,
                                 fatal = true,
-                                "Fatal error reading from stream"
+                                "Fatal error reading from stream closing connection with downstream"
                             );
-                            return Err(Box::new(StratumErrors::UnableToReadStream { error: e }));
+                            break;
                         }
                         None => {
                             info!(
@@ -2082,14 +2125,17 @@ impl Server {
                                 "Connection closed by client"
                             );
                             break;
-
                         }
                     }
+                }
+                _ = cancellation_token.cancelled() => {
+                        debug!(component = "stratum_service", "Shutdown signal received, exiting gracefully");
+                        break;
                 }
 
             }
         }
-        Ok(())
+        drop(shutdown_completion_tx);
     }
 }
 #[allow(dead_code, unused)]
@@ -2108,7 +2154,7 @@ mod test {
         absolute::LockTime, pow::CompactTargetExt, script::ScriptBufExt, Amount, BlockHash,
         BlockVersion, OutPoint, ScriptBuf, Sequence, TxIn, TxOut,
     };
-    use futures::lock::Mutex;
+    use futures::{channel::oneshot::Cancellation, lock::Mutex};
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
         net::TcpStream,
@@ -2124,7 +2170,7 @@ mod test {
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
+        let notify_tx = mpsc::unbounded_channel::<NotifyCmd>().0;
         let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
@@ -2136,17 +2182,20 @@ mod test {
         };
 
         let mut server = Server::new(config.clone(), connection_mapping.clone(), None);
-
-        let server_task = tokio::spawn(async move {
-            let _ = server
-                .run_stratum_service(
-                    mining_job_map,
-                    notify_tx,
-                    swarm_handler_arc,
-                    test_ibd_spinlock.clone(),
-                )
-                .await;
-        });
+        let test_task_manager = Arc::new(TaskManager::new());
+        let test_token = CancellationToken::new();
+        let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        server
+            .run_stratum_service(
+                mining_job_map,
+                notify_tx,
+                swarm_handler_arc.clone(),
+                test_ibd_spinlock.clone(),
+                test_token.clone(),
+                shutdown_complete_tx.clone(),
+                test_task_manager.clone(),
+            )
+            .await;
 
         tokio::time::sleep(Duration::from_millis(300)).await;
 
@@ -2177,7 +2226,6 @@ mod test {
         let conn_map = connection_mapping.lock().await;
         assert_eq!(conn_map.downstream_channel_mapping.len(), 3);
         drop(streams);
-        drop(server_task);
     }
 
     #[tokio::test]
@@ -2193,7 +2241,7 @@ mod test {
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
-        let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
+        let notify_tx = mpsc::unbounded_channel::<NotifyCmd>().0;
 
         let config = StratumServerConfig {
             hostname: "127.0.0.1".to_string(),
@@ -2203,16 +2251,20 @@ mod test {
 
         let mut server = Server::new(config.clone(), connection_mapping.clone(), None);
 
-        let server_task = tokio::spawn(async move {
-            let _ = server
-                .run_stratum_service(
-                    mining_job_map,
-                    notify_tx,
-                    swarm_handler_arc,
-                    test_ibd_spinlock,
-                )
-                .await;
-        });
+        let test_task_manager = Arc::new(TaskManager::new());
+        let test_token = CancellationToken::new();
+        let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        server
+            .run_stratum_service(
+                mining_job_map,
+                notify_tx,
+                swarm_handler_arc.clone(),
+                test_ibd_spinlock.clone(),
+                test_token.clone(),
+                shutdown_complete_tx.clone(),
+                test_task_manager.clone(),
+            )
+            .await;
 
         tokio::time::sleep(Duration::from_millis(300)).await;
 
@@ -2233,13 +2285,13 @@ mod test {
     #[tokio::test]
     async fn test_mining_authorize_response() {
         let ibd_or_not: AtomicBool = AtomicBool::new(false);
-        let ibd_spinlock = Arc::new(ibd_or_not);
+        let test_ibd_spinlock = Arc::new(ibd_or_not);
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
+        let notify_tx = mpsc::unbounded_channel::<NotifyCmd>().0;
         let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
@@ -2252,16 +2304,20 @@ mod test {
 
         let port = config.port;
         let mut server = Server::new(config, connection_mapping, None);
-        tokio::spawn(async move {
-            let _ = server
-                .run_stratum_service(
-                    mining_job_map,
-                    notify_tx,
-                    swarm_handler_arc,
-                    ibd_spinlock.clone(),
-                )
-                .await;
-        });
+        let test_task_manager = Arc::new(TaskManager::new());
+        let test_token = CancellationToken::new();
+        let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        server
+            .run_stratum_service(
+                mining_job_map,
+                notify_tx,
+                swarm_handler_arc.clone(),
+                test_ibd_spinlock.clone(),
+                test_token.clone(),
+                shutdown_complete_tx.clone(),
+                test_task_manager.clone(),
+            )
+            .await;
 
         tokio::time::sleep(Duration::from_millis(300)).await;
 
@@ -2284,14 +2340,14 @@ mod test {
     #[tokio::test]
     async fn test_mining_set_difficulty_response() {
         let ibd_or_not: AtomicBool = AtomicBool::new(false);
-        let ibd_spinlock = Arc::new(ibd_or_not);
+        let test_ibd_spinlock = Arc::new(ibd_or_not);
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
         let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
+        let notify_tx = mpsc::unbounded_channel::<NotifyCmd>().0;
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -2302,16 +2358,20 @@ mod test {
         };
         let port = config.port;
         let mut server = Server::new(config, connection_mapping, None);
-        tokio::spawn(async move {
-            let _ = server
-                .run_stratum_service(
-                    mining_job_map,
-                    notify_tx,
-                    swarm_handler_arc,
-                    ibd_spinlock.clone(),
-                )
-                .await;
-        });
+        let test_task_manager = Arc::new(TaskManager::new());
+        let test_token = CancellationToken::new();
+        let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        server
+            .run_stratum_service(
+                mining_job_map,
+                notify_tx,
+                swarm_handler_arc.clone(),
+                test_ibd_spinlock.clone(),
+                test_token.clone(),
+                shutdown_complete_tx.clone(),
+                test_task_manager.clone(),
+            )
+            .await;
         tokio::time::sleep(Duration::from_millis(300)).await;
         let addr = format!("127.0.0.1:{}", port);
         let mut stream = TcpStream::connect(&addr).await.unwrap();
@@ -2327,7 +2387,7 @@ mod test {
     #[tokio::test]
     async fn test_invalid_json() {
         let ibd_or_not: AtomicBool = AtomicBool::new(false);
-        let ibd_spinlock = Arc::new(ibd_or_not);
+        let test_ibd_spinlock = Arc::new(ibd_or_not);
         let connection_mapping = Arc::new(Mutex::new(ConnectionMapping::new()));
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
@@ -2335,7 +2395,7 @@ mod test {
         let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
         let mining_job_map: Arc<Mutex<HashMap<String, Arc<Mutex<MiningJobMap>>>>> =
             Arc::new(Mutex::new(HashMap::new()));
-        let (notify_tx, _notify_rx) = mpsc::channel::<NotifyCmd>(32);
+        let notify_tx = mpsc::unbounded_channel::<NotifyCmd>().0;
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx);
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -2348,31 +2408,36 @@ mod test {
         let mut server = Server::new(config, connection_mapping.clone(), None);
         let mining_job_map_clone = mining_job_map.clone();
         let notify_tx_clone = notify_tx.clone();
-        tokio::spawn(async move {
-            server
-                .run_stratum_service(
-                    mining_job_map_clone,
-                    notify_tx_clone,
-                    swarm_handler_arc,
-                    ibd_spinlock,
-                )
-                .await
-                .unwrap();
-        });
+        let test_task_manager = Arc::new(TaskManager::new());
+        let test_token = CancellationToken::new();
+        let (shutdown_complete_tx, mut shutdown_complete_rx) = mpsc::channel::<()>(1);
+        server
+            .run_stratum_service(
+                mining_job_map,
+                notify_tx,
+                swarm_handler_arc.clone(),
+                test_ibd_spinlock.clone(),
+                test_token.clone(),
+                shutdown_complete_tx.clone(),
+                test_task_manager.clone(),
+            )
+            .await;
 
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let mut stream = TcpStream::connect("127.0.0.1:5050").await.unwrap();
-
+        //Invalid request format (connection will be dropped)
         stream
             .write_all(b"{\"method\":\"mining.subscribe\", \"params\": [\"test\", 1]\n")
             .await
             .unwrap();
         stream.flush().await.unwrap();
-
+        //Invalid request format (connection will be dropped)
         stream.write_all(b"not a json at all\n").await.unwrap();
         stream.flush().await.unwrap();
 
+        //Reconnecting as peer connection is dropped due to invalid request
+        let mut stream = TcpStream::connect("127.0.0.1:5050").await.unwrap();
         tokio::time::sleep(std::time::Duration::from_millis(200)).await;
 
         let valid_msg = r#"{"id": 1, "method": "mining.subscribe", "params": []}"#;

--- a/node/src/task_manager.rs
+++ b/node/src/task_manager.rs
@@ -1,0 +1,90 @@
+use std::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time::{timeout, Duration};
+use tracing::{info, span, warn, Level};
+
+/// Graceful shutdown timeout before forcing abort
+pub const GRACEFUL_SHUTDOWN_TIMEOUT: Duration = Duration::from_secs(5);
+
+pub struct TaskManager {
+    tasks: Mutex<Vec<JoinHandle<()>>>,
+}
+
+impl Default for TaskManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl TaskManager {
+    pub fn new() -> Self {
+        Self {
+            tasks: Mutex::new(Vec::new()),
+        }
+    }
+
+    pub fn spawn<F>(&self, fut: F)
+    where
+        F: std::future::Future<Output = ()> + Send + 'static,
+        F::Output: Send + 'static,
+    {
+        use tracing::Instrument;
+        let location = std::panic::Location::caller();
+        let span = span!(
+            Level::DEBUG,
+            "task",
+            file = location.file(),
+            line = location.line(),
+            column = location.column(),
+        );
+        let handle = tokio::spawn(fut.instrument(span));
+        self.tasks.lock().unwrap().push(handle);
+    }
+
+    /// Wait for all tasks to complete gracefully within timeout.
+    /// Returns true if all tasks completed gracefully, false if timeout occurred.
+    pub async fn shutdown_graceful(&self, timeout_duration: Duration) -> bool {
+        let handles = {
+            let mut tasks = self.tasks.lock().unwrap();
+            std::mem::take(&mut *tasks)
+        };
+
+        let join_future = async {
+            for handle in handles {
+                let _ = handle.await;
+            }
+        };
+
+        match timeout(timeout_duration, join_future).await {
+            Ok(_) => {
+                info!(component = "task_manager", "All tasks completed gracefully");
+                true
+            }
+            Err(_) => {
+                warn!(
+                    component = "task_manager",
+                    "Graceful shutdown timeout exceeded"
+                );
+                false
+            }
+        }
+    }
+
+    pub async fn join_all(&self) {
+        let handles = {
+            let mut tasks = self.tasks.lock().unwrap();
+            std::mem::take(&mut *tasks)
+        };
+
+        for handle in handles {
+            let _ = handle.await;
+        }
+    }
+
+    pub async fn abort_all(&self) {
+        let mut tasks = self.tasks.lock().unwrap();
+        for handle in tasks.drain(..) {
+            handle.abort();
+        }
+    }
+}


### PR DESCRIPTION
Addresses #363 .
- Introduces `StatusSender` which resembles the state of each task initiated for better shutdown management along with `ShutDownMessages` and broadcast notifier.
- `TaskManager` which acts as the centralized future executor for keeping all the tasks `JoinHandles<T>` under single roof .
- Providing access of `CancellationToken` to each task which was earlier limited to few tasks only .
- Better management and reduced `panics` situation leading to better fallbacks in case of recoverable errors and thus improving the inter-communication between processes .