### PR TITLE
Adapting context passing for better network handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -670,7 +670,7 @@ name = "braidpool-cli"
 version = "0.1.0"
 dependencies = [
  "clap",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "tokio",
@@ -1975,44 +1975,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
 dependencies = [
- "base64 0.22.1",
  "bytes",
  "futures-channel",
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.8.1",
- "ipnet",
  "libc",
- "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.2",
- "system-configuration 0.7.0",
  "tokio",
  "tower-service",
  "tracing",
- "windows-registry",
 ]
 
 [[package]]
@@ -2261,16 +2240,6 @@ name = "ipnet"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
-
-[[package]]
-name = "iri-string"
-version = "0.7.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c91338f0783edbd6195decb37bae672fd3b165faffb89bf7b9e6942f8b1a731a"
-dependencies = [
- "memchr",
- "serde",
-]
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -3293,7 +3262,7 @@ dependencies = [
  "libp2p",
  "num",
  "rand 0.8.5",
- "reqwest 0.11.27",
+ "reqwest",
  "secp256k1 0.30.0",
  "serde",
  "serde_json",
@@ -4039,7 +4008,7 @@ dependencies = [
  "http 0.2.12",
  "http-body 0.4.6",
  "hyper 0.14.32",
- "hyper-tls 0.5.0",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
@@ -4062,46 +4031,6 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
  "winreg",
-]
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "encoding_rs",
- "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
- "http-body 1.0.1",
- "http-body-util",
- "hyper 1.8.1",
- "hyper-rustls",
- "hyper-tls 0.6.0",
- "hyper-util",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 1.0.2",
- "tokio",
- "tokio-native-tls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
 ]
 
 [[package]]
@@ -4907,9 +4836,6 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
-dependencies = [
- "futures-core",
-]
 
 [[package]]
 name = "synstructure"
@@ -4938,17 +4864,6 @@ name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
-dependencies = [
- "bitflags 2.10.0",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
@@ -5276,25 +5191,6 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "sync_wrapper 1.0.2",
- "tokio",
- "tower-layer",
- "tower-service",
-]
-
-[[package]]
-name = "tower-http"
-version = "0.6.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
-dependencies = [
- "bitflags 2.10.0",
- "bytes",
- "futures-util",
- "http 1.4.0",
- "http-body 1.0.1",
- "iri-string",
- "pin-project-lite",
- "tower",
  "tower-layer",
  "tower-service",
 ]
@@ -5774,17 +5670,6 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result 0.4.1",
- "windows-strings",
-]
 
 [[package]]
 name = "windows-result"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -96,9 +96,9 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "asn1-rs"
-version = "0.7.1"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56624a96882bb8c26d61312ae18cb45868e5a9992ea73c58e45c3101e56a1e60"
+checksum = "b7f43a50ac4fdca5df8e885c21b835997f0a1cdee65494a6847694a98652d9d8"
 dependencies = [
  "asn1-rs-derive",
  "asn1-rs-impl",
@@ -352,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base-x"
@@ -374,12 +374,11 @@ dependencies = [
 
 [[package]]
 name = "base58ck"
-version = "0.1.0"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+checksum = "ec5dc7e09f7bb15f0062da7c03086d6b71a2c84e0af4fccbbc7d8c6559847816"
 dependencies = [
- "bitcoin-internals 0.3.0",
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.100",
 ]
 
 [[package]]
@@ -456,28 +455,18 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.8"
+version = "0.32.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
+checksum = "39581299241111285f3268ba75ddf372746fd041620918b145c1af9d75e91b6c"
 dependencies = [
- "base58ck 0.1.0",
+ "base58ck 0.1.100",
  "bech32 0.11.1",
- "bitcoin-internals 0.3.0",
- "bitcoin-io 0.1.4",
- "bitcoin-units 0.1.3",
- "bitcoin_hashes 0.14.1",
+ "bitcoin-io 0.1.100",
+ "bitcoin-units 0.1.100",
+ "bitcoin_hashes 0.14.100",
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1 0.29.1",
- "serde",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
-dependencies = [
  "serde",
 ]
 
@@ -498,9 +487,9 @@ checksum = "a90bbbfa552b49101a230fb2668f3f9ef968c81e6f83cf577e1d4b80f689e1aa"
 
 [[package]]
 name = "bitcoin-io"
-version = "0.1.4"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dee39a0ee5b4095224a0cfc6bf4cc1baf0f9624b96b367e53b66d974e51d953"
+checksum = "11301df0b06f22dea7bb1916403fdd88a371031e495c49b8f96931b28189e175"
 
 [[package]]
 name = "bitcoin-io"
@@ -535,11 +524,10 @@ dependencies = [
 
 [[package]]
 name = "bitcoin-units"
-version = "0.1.3"
+version = "0.1.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
+checksum = "57bad157b78d0d1b22c4cbb6a35a566211fc4d14866a37f2c780652b50f3b845"
 dependencies = [
- "bitcoin-internals 0.3.0",
  "serde",
 ]
 
@@ -554,11 +542,11 @@ dependencies = [
 
 [[package]]
 name = "bitcoin_hashes"
-version = "0.14.1"
+version = "0.14.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26ec84b80c482df901772e931a9a681e26a1b9ee2302edeff23cb30328745c8b"
+checksum = "0c9901a56e133a1fc86eeb1113e2591f45f4682451ca893bff494d2f88918e3f"
 dependencies = [
- "bitcoin-io 0.1.4",
+ "bitcoin-io 0.1.100",
  "hex-conservative 0.2.2",
  "serde",
 ]
@@ -611,7 +599,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.8",
+ "bitcoin 0.32.100",
  "serde",
  "serde_json",
 ]
@@ -622,7 +610,7 @@ version = "1.5.4"
 source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#9946d0fe5b4e5b04bef63e5db4a33d044687dd8f"
 dependencies = [
  "async_zmq",
- "bitcoin 0.32.8",
+ "bitcoin 0.32.100",
  "futures-util",
  "zmq",
  "zmq-sys",
@@ -636,9 +624,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 dependencies = [
  "serde_core",
 ]
@@ -687,9 +675,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.20.2"
+version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
 name = "byteorder"
@@ -745,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.63"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -791,9 +779,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -1143,9 +1131,9 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1190,9 +1178,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 dependencies = [
  "serde",
 ]
@@ -1501,11 +1489,11 @@ checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
-version = "3.0.3"
+version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f288b0a4f20f9a56b5d1da57e2227c661b7b16168e2f72365f57b63326e29b24"
+checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 dependencies = [
- "gloo-timers 0.2.6",
+ "gloo-timers 0.4.0",
  "send_wrapper",
 ]
 
@@ -1597,7 +1585,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.4.0",
+ "http 1.4.1",
  "js-sys",
  "pin-project",
  "serde",
@@ -1610,9 +1598,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.2.6"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b995a66bb87bebce9a0f4a95aed01daca4872c050bfcb21653361c03bc35e5c"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1622,9 +1610,9 @@ dependencies = [
 
 [[package]]
 name = "gloo-timers"
-version = "0.3.0"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+checksum = "482ce8a491a501da4cd806bd190275363d674f2845005c6ddbd5d3e1dd54495d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1666,16 +1654,16 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "171fefbc92fe4a4de27e0698d6a5b392d6a0e333506bc49133760b3bcf948733"
 dependencies = [
  "atomic-waker",
  "bytes",
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.0",
+ "http 1.4.1",
  "indexmap",
  "slab",
  "tokio",
@@ -1696,9 +1684,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1845,9 +1833,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.0"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3ba2a386d7f85a81f119ad7498ebe444d2e22c2af0b86b069416ace48b3311a"
+checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
 dependencies = [
  "bytes",
  "itoa",
@@ -1871,7 +1859,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.0",
+ "http 1.4.1",
 ]
 
 [[package]]
@@ -1882,7 +1870,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -1925,16 +1913,16 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.9.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
+checksum = "55281c53a1894c864990125767da440a4e630446785086f52523b20033b74498"
 dependencies = [
  "atomic-waker",
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.13",
- "http 1.4.0",
+ "h2 0.4.14",
+ "http 1.4.1",
  "http-body 1.0.1",
  "httparse",
  "httpdate",
@@ -1951,8 +1939,8 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.0",
- "hyper 1.9.0",
+ "http 1.4.1",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "rustls",
@@ -1983,12 +1971,12 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "libc",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio",
  "tower-service",
  "tracing",
@@ -2119,9 +2107,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2180,9 +2168,9 @@ dependencies = [
  "attohttpc",
  "bytes",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "log",
  "rand 0.8.6",
@@ -2198,7 +2186,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -2238,7 +2226,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "widestring",
  "windows-registry",
  "windows-result",
@@ -2256,6 +2244,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itoa"
@@ -2319,9 +2316,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "142bc4740e452c1e57ade0cbc129f139c9093e354346f0872ef985f4f5cf5f11"
 dependencies = [
  "cfg-if 1.0.4",
  "futures-util",
@@ -2369,7 +2366,7 @@ dependencies = [
  "futures-channel",
  "futures-util",
  "gloo-net",
- "http 1.4.0",
+ "http 1.4.1",
  "jsonrpsee-core",
  "pin-project",
  "rustls",
@@ -2394,7 +2391,7 @@ dependencies = [
  "bytes",
  "futures-timer",
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
  "jsonrpsee-types",
@@ -2420,7 +2417,7 @@ checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
 dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -2455,10 +2452,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d38b0bcf407ac68d241f90e2d46041e6a06988f97fe1721fb80b91c42584fae6"
 dependencies = [
  "futures-util",
- "http 1.4.0",
+ "http 1.4.1",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
+ "hyper 1.10.1",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2481,7 +2478,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66df7256371c45621b3b7d2fb23aea923d577616b9c0e9c0b950a6ea5c2be0ca"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2505,7 +2502,7 @@ version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2da2694c9ff271a9d3ebfe520f6b36820e85133a51be77a3cb549fd615095261"
 dependencies = [
- "http 1.4.0",
+ "http 1.4.1",
  "jsonrpsee-client-transport",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2710,15 +2707,15 @@ dependencies = [
 
 [[package]]
 name = "libp2p-identity"
-version = "0.2.13"
+version = "0.2.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0c7892c221730ba55f7196e98b0b8ba5e04b4155651736036628e9f73ed6fc3"
+checksum = "9525f3831544f7ae497bde79adf114ef127b0fbbb97edbbf692a80408636421c"
 dependencies = [
  "bs58",
  "ed25519-dalek",
  "hkdf",
  "multihash",
- "quick-protobuf",
+ "prost",
  "rand 0.8.6",
  "sha2",
  "thiserror 2.0.18",
@@ -2932,14 +2929,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "f02ab6bace2054fb888a3c16f990117b579d14a3088e472d63c6011fa185c9d3"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "plain",
- "redox_syscall 0.7.4",
+ "redox_syscall 0.8.1",
 ]
 
 [[package]]
@@ -2982,9 +2979,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 dependencies = [
  "value-bag",
 ]
@@ -3036,9 +3033,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
 
 [[package]]
 name = "mime"
@@ -3083,9 +3080,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -3154,11 +3151,10 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "no_std_io2",
  "unsigned-varint 0.8.0",
 ]
 
@@ -3219,7 +3215,7 @@ version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "libc",
  "log",
  "netlink-packet-core",
@@ -3258,19 +3254,10 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3386,9 +3373,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -3455,15 +3442,14 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.80"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "a45fa2aa886c42762255da344f0a0d313e254066c46aad76f300c3d3da62d967"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
- "once_cell",
  "openssl-macros",
  "openssl-sys",
 ]
@@ -3487,9 +3473,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.116"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "f28a22dc7140cda5f096e5e7724a6962ca81a7f8bfd2979f9b18c11af56318c4"
 dependencies = [
  "cc",
  "libc",
@@ -3565,18 +3551,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
+checksum = "2466b2336ed02bcdca6b294417127b90ec92038d1d5c4fbeac971a922e0e0924"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.11"
+version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
+checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3715,7 +3701,7 @@ version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -3745,6 +3731,29 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "440f724eba9f6996b75d63681b0a92b06947f1457076d503a4d2e2c8f56442b8"
 dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "prost"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
+dependencies = [
+ "bytes",
+ "prost-derive",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.14.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
+dependencies = [
+ "anyhow",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn",
@@ -3786,7 +3795,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3823,7 +3832,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3988,16 +3997,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.4"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "5b44b894f2a6e36457d665d1e08c3866add6ed5e70050c1b4ba8a8ddedb02ce7"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -4188,7 +4197,7 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
@@ -4197,9 +4206,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -4212,9 +4221,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -4332,7 +4341,7 @@ version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.100",
  "rand 0.8.6",
  "secp256k1-sys",
  "serde",
@@ -4344,7 +4353,7 @@ version = "0.30.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
- "bitcoin_hashes 0.14.1",
+ "bitcoin_hashes 0.14.100",
  "rand 0.8.6",
  "secp256k1-sys",
  "serde",
@@ -4365,7 +4374,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4390,9 +4399,9 @@ checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "send_wrapper"
-version = "0.4.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f638d531eccd6e23b980caf34876660d38e265409d8e99b397ab71eb3612fad0"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -4426,9 +4435,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.150"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
 dependencies = [
  "itoa",
  "memchr",
@@ -4500,9 +4509,9 @@ dependencies = [
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -4561,9 +4570,9 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -4578,7 +4587,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures",
- "http 1.4.0",
+ "http 1.4.1",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -4702,7 +4711,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -4746,7 +4755,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "byteorder",
  "chrono",
  "crc",
@@ -4912,7 +4921,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -5082,16 +5091,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.2.0",
+ "mio 1.2.1",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2 0.6.4",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -5203,14 +5212,14 @@ dependencies = [
 
 [[package]]
 name = "toml_edit"
-version = "0.25.11+spec-1.1.0"
+version = "0.25.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5219,7 +5228,7 @@ version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -5323,9 +5332,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.20.0"
+version = "1.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
 name = "uint"
@@ -5416,9 +5425,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "d258b83ceec21034727ecee8c382cfa6c3e133699b0742c64571814fb420c9f7"
 dependencies = [
  "getrandom 0.4.2",
  "js-sys",
@@ -5518,9 +5527,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "3ed04576f974d2b2fba0f38c51dbc5518011e38c36bf1143164be765528fd409"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -5531,9 +5540,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.72"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5541,9 +5550,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "916151b09da36bd82f6615cbf3a419e2f0ba23a03c6160e8e92eb6bd4aa1dec6"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5551,9 +5560,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "299047362ccbfce148b67ab7e73349f77748e00c8296f9542adfad2ad82c5c5e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5564,9 +5573,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "9a929b2c61f11ba3e9bc35b50c1f25cb38e0e892c0c231ae2b8cf78d5dad4437"
 dependencies = [
  "unicode-ident",
 ]
@@ -5599,7 +5608,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5607,9 +5616,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6131,9 +6140,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
 ]
@@ -6212,7 +6221,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.13.0",
  "indexmap",
  "log",
  "serde",
@@ -6301,9 +6310,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -6324,18 +6333,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
+checksum = "3b065d4f0e55f82fae73202e189638116a87c55ab6b8e6c2721e13dd9d854ad1"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.48"
+version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
+checksum = "0b631b19d36a892ab55420c92dbc83ccd79274f25be714855d3074aa71cab639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6344,9 +6353,9 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -77,10 +77,7 @@ impl Braid {
     pub fn extend(&mut self, bead: &Bead) -> AddBeadStatus {
         // If the braid is empty and bead has no parents, treat as genesis bead
         if self.beads.is_empty() && bead.committed_metadata.parents.is_empty() {
-            tracing::info!(
-                "I AM A GENESIS BEAD ! - {:?}",
-                bead.block_header.block_hash()
-            );
+            tracing::debug!("Genesis bead - {}", bead.block_header.block_hash());
             *self = Braid::new(vec![bead.clone()]);
             return AddBeadStatus::BeadAdded;
         }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -50,6 +50,7 @@ pub mod ipc;
 pub mod peer_manager;
 pub mod rpc_server;
 pub mod stratum;
+pub mod swarm;
 pub mod template_creator;
 pub mod uncommitted_metadata;
 pub mod utils;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,79 +1,55 @@
-use bitcoin::consensus::encode::deserialize;
 use bitcoin::Network;
 use clap::Parser;
 use futures::lock::Mutex;
-use futures::StreamExt;
-use libp2p::kad::BootstrapOk;
-use libp2p::{
-    core::multiaddr::Multiaddr,
-    floodsub::{self},
-    identify,
-    identity::Keypair,
-    kad::{self, Mode, QueryResult},
-    ping, request_response,
-    swarm::SwarmEvent,
-    PeerId,
-};
-use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
-use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
-use node::utils::BeadHash;
-use node::SwarmHandler;
+use libp2p::{floodsub, identity::Keypair};
 use node::{
-    bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
-    behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
+    behaviour::BRAIDPOOL_TOPIC,
     braid, cli,
-    db::db_handlers::DBHandler,
-    ibd_manager::{IBDCommands, IBDManager, IBD_BATCH_SIZE},
+    db::db_handlers::{fetch_beads_in_batch, DBHandler},
+    ibd_manager::{IBDManager, IBD_TRIGGER_AFTER},
     ipc_template_consumer,
     peer_manager::PeerManager,
     rpc_server::{run_rpc_server, BitcoinRpcConfig, RpcProxyCommand},
     setup_tracing,
     stratum::{BlockTemplate, ConnectionMapping, Notifier, NotifyCmd, Server, StratumServerConfig},
-    SwarmCommand, TemplateId,
+    swarm::{
+        bootstrap::{dial_additional_nodes, setup_and_bootstrap},
+        builder::{build_swarm, parse_bind_address, SwarmConfig},
+        config::DEFAULT_P2P_PORT,
+        p2p_event_loop, SwarmContext,
+    },
+    SwarmCommand, SwarmHandler, TemplateId,
 };
-use std::collections::HashSet;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::{collections::HashMap, error::Error};
-use std::{fs, time::Duration};
+use std::{
+    collections::HashMap,
+    error::Error,
+    fs,
+    path::Path,
+    sync::{atomic::AtomicBool, Arc},
+    time::Duration,
+};
+use tokio::sync::{mpsc, RwLock};
 use tokio_util::sync::CancellationToken;
-#[allow(unused_imports)]
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
-use behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
-use crate::behaviour::KADPROTOCOLNAME;
-const LATENCY_ALPHA: u64 = 10; // seconds
-                               //boot nodes peerIds
-const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
-//dns NS
-const SEED_DNS: &str = "/dnsaddr/french.braidpool.net";
-//combined addr for dns resolution and dialing of boot for peer discovery
-const ADDR_REFRENCE: &str =
-    "/dnsaddr/french.braidpool.net/p2p/12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3";
-use tokio::sync::{
-    mpsc::{self},
-    RwLock,
-};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Initialize tracing with colors and module prefixes
+    // Initialize tracing
     setup_tracing()?;
+    //IBD manager for ibd handling
     let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
-    //IBD cache handler
     let _ibd_handler = tokio::spawn(async move {
         ibd_manager.run_ibd_handler().await;
     });
-    //False if not under ibd otherwise true at start will be in IBD by default
-    let ibd_or_not: AtomicBool = AtomicBool::new(true);
-    let ibd_spinlock = Arc::new(ibd_or_not);
-    // Initializing the braid object with read write lock
-    //for supporting concurrent readers and single writer
+
+    // IBD flag - true at start (will be in IBD by default)
+    let ibd_spinlock = Arc::new(AtomicBool::new(true));
+    //Local braid instance being shared across different tasks
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
-    //Initializing DB and db command handler
+    //DB task handler for persistant of beads onto disk
     let (mut _db_handler, db_tx) = DBHandler::new().await.map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -81,31 +57,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
     })?;
     let db_connection_pool = _db_handler.db_connection_pool.clone();
-    //Reconstructing local braid upon startup
+
+    // Load beads from database
     let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
     let braid_ref = braid.clone();
-    // FIXME instead we should look 144 blocks back from the bitcoin tip (1 day) and load beads
-    // starting from that block as genesis
+    //Fetching beads from disk before initializing other tasks to pre-shutdown state
     let initial_bead_fetch_handle = tokio::spawn(async move {
         let mut guard = braid_ref.write().await;
         let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000).await?;
         for bead in &fetched_beads {
-            let curr_bead_status = guard.extend(&bead);
-            debug!(
-                hash = ?bead.block_header.block_hash(),
-                status = ?curr_bead_status,
-                "Bead inserted"
-            );
+            let status = guard.extend(bead);
+            debug!(hash = ?bead.block_header.block_hash(), status = ?status, "Bead inserted");
         }
         info!(beads = fetched_beads.len(), "Beads loaded from DB");
         Ok::<(), node::error::DBErrors>(())
     });
+
     match initial_bead_fetch_handle.await {
-        Ok(Ok(())) => {
-            info!("Initial bead fetch completed successfully");
-        }
+        Ok(Ok(())) => info!("Initial bead fetch completed"),
         Ok(Err(e)) => {
-            error!(error = ?e, "Failed to fetch beads from DB during startup");
+            error!(error = ?e, "Failed to fetch beads from DB");
             return Err(format!("Database bead fetch failed: {:?}", e).into());
         }
         Err(e) => {
@@ -113,65 +84,61 @@ async fn main() -> Result<(), Box<dyn Error>> {
             return Err(format!("Initial bead fetch task panicked: {}", e).into());
         }
     }
-    let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
-    let latest_template_id_for_notifier = latest_template_id.clone();
-    let latest_template_id_for_consumer = latest_template_id.clone();
-    //Starting the `query_handler` task
+
+    // Start DB query handler
     tokio::spawn(async move {
         let _res = _db_handler.insert_query_handler().await;
     });
-    //latest available template to be cached for the newest connection until new job is received
+
+    let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
+    let latest_template_id_for_notifier = latest_template_id.clone();
+    let latest_template_id_for_consumer = latest_template_id.clone();
+    //Initial template being shared across the notification task and swarm_handler task
     let latest_template = Arc::new(Mutex::new(BlockTemplate::default()));
-    //latest available template merkle branch
     let latest_template_merkle_branch = Arc::new(Mutex::new(Vec::new()));
     let mut latest_template_ref = latest_template.clone();
     let mut latest_template_merkle_branch_ref = latest_template_merkle_branch.clone();
-    //One will go into the IPC and the other will go to the `notifier`
+
     let (notification_tx, notification_rx) = mpsc::channel::<NotifyCmd>(1024);
-    //Communication bridge between stratum and network swarm and swarm commands also, for communicating share population and propogating them further
-    let (swarm_handler, mut swarm_command_receiver) =
+    //Swarm handler for additional event other than p2p events related to swarm
+    let (swarm_handler, swarm_command_receiver) =
         SwarmHandler::new(Arc::clone(&braid), db_tx.clone());
-    //Swarm command sender
     let swarm_command_sender = swarm_handler.command_sender.clone();
     let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
-    //cloning the channel to be sent across different interfaces
+
     let notification_tx_clone = notification_tx.clone();
-    //Connection mapping for all the downstream connection connected to the stratum server
+    //Global connection mapping for each downstream connected to stratum server along with their respective sender channels
     let connection_mapping = Arc::new(tokio::sync::RwLock::new(ConnectionMapping::new()));
     // Clone connection_mapping for RPC server before it's used in async move blocks
     let connection_mapping_for_rpc = Arc::clone(&connection_mapping);
-    //Mining job map keeping all the jobs provided to the downstream
+    //Global mining mapping mapping peer to its jobs provided by upstream uptill now
     let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
-    //Intializing `notifier` for mining.notify
-    let mut notifier: Notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
-    //Stratum configuration initialization
-    let stratum_config: StratumServerConfig = StratumServerConfig::default();
+    //Notifier task for providing jobs to downstream
+    let mut notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
+    let stratum_config = StratumServerConfig::default();
+    //Block submission channel after validation of PoW to bitcoin-node
     let (block_submission_tx, block_submission_rx) =
         tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
-    //IBD notifier task after peer_discovery
-    let swarm_command_sender_ref = swarm_command_sender.clone();
+
+    // IBD trigger task
+    let swarm_cmd_for_ibd = swarm_command_sender.clone();
     let _ibd_trigger_handler = tokio::spawn(async move {
         tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-        //Sending IBD initiating command
-        match swarm_command_sender_ref
-            .send(SwarmCommand::InitiateIBD)
-            .await
-        {
-            Ok(_) => {
-                info!("IBD trigger sent");
-            }
-            Err(error) => {
-                error!(error=?error,"An error occurred while initiating IBD after waiting for peer discovery - ");
-            }
-        };
+        if let Err(e) = swarm_cmd_for_ibd.send(SwarmCommand::InitiateIBD).await {
+            error!(error = ?e, "Failed to initiate IBD");
+        } else {
+            info!("IBD trigger sent");
+        }
     });
-    //Initializing stratum server
+
+    // Start stratum server
     let mut stratum_server = Server::new(
         stratum_config,
         connection_mapping.clone(),
         Some(block_submission_tx),
     );
-    //Running the notification service
+
+    // Run notifier
     tokio::spawn(async move {
         let _res = notifier
             .run_notifier(
@@ -182,15 +149,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
             )
             .await;
     });
-    //Running the stratum service
-    let spin_lock_ref = ibd_spinlock.clone();
+
+    // Run stratum service
+    let ibd_flag_for_stratum = ibd_spinlock.clone();
     tokio::spawn(async move {
         let _res = stratum_server
             .run_stratum_service(
                 mining_job_map,
                 notification_tx_clone,
                 swarm_handler_arc.clone(),
-                spin_lock_ref,
+                ibd_flag_for_stratum,
             )
             .await;
     });
@@ -199,7 +167,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
         mpsc::channel::<tokio::signal::unix::SignalKind>(32);
     let main_task_token = CancellationToken::new();
     let ipc_task_token = main_task_token.clone();
+
+    //Parsing args
     let args = cli::Cli::parse();
+
     let datadir_str = args.datadir.to_str().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -212,11 +183,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
             format!("Shell expansion failed: {}", e),
         )
     })?;
+
+    // Create data directory if needed
     match fs::metadata(&*datadir) {
-        Ok(m) => {
-            if !m.is_dir() {
-                error!(datadir = %datadir, "Data directory exists but is not a directory");
-            }
+        Ok(m) if !m.is_dir() => {
+            error!(datadir = %datadir, "Data directory exists but is not a directory");
+        }
+        Ok(_) => {
             info!(datadir = %datadir, "Using existing data directory");
         }
         Err(_) => {
@@ -227,14 +200,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let datadir_path = Path::new(&*datadir);
     let keystore_path = datadir_path.join("keystore");
+
     #[cfg(unix)]
     {
         if keystore_path.exists() {
             let perms = fs::metadata(&keystore_path)?.permissions();
             if perms.mode() & 0o777 != 0o400 {
                 warn!(
-                    permissions = perms.mode() & 0o777,
-                    "Keystore permissions are not secure, setting to 0o400"
+                    perms = perms.mode() & 0o777,
+                    "Keystore permissions not secure, fixing"
                 );
                 let mut new_perms = perms.clone();
                 new_perms.set_mode(0o400);
@@ -242,19 +216,21 @@ async fn main() -> Result<(), Box<dyn Error>> {
             }
         }
     }
+    //Generating ed25519 curve keypair for unique PeerId during initialization
     let keypair = match fs::read(&keystore_path) {
-        Ok(keypair) => {
+        Ok(bytes) => {
             info!(path = %keystore_path.display(), "Loading keypair from keystore");
-            libp2p::identity::Keypair::from_protobuf_encoding(&keypair).map_err(|e| {
-                error!(error = %e, path = %keystore_path.display(), "Failed to read keypair from keystore");
+            Keypair::from_protobuf_encoding(&bytes).map_err(|e| {
+                error!(error = %e, "Failed to read keypair");
                 e
             })?
         }
         Err(_) => {
             info!(path = %keystore_path.display(), "Generating new keypair");
-            let keypair: Keypair = libp2p::identity::Keypair::generate_ed25519();
-            let keypair_bytes = keypair.to_protobuf_encoding()?;
-            fs::write(&keystore_path, keypair_bytes)?;
+            let keypair = Keypair::generate_ed25519();
+            let bytes = keypair.to_protobuf_encoding()?;
+            fs::write(&keystore_path, bytes)?;
+
             #[cfg(unix)]
             {
                 let mut perms = fs::metadata(&keystore_path)?.permissions();
@@ -262,101 +238,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 fs::set_permissions(&keystore_path, perms)?;
                 info!(path = %keystore_path.display(), perms = "0o400", "Set keystore permissions");
             }
+
             keypair
         }
     };
-    // load beads from db (if present) and insert in braid here
     // Initializing the peer manager (shared between swarm and RPC server)
     // Using RwLock to allow concurrent reads (RPC server) while swarm handler can write
     let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
     //For local testing uncomment this keypair peer since it running to process will
     //result in same peerID leading to OutgoingConnectionError
     // let keypair = identity::Keypair::generate_ed25519();
-    //creating a main topic subscribing to the current test topic
-    let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
-
-    let swarm_builder = libp2p::SwarmBuilder::with_existing_identity(keypair)
-        .with_tokio()
-        .with_quic()
-        .with_dns()
-        .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("DNS setup failed: {:?}", e),
-            )
-        })?;
-    // Note: with_behaviour closure must return behaviour directly (not Result), using expect for clear error message
-    let mut swarm = swarm_builder
-        .with_behaviour(|local_key| {
-            BraidPoolBehaviour::new(local_key).expect(
-                "Failed to create BraidPoolBehaviour - check keypair and network configuration",
-            )
-        })?
-        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
-        .build();
-    let socket_addr: std::net::SocketAddr = match args.bind.parse() {
-        Ok(addr) => addr,
-        Err(_) => format!("{}:6680", args.bind).parse().map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Failed to parse bind address: {}", e),
-            )
-        })?,
-    };
-    let multi_addr: Multiaddr = format!(
-        "/ip4/{}/udp/{}/quic-v1",
-        socket_addr.ip(),
-        socket_addr.port()
-    )
-    .parse()
-    .map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Failed to create multiaddress: {}", e),
-        )
-    })?;
-    //subscribing to the braidpool topic for broadcasting bead_found and other peer_communications belonging to a particular topic
-    swarm
-        .behaviour_mut()
-        .bead_announce
-        .subscribe(current_broadcast_topic.clone());
-    //setting the server mode for the kademlia apart from the server
-    swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
-
-    //adding the boot nodes for peer discovery
-    swarm.listen_on(multi_addr.clone())?;
-    for boot_peer in BOOTNODES {
-        let peer_id = match boot_peer.parse::<PeerId>() {
-            Ok(id) => id,
-            Err(e) => {
-                error!(boot_peer = %boot_peer, error = %e, "Failed to parse boot peer ID, skipping");
-                continue;
-            }
-        };
-        let seed_addr = match SEED_DNS.parse::<Multiaddr>() {
-            Ok(addr) => addr,
-            Err(e) => {
-                error!(seed_dns = %SEED_DNS, error = %e, "Failed to parse seed DNS, skipping");
-                continue;
-            }
-        };
-        swarm
-            .behaviour_mut()
-            .kademlia
-            .add_address(&peer_id, seed_addr);
-    }
-    info!(boot_node_count = %BOOTNODES.len(), "Boot nodes added to DHT");
-    let boot_addr: Multiaddr = ADDR_REFRENCE.parse().map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Failed to parse boot address: {}", e),
-        )
-    })?;
-    swarm.dial(boot_addr)?;
-    info!(address = %ADDR_REFRENCE, "Dialed boot node");
-    //IPC(inter process communication) based `getblocktemplate` and `notification` to send to the downstream via the `cmempoold` architecture
-    info!(socket = %args.ipc_socket, "IPC socket path");
-
+    //Configured network
     let network = if let Some(network_name) = &args.network {
         info!(network = %network_name, "Network selected");
         match network_name.as_str() {
@@ -366,20 +258,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
             "regtest" => Network::Regtest,
             "cpunet" => Network::CPUNet,
             _ => {
-                error!(
-                    network = %network_name,
-                    valid_networks = "main, testnet, testnet4, signet, regtest, cpunet",
-                    "Invalid network specified"
-                );
-                info!(fallback = "regtest", "Using fallback network");
+                error!(network = %network_name, "Invalid network");
+                info!("Using fallback: regtest");
                 Network::Regtest
             }
         }
     } else {
         Network::Bitcoin
     };
-
-    let ipc_socket_path_for_blocking = args.ipc_socket.clone();
+    //IPC node initializer including our capnp client
+    let ipc_socket_path = args.ipc_socket.clone();
     let notification_tx_for_ipc = notification_tx.clone();
     let latest_template_for_ipc = latest_template.clone();
     let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
@@ -420,7 +308,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         }
     };
 
-    // Spawn IPC handler
+    info!(socket = %ipc_socket_path, "IPC socket path");
+
     let _ipc_handler = tokio::task::spawn_blocking(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -428,13 +317,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         {
             Ok(rt) => rt,
             Err(e) => {
-                error!(error = %e, "Failed to create tokio runtime for IPC handler");
+                error!(error = %e, "Failed to create tokio runtime for IPC");
                 return;
             }
         };
+
         rt.block_on(async {
             let local_set = tokio::task::LocalSet::new();
-
             local_set
                 .run_until(async {
                     let template_cache: Arc<
@@ -442,1093 +331,87 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             HashMap<TemplateId, Arc<node::ipc::client::BlockTemplate>>,
                         >,
                     > = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-                    let template_cache_for_consumer = template_cache.clone();
-                    let template_cache_for_listener = template_cache.clone();
+
                     let (ipc_template_tx, ipc_template_rx) =
                         tokio::sync::mpsc::channel::<Arc<node::ipc::client::BlockTemplate>>(1);
 
                     let listener_task = tokio::task::spawn_local({
-                        let ipc_socket_path = ipc_socket_path_for_blocking.clone();
-                        let ipc_template_tx = ipc_template_tx.clone();
-                        let template_cache = template_cache_for_listener.clone();
+                        let ipc_socket = ipc_socket_path.clone();
+                        let tx = ipc_template_tx.clone();
+                        let cache = template_cache.clone();
                         let rpc_command_rx = rpc_proxy_rx;
-
                         async move {
                             match node::ipc::ipc_block_listener(
-                                ipc_socket_path,
-                                ipc_template_tx,
+                                ipc_socket,
+                                tx,
                                 network,
-                                template_cache,
+                                cache,
                                 block_submission_rx,
                                 rpc_command_rx,
                             )
                             .await
                             {
-                                Ok(_) => {
-                                    info!("IPC block listener exited");
-                                }
-                                Err(e) => {
-                                    error!(error = %e, "IPC block listener error");
-                                }
+                                Ok(_) => info!("IPC listener exited"),
+                                Err(e) => error!(error = %e, "IPC listener error"),
                             }
                         }
                     });
 
                     let consumer_task = tokio::task::spawn_local({
+                        let cache = template_cache.clone();
                         async move {
                             if let Err(e) = ipc_template_consumer(
                                 ipc_template_rx,
                                 notification_tx_for_ipc,
                                 &mut latest_template_for_ipc.clone(),
                                 &mut latest_template_merkle_branch_for_ipc.clone(),
-                                template_cache_for_consumer,
+                                cache,
                                 latest_template_id_for_consumer,
                             )
                             .await
                             {
-                                error!(error = ?e, "IPC template consumer error");
+                                error!(error = ?e, "IPC consumer error");
                             }
                         }
                     });
 
                     tokio::select! {
-                        _ = listener_task => info!(task = "listener", "IPC listener task completed"),
-                        _ = consumer_task => info!(task = "consumer", "Template consumer task completed"),
-                        _ = ipc_task_token.cancelled() => {
-                            info!("IPC task shutting down - cancellation token triggered");
-                        }
+                        _ = listener_task => info!("IPC listener completed"),
+                        _ = consumer_task => info!("IPC consumer completed"),
+                        _ = ipc_task_token.cancelled() => info!("IPC cancelled"),
                     }
                 })
                 .await;
         });
     });
+    //Default listening addr of spawned peer
+    let bind_addr = parse_bind_address(&args.bind, DEFAULT_P2P_PORT)?;
+    let swarm_config = SwarmConfig::new(keypair, bind_addr);
+    let listen_addr = swarm_config.to_multiaddr()?;
+    //Building swarm with `BraidpoolBeahaviour`
+    let mut swarm = build_swarm(swarm_config).await?;
 
+    // Bootstrap the swarm
+    let topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
+    setup_and_bootstrap(&mut swarm, listen_addr, topic)?;
+
+    // Dial additional nodes if provided
+    //This should be changed to a single dial function only
     if let Some(addnode) = args.addnode {
-        for node in addnode.iter() {
-            let node_multiaddr: Multiaddr = match node.parse() {
-                Ok(addr) => addr,
-                Err(e) => {
-                    error!(node = %node, error = %e, "Failed to parse multiaddr, skipping");
-                    continue;
-                }
-            };
-            let dial_result = swarm.dial(node_multiaddr.clone());
-            if let Some(err) = dial_result.err() {
-                error!(address = %node_multiaddr, error = %err, "Failed to dial peer node");
-                continue;
-            }
-            info!(address = %node_multiaddr, "Dialed peer node");
-        }
-    };
-    let peer_manager_arc_for_swarm = peer_manager_arc.clone();
+        dial_additional_nodes(&mut swarm, &addnode);
+    }
+    //Swarm context shared as reference among different handlers and task but keeping the Swarm centralized
+    let ctx = SwarmContext::new(
+        braid.clone(),
+        db_tx,
+        ibd_command_tx,
+        ibd_spinlock.clone(),
+        peer_manager_arc.clone(),
+        swarm_command_sender,
+    );
+    //Event loop for p2p related events
     let swarm_handle = tokio::spawn(async move {
-        let braid = std::sync::Arc::clone(&braid);
-        let peer_manager_arc = peer_manager_arc_for_swarm;
-        loop {
-            tokio::select! {
-             swarm_event = swarm.select_next_some()=>{
-                 match swarm_event{
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
-                         kad::Event::RoutingUpdated {
-                             peer,
-                             is_new_peer,
-                             addresses,
-                             bucket_range,
-                             old_peer,
-                         },
-                     )) => {
-                         info!(
-                             peer = %peer,
-                             is_new = %is_new_peer,
-                             addresses = ?addresses,
-                             bucket = ?bucket_range,
-                             old_peer = ?old_peer,
-                             "DHT routing updated"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Subscribed { peer_id, topic },
-                     )) => {
-                         info!(
-                             peer = ?peer_id,
-                             topic = ?topic,
-                             "Peer subscribed to topic"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Unsubscribed { peer_id, topic },
-                     )) => {
-                         info!(
-                             peer = ?peer_id,
-                             topic = ?topic,
-                             "Peer unsubscribed from topic"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Message(message),
-                     )) => {
-                         info!(
-                             topics = ?message.topics,
-                             source = ?message.source,
-                             size_bytes = %message.data.len(),
-                             "Floodsub message received"
-                         );
-                         let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&message.data);
-                         match result_bead {
-                             Ok(bead) => {
-                                info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
-                                // Handle the received bead here
-                                let mut braid_data = braid.write().await;
-                                let status = {
-                                     braid_data.extend(&bead)
-                                 };
-                                 if ibd_spinlock.load(Ordering::SeqCst){
-                                    let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
-                                    let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
-                                    if let Err(e) = ibd_command_tx
-                                        .send(IBDCommands::FetchAllTimestamps { sender: ts_tx })
-                                        .await {
-                                        tracing::warn!("Failed to request timestamp map: {:?}", e);
-                                    }
-                                    let timestamp_map = match ts_rx.await {
-                                        Ok(map) => map,
-                                        Err(_) => {
-                                            tracing::error!("Failed to receive timestamp map");
-                                            continue;
-                                        }
-                                    };
-                                      //If the received  bead exceeds the timestamp of ibd completion wrt to a sync node
-                                      if let braid::AddBeadStatus::ParentsNotYetReceived = status {
-                                        //request the parents using request response protocol
-                                        let peer_id = {
-                                            let peer_manager = peer_manager_arc.read().await;
-                                            peer_manager.get_top_k_peers_for_propagation(1)
-                                        };
-                                        if let Some(peer) = peer_id.first() {
-                                            swarm.behaviour_mut().bead_sync.send_request(
-                                                &peer,
-                                                BeadRequest::GetBeads(
-                                                    BeadHashes(
-                                                        bead.committed_metadata
-                                                            .parents
-                                                            .clone()
-                                                            .into_iter()
-                                                            .collect(),
-                                                    )
-                                                ),
-                                            );
-                                        } else {
-                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
-                                        }
-                                    } else if let braid::AddBeadStatus::InvalidBead = status {
-                                        // update the peer manager about the invalid bead
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.penalize_for_invalid_bead(&message.source);
-                                        }
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
-                                     //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
-                                                continue;
-                                            }
-                                        };
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
-                                            Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                continue;
-                                            }
-                                        };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                           Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.update_score(&message.source, 1.0);
-                                        }
-                                    }
-                                    for (sync_peer, ibd_ts) in timestamp_map.iter() {
-                                        let threshold = *ibd_ts + LATENCY_ALPHA * 10;
-                                        let sync_peer_id = match sync_peer.parse::<PeerId>() {
-                                            Ok(id) => id,
-                                            Err(e) => {
-                                                error!(sync_peer = %sync_peer, error = %e, "Failed to parse sync peer ID");
-                                                continue;
-                                            }
-                                        };
-                                        // broadcast_timestamp < timestamp + alpha * 10
-                                        if broadcast_ts  < threshold as u32 {
-                                            info!("Incoming BEAD received during IBD within threshold limit with broadcast timestamp - {:?} and threshold is - {:?}",broadcast_ts,threshold);
-                                           match status{
-                                            braid::AddBeadStatus::InvalidBead | braid::AddBeadStatus::ParentsNotYetReceived=>{
-                                                //Aborting/evicting the wait_ibd handler corresponding to the sync peer
-                                                match ibd_command_tx.send(IBDCommands::AbortWaitHandle { peer_id:sync_peer_id }).await{
-                                                    Ok(_)=>{
-                                                        warn!("Abort handle and evicting handler corresponding to sync peer sent successfully");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"An error occurred while sending abort handler wrt sync peer due to -");
-                                                    }
-                                                };
-                                                // If result is invalid then reinitiate IBD
-                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                    Ok(_)=>{
-                                                        warn!("Reinitiating IBD command sent to swarm handler");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                    }
-                                                }
-                                                continue;
-                                            },
-                                            braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
-                                                ibd_spinlock.store(false,Ordering::SeqCst);
-                                                continue;
-                                            },
-                                           }
-
-                                        }
-                                        else{
-                                            ibd_spinlock.store(false,Ordering::SeqCst);
-                                            continue;
-                                        }
-                                    }
-                                }
-                                else{
-                                    if let braid::AddBeadStatus::ParentsNotYetReceived = status {
-                                        //request the parents using request response protocol
-                                        let peer_id = {
-                                            let peer_manager = peer_manager_arc.read().await;
-                                            peer_manager.get_top_k_peers_for_propagation(1)
-                                        };
-                                        if let Some(peer) = peer_id.first() {
-                                            swarm.behaviour_mut().bead_sync.send_request(
-                                                &peer,
-                                                BeadRequest::GetBeads(
-                                                    BeadHashes(
-                                                        bead.committed_metadata
-                                                            .parents
-                                                            .clone()
-                                                            .into_iter()
-                                                            .collect(),
-                                                    )
-                                                ),
-                                            );
-                                        } else {
-                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
-                                        }
-                                    } else if let braid::AddBeadStatus::InvalidBead = status {
-                                        // update the peer manager about the invalid bead
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.penalize_for_invalid_bead(&message.source);
-                                        }
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
-                                                continue;
-                                            }
-                                        };
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
-                                            Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                continue;
-                                            }
-                                        };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                            Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.update_score(&message.source, 1.0);
-                                        }
-                                    }
-                                }
-
-                             }
-                             Err(e) => {
-                                 error!(error = %e, "Failed to deserialize bead");
-                             }
-                         }
-                     }
-                     SwarmEvent::NewListenAddr { address, .. } => {
-                         info!(address = ?address, "P2P listening on address")
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Sent { peer_id, .. },
-                     )) => {
-                         debug!(peer = ?peer_id, "Sent identify info");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Received { peer_id, info,  .. },
-                     )) => {
-                         let info_reference = info.clone();
-                         info!(
-                             peer = ?peer_id,
-                             address_count = %info_reference.listen_addrs.len(),
-                             "Received listen addresses"
-                         );
-                         if info.protocols.iter().any(|p| *p == KADPROTOCOLNAME) {
-                             for addr in info.listen_addrs {
-                                 info!(address = %addr, "Received address via identify");
-                             }
-                         } else {
-                             info!(peer = ?peer_id, "Peer does not support Kademlia");
-                         }
-                         if info_reference
-                             .clone()
-                             .protocols
-                             .iter()
-                             .any(|p| *p != BEAD_ANNOUNCE_PROTOCOL)
-                         {
-
-                             info!(
-                                 peer_address = ?info_reference.observed_addr,
-                                 "Peer does not support floodsub"
-                             );
-                         }
-                         debug!(info = ?info_reference, "Received peer info");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
-                         kad::Event::OutboundQueryProgressed { result, .. },
-                     )) => match result {
-                         QueryResult::GetClosestPeers(Ok(ok)) => {
-                             info!(peers = ?ok.peers, peer_count = %ok.peers.len(), "Got closest peers");
-                         }
-                         QueryResult::GetClosestPeers(Err(err)) => {
-                             error!(error = %err, "Failed to get closest peers");
-                         }
-                        QueryResult::Bootstrap(Ok(BootstrapOk {
-                            peer, ..
-                        }))=>{
-                            info!(peer = ?peer, "New peer");
-                        }
-                         _ => info!(result = ?result, "Other DHT query result"),
-                     },
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Error {
-                             peer_id,
-                             error,
-                             connection_id: _,
-                         },
-                     )) => {
-                         error!(peer = %peer_id, error = ?error, "Identify event error");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Ping(ping::Event {
-                         peer,
-                         result,
-                         ..
-                     })) => {
-                         match result {
-                             Ok(latency) => {
-                                 info!(
-                                     peer = %peer,
-                                     latency_ms = %latency.as_millis(),
-                                     "Ping"
-                                 );
-                                {
-                                    let mut peer_manager = peer_manager_arc.write().await;
-                                    peer_manager.update_latency(&peer,latency);
-                                }
-                             }
-                             Err(err) => {
-                                 warn!(
-                                     peer = %peer,
-                                     error = %err,
-                                     "Ping failed"
-                                 );
-                             }
-                         }
-                     }
-                     SwarmEvent::ConnectionEstablished {
-                         peer_id, endpoint, ..
-                     } => {
-
-                         // Add the peer to the peer manager
-                         let remote_addr = endpoint.get_remote_address();
-                         swarm.behaviour_mut().kademlia.add_address(&peer_id,remote_addr.clone());
-                         info!(address = ?remote_addr, "DHT updated with peer address");
-                         swarm.behaviour_mut()
-                         .bead_announce
-                         .add_node_to_partial_view(peer_id);
-
-                         info!(peer = %peer_id, "Peer added to floodsub mesh");
-                         let ip = remote_addr.iter().find_map(|p| match p {
-                             libp2p::core::multiaddr::Protocol::Ip4(ip) => {
-                                 Some(std::net::IpAddr::V4(ip))
-                             }
-                             libp2p::core::multiaddr::Protocol::Ip6(ip) => {
-                                 Some(std::net::IpAddr::V6(ip))
-                             }
-                             _ => None,
-                         });
-                         {
-                             let mut peer_manager = peer_manager_arc.write().await;
-                             peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
-                         }
-                         info!(
-                            peer_id = ?peer_id,
-                            remote_addr = ?remote_addr,
-                            "Connection established to peer"
-                        );
-
-                     }
-                     SwarmEvent::ConnectionClosed {
-                         peer_id,
-                         connection_id,
-                         endpoint,
-                         num_established,
-                         cause,
-                     } => {
-                         info!(peer = %peer_id, connection_id = %connection_id, address = %endpoint.get_remote_address(), established = %num_established, cause = ?cause, "Connection closed");
-                         // Remove the peer from the peer manager
-                         {
-                             let mut peer_manager = peer_manager_arc.write().await;
-                             peer_manager.remove_peer(&peer_id);
-                         }
-                         swarm
-                             .behaviour_mut()
-                             .kademlia
-                             .remove_address(&peer_id, endpoint.get_remote_address());
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadSync(
-                    request_response::Event::Message {
-                        peer,
-                        message,
-                        connection_id,
-                    },
-                )) => {
-                    info!(
-                        peer = %peer,
-                        message = ?message,
-                        connection = ?connection_id,
-                        "Bead sync message received"
-                    );
-                    match message {
-                        request_response::Message::Request {
-                            request,
-                            request_id: _,
-                            channel,
-                        } => {
-                            // Handle the bead sync request here
-                            match request {
-                                BeadRequest::GetBeads(hashes) => {
-                                        let mut beads = Vec::new();
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            for hash in hashes.iter() {
-                                                if let Some(index) =
-                                                    braid_lock.bead_index_mapping.get(hash)
-                                                {
-                                                    if let Some(bead) = braid_lock.beads.get(*index) {
-                                                        beads.push(bead.clone());
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        //Sending all the beads requested in the hashes supplied during `GetData` request
-                                        swarm.behaviour_mut().respond_with_beads(channel, beads);
-                                }
-                                BeadRequest::GetTips => {
-                                        let tips;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            tips = braid_lock
-                                                .tips
-                                                .iter()
-                                                .filter_map(|index| braid_lock.beads.get(*index))
-                                                .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
-                                                .collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_tips(channel, tips);
-                                }
-                                BeadRequest::GetGenesis => {
-                                        let genesis;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            genesis = braid_lock
-                                                .genesis_beads
-                                                .iter()
-                                                .filter_map(|index| braid_lock.beads.get(*index))
-                                                .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
-                                                .collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_genesis(channel, genesis);
-                                }
-                                BeadRequest::GetAllBeads => {
-
-                                        let all_beads;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            all_beads = braid_lock.beads.iter().cloned().collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_beads(channel, all_beads);
-                                }
-                                BeadRequest::GetBeadsAfter(hashes) => {
-                                        let beads = braid.read().await.get_beads_after(hashes.into());
-                                        if let Some(response_beads) = beads {
-                                            let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
-                                            for bead in response_beads.into_iter(){
-                                                computed_beads_hashes.push(bead.block_header.block_hash());
-                                            }
-                                            //Sending the corresponding bead hashes requested by the new peer for IBD that will
-                                            //be after the new peer's `Tips`.
-                                            swarm
-                                                .behaviour_mut()
-                                                .respond_with_beadhashes(channel, computed_beads_hashes);
-                                        } else {
-                                            swarm.behaviour_mut().respond_with_error(
-                                                channel,
-                                                BeadSyncError::BeadHashNotFound,
-                                            );
-                                        }
-                                }
-                            }
-                        }
-                        request_response::Message::Response {
-                            request_id: _,
-                            response,
-                        } => {
-                            match response {
-                                BeadResponse::Beads(beads)
-                                | BeadResponse::GetAllBeads(beads) => {
-                                    let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    //Fetching the pruned bead-hashes received during `GetBeadAfter` request
-                                    match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
-                                        Ok(_)=>{
-                                            debug!("IBD command sent to handler successfully !");
-                                        },
-                                        Err(error)=>{
-                                            //Re-initiating IBD
-                                            error!("An error occurred while sending ibd command to ibd_handler - {:?}, re-trying IBD",error.0);
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    let pruned_beads = match beads_rx.await{
-                                        Ok(received_beads)=>{
-                                            received_beads
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error.to_string(),"An error occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    for bead in beads.into_iter() {
-                                        let mut braid_data = braid.write().await;
-                                        let status = braid_data.extend(&bead);
-                                        let curr_beadhash = bead.block_header.block_hash().to_string();
-                                        if let braid::AddBeadStatus::InvalidBead = status {
-                                            // update the peer manager about the invalid bead
-                                            {
-                                                let mut peer_manager = peer_manager_arc.write().await;
-                                                peer_manager.penalize_for_invalid_bead(&peer);
-                                            }
-                                        } else if let braid::AddBeadStatus::BeadAdded = status {
-                                            let bead_id = match braid_data
-                                                .bead_index_mapping
-                                                .get(&bead.block_header.block_hash()) {
-                                                Some(id) => id,
-                                                None => {
-                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
-                                                    continue;
-                                                }
-                                            };
-                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                                &braid_data.beads,
-                                                &braid_data.bead_index_mapping,
-                                                &bead,
-                                            ){
-                                                Ok(received_tuples)=>received_tuples,
-                                                Err(error)=>{
-                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
-                                                    continue;
-                                                }
-                                            };
-                                            // update score of the peer
-                                            {
-                                                let mut peer_manager = peer_manager_arc.write().await;
-                                                peer_manager.update_score(&peer, 1.0);
-                                            }
-                                            //persisting the received beads from peer onto DB(disk)
-                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
-                                                Ok(_)=>{
-                                                    debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
-                                                },
-                                                Err(error)=>{
-                                                    tracing::error!(
-                                                        peer = %peer,
-                                                        err = ?error.0,
-                                                        "An error occurred while persisting received bead from peer"
-                                                    );
-                                                }
-                                            };
-                                        }
-                                    }
-                                    //Preparing next batch request to be sent to the sync node
-                                    let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await{
-                                            Ok(_)=>{
-                                                debug!("Offset Updated");
-                                            },
-                                            Err(error)=>{
-                                                error!(error=?error,"An error occurred while sending the offset update command, re-trying IBD");
-                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                    Ok(_)=>{
-                                                        warn!("Reinitiating IBD command sent to swarm handler");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                    }
-                                                }
-                                                continue;
-                                            }
-                                    };
-                                    let next_batch_offset = match batch_rx.await{
-                                        Ok(next_offset)=>{
-                                            debug!(next_offset=?next_offset,"Newer offset for batch request received successfully ");
-                                            next_offset
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while receiving the offset, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)< pruned_beads.len()){
-                                        info!("Received beads within batch range");
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..(next_batch_offset+IBD_BATCH_SIZE)].to_vec());
-                                    }
-                                    else if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)>=pruned_beads.len()){
-                                        info!("Received beads within batch range");
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..].to_vec());
-
-                                    }
-                                    else{
-                                        //IBD completed
-                                        info!(
-                                            peer = %peer,
-                                            "Initial IBD has been completed with respect to peer"
-                                        );
-                                        // Get current time and create recent timestamps (within last hour)
-                                        let current_time = SystemTime::now()
-                                            .duration_since(UNIX_EPOCH)
-                                            .map(|d| d.as_secs())
-                                            .unwrap_or_else(|e| {
-                                                error!(error = %e, "System time before UNIX epoch");
-                                                0
-                                            });
-                                        match ibd_command_tx.send(IBDCommands::UpdateTimestampMapping { peer_id: peer.to_string(), end_timestamp: current_time }).await{
-                                            Ok(_)=>{
-                                                debug!("Timestamp updated command sent successfully");
-                                                //Scheduling a corresponding watcher task that will check after a latency period
-                                                //if no incoming is received during the instance of [initial_headers_fetched,(initial_headers_fetched+(alpha*10))]
-                                                let ibd_spinlock_ref = ibd_spinlock.clone();
-                                                let ibd_incoming_handler = tokio::spawn(async move{
-                                                    //Sleeping for a fixed duration to be set according to statistical estimates
-                                                    tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
-                                                    //We will check if no bead is `incoming` after the duration of 600 seconds then we will reset/set ibd_flag accordingly
-                                                    if ibd_spinlock_ref.load(Ordering::SeqCst){
-                                                        //If no incoming is received during the period then we can say
-                                                        //that ibd wrt the given sync node is successfully completed
-                                                        ibd_spinlock_ref.store(false,Ordering::SeqCst);
-                                                        warn!("Maximum threshold wrt IBD incoming exceeded thus ibd_flag being set to false");
-                                                    }
-
-                                                });
-                                                //At retry we will have to abort and evict the corresponding sync-peers's wait handle
-                                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:peer,retry_or_not:false,handle:Some(ibd_incoming_handler)}).await{
-                                                    Ok(_)=>{
-                                                        debug!("Incoming bead command sent successfully");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                                    }
-                                                };
-                                            },
-                                            Err(error)=>{
-                                                error!(error=?error,"An error occurred while sending timestamp update command for the given sync node");
-                                            }
-                                        };
-                                    }
-                                }
-                                 BeadResponse::GetBeadsAfter(bead_hashes)=>{
-                                    //Getting all the beadhashes after the common oldest in both the peers
-                                    let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    match ibd_command_tx.send(IBDCommands::FetchTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
-                                        Ok(_)=>{
-                                            debug!("Sync peer Tips received successfully.");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"Error occurred while receiving tips, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    let received_tips = match tips_rx.await{
-                                        Ok(received_tips)=>{
-                                            received_tips
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while receiving the Tips, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    //Pruning the hashes wrt cached `Tips`
-                                    let mut found_tips = HashSet::new();
-                                    let mut pruned = Vec::new();
-                                    let tips_set: HashSet<_> = received_tips.into_iter().collect();
-                                    for hash in bead_hashes {
-                                        if tips_set.contains(&hash) {
-                                            found_tips.insert(hash.clone());
-                                        }
-                                        pruned.push(hash);
-                                        // Stop once all tips have been matched
-                                        if found_tips.len() == tips_set.len() {
-                                            break;
-                                        }
-                                    }
-                                    let pruned_ref = pruned.clone();
-                                    // Storing them in cache
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncoming { get_bead_response: pruned, peer_id: peer.to_string() }).await{
-                                        Ok(_)=>{
-                                            debug!("Received beads to be fetched in GetBeads saved successfully");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while Caching pruned beadhashes to be fetched in GetBeads");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    // Initiating `GetBead` request cycle
-                                    if pruned_ref.len() <= IBD_BATCH_SIZE{
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref);
-                                    }
-                                    else{
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref[0..IBD_BATCH_SIZE].to_vec());
-                                    }
-
-                                }
-                                BeadResponse::Tips(tips) => {
-                                    info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
-                                    //If received tips are already present in the local braid arc then we can stop
-                                    //IBD and continue with mining
-                                    //Initializing the batch offset for the corresponding sync peer
-                                    let (ibd_bridge_tx, _ibd_bridge_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await{
-                                        Ok(_)=>{
-                                            debug!("Offset Initialized successfully");
-                                        },
-                                        Err(_error)=>{
-                                            error!("An error occurred while sending offset initalization command to ibd_handler");
-                                            continue;
-                                        }
-                                    };
-                                    let _val = match _ibd_bridge_rx.await {
-                                        Ok(v) => v,
-                                        Err(e) => {
-                                            error!(error = %e, "Failed to receive IBD batch offset");
-                                            continue;
-                                        }
-                                    };
-                                    let braid_data = braid.read().await;
-
-                                    let bead_hash_set: HashSet<BeadHash> = braid_data
-                                    .beads
-                                    .iter()
-                                    .map(|b| b.block_header.block_hash())
-                                    .collect();
-
-                                    let flag = tips.iter().all(|tip_hash| bead_hash_set.contains(tip_hash));
-
-                                    if flag{
-                                        //No need to proceed further and continue to next event
-                                        info!("Peer already synced to tip");
-                                        //IBD flag can be set  as the current bead is already synced//
-                                        ibd_spinlock.store(false, Ordering::SeqCst);
-                                        continue;
-                                    }
-                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips.0, peer_id: peer.to_string() }).await{
-                                    Ok(_)=>{
-                                        debug!("Sync peers Tip mapping update successfully");
-                                    },
-                                    Err(error)=>{
-                                        tracing::error!(
-                                            err = ?error,
-                                            "Error while sending update cache command"
-                                        );
-                                        continue;
-                                    }
-                                  };
-                                    // After storing tips we will issue `GetBeads` command that will find the oldest
-                                    // common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
-                                    // the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
-                                    let mut current_tip_hashes = Vec::new();
-                                    for curr_bead_idx in braid_data.tips.iter() {
-                                        if let Some(current_bead) = braid_data.beads.get(*curr_bead_idx) {
-                                            current_tip_hashes.push(current_bead.block_header.block_hash());
-                                        } else {
-                                            error!(bead_idx = %curr_bead_idx, "Tip bead not found in beads list");
-                                        }
-                                    }
-                                    // Sending the current bead hashes for the receiving of beads to start in batches
-                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
-                                    swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
-
-                                }
-                                BeadResponse::Genesis(genesis) => {
-                                    info!(genesis=?genesis,"Received genesis beads: ");
-                                    let status = {
-                                        let braid_lock = braid.read().await;
-                                        braid_lock.check_genesis_beads(&genesis.0)
-                                    };
-                                    match status {
-                                        braid::GenesisCheckStatus::GenesisBeadsValid => {
-                                            info!("Genesis beads are valid");
-                                        }
-                                        braid::GenesisCheckStatus::MissingGenesisBead => {
-                                            warn!(peer = %peer, "Missing genesis bead");
-                                            swarm
-                                                .behaviour_mut()
-                                                .request_beads(peer, &genesis.0);
-                                        }
-                                        braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
-                                            warn!(
-                                                received = %genesis.0.len(),
-                                                peer = %peer,
-                                                "Genesis bead count mismatch"
-                                            );
-                                        }
-                                    }
-                                }
-                                BeadResponse::Error(error) => match error {
-                                    BeadSyncError::GenesisMismatch => {
-                                        warn!("Genesis mismatch error received");
-                                        swarm.behaviour_mut().request_genesis(peer.clone());
-                                    }
-                                    BeadSyncError::BeadHashNotFound => {
-                                        warn!("Peer requested bead hashes not found in local store");
-                                    }
-                                },
-                            };
-                        }
-                    }
-                }
-                     other_event=>{
-                             debug!(event = ?other_event, "Other swarm event");
-                     }
-                 }
-
-             }
-             Some(swarm_command) = swarm_command_receiver.recv()=>{
-                 match swarm_command{
-                     SwarmCommand::PropagateValidBead {
-                         bead_bytes,
-                     } => {
-                         swarm
-                             .behaviour_mut()
-                             .bead_announce
-                             .publish(current_broadcast_topic.clone(), bead_bytes);
-                        info!(topic = ?current_broadcast_topic, "Published bead to floodsub topic");
-                     },
-                     SwarmCommand::InitiateIBD=>{
-                        info!("Initiating IBD after peer discovery and selecting peer with lowest latency score");
-                        //Evicting lowest latency peer id
-                        let peer_ids = {
-                            let peer_manager = peer_manager_arc.read().await;
-                            peer_manager.get_top_k_peers_for_propagation(1)
-                        };
-                        if peer_ids.len() == 0 {
-                            warn!("No peer available for syncing to take place");
-                                tokio::spawn({
-                                    let swarm_command_sender = swarm_command_sender.clone();
-                                    //Retrying at fixed interval in case of no sync peers being available
-                                    async move {
-                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
-                                            Ok(_) => {
-                                                info!("Retrying IBD when no sync peers are available");
-                                            }
-                                            Err(error) => {
-                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
-                                            }
-                                        }
-                                    }
-                                });
-                        }
-                        else{
-                            let mut sync_request_sent = false;
-                            for lowest_latency_peer in peer_ids.into_iter(){
-                                let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
-                                match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:lowest_latency_peer,retry_sender:retry_count_tx}).await{
-                                    Ok(_)=>{
-                                        info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
-                                    },
-                                    Err(error)=>{
-                                        error!(error=?error,"An error occurred while sending retry count to IBDHandler");
-                                    }
-                                }
-                                let retry_cnt = match retry_count_rx.await {
-                                    Ok(cnt) => cnt,
-                                    Err(e) => {
-                                        error!(error=?e, "Failed to receive retry count from IBDHandler, channel closed or sender dropped");
-                                        continue;
-                                    }
-                                };
-                                if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
-                                    warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
-                                    continue;
-                                }
-                                else if retry_cnt == u64::MAX{
-                                    //First time syncing is being done wrt the provided peer
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:false,handle:None}).await{
-                                        Ok(_)=>{
-                                            info!("Incoming bead command sent successfully");
-                                            let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                        }
-                                    };
-                                    sync_request_sent = true;
-                                    break;
-                                }
-                                else{
-                                    //Case of retry is there
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:true,handle:None}).await{
-                                        Ok(_)=>{
-                                            info!("Incoming bead command sent successfully");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                        }
-                                    };
-                                    //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
-                                    let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                    swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                    sync_request_sent = true;
-                                    break;
-                                }
-
-                            }
-                            if sync_request_sent{
-                                //The lowest latency avaialble sync peer whose retry count is not exceeded has been selected and requested to initiate IBD
-                                continue;
-                            }
-                            else{
-                                warn!("Retry count for all the available sync peers exceeded waiting for new peer connections");
-                                tokio::spawn({
-                                    let swarm_command_sender = swarm_command_sender.clone();
-                                    //Retrying at fixed interval in case of all available sync peer retry count has exceeded
-                                    //Probe at fixed interval for any new peer
-                                    async move {
-                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
-                                            Ok(_) => {
-                                                info!("Retrying IBD when no sync peers are available");
-                                            }
-                                            Err(error) => {
-                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
-                                            }
-                                        }
-                                    }
-                                });
-                            }
-                        }
-                     }
-                 }
-             }
-
-
-
-
-            }
-        }
+        p2p_event_loop::run(ctx, swarm, swarm_command_receiver).await;
     });
 
     //graceful shutdown via `Cancellation token`
@@ -1537,35 +420,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Ok(_) => {
             info!(component = "database", "Closing connection pool");
             let pool = db_connection_pool.lock().await;
-            //Closing all the existing connections to pool and committing from .db-wal to .db
             pool.close().await;
             info!(component = "database", "Connections closed");
-            info!(component = "swarm", "Shutting down network swarm");
+
+            info!(component = "swarm", "Shutting down");
             swarm_handle.abort();
             tokio::time::sleep(Duration::from_millis(1)).await;
-            #[allow(unused)]
-            let shutdown_sub_tasks = match main_shutdown_tx
+
+            if let Err(e) = main_shutdown_tx
                 .send(tokio::signal::unix::SignalKind::interrupt())
                 .await
             {
-                Ok(_) => {
-                    info!(
-                        component = "shutdown",
-                        "Sub-tasks interrupted - waiting for graceful shutdown"
-                    );
-                    main_task_token.cancel();
-                }
-                Err(error) => {
-                    error!(error = ?error, "Failed to send interrupt signal to sub-tasks");
-                }
-            };
+                error!(error = ?e, "Failed to send shutdown signal");
+            } else {
+                info!(component = "shutdown", "Graceful shutdown initiated");
+                main_task_token.cancel();
+            }
         }
-        Err(error) => {
-            error!(
-                error = ?error,
-                component = "shutdown",
-                "Shutdown signal error"
-            );
+        Err(e) => {
+            error!(error = ?e, "Shutdown signal error");
         }
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,80 +1,57 @@
-use bitcoin::consensus::encode::deserialize;
 use bitcoin::Network;
 use clap::Parser;
 use futures::lock::Mutex;
-use futures::StreamExt;
-use libp2p::kad::BootstrapOk;
-use libp2p::{
-    core::multiaddr::Multiaddr,
-    floodsub::{self},
-    identify,
-    identity::Keypair,
-    kad::{self, Mode, QueryResult},
-    ping, request_response,
-    swarm::SwarmEvent,
-    PeerId,
-};
-use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
-use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
-use node::utils::BeadHash;
-use node::SwarmHandler;
+use libp2p::{floodsub, identity::Keypair};
 use node::{
-    bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
-    behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
+    behaviour::BRAIDPOOL_TOPIC,
     braid, cli,
-    db::db_handlers::DBHandler,
-    ibd_manager::{IBDCommands, IBDManager, IBD_BATCH_SIZE},
+    db::db_handlers::{fetch_beads_in_batch, DBHandler},
+    ibd_manager::{IBDManager, IBD_TRIGGER_AFTER},
     ipc_template_consumer,
     peer_manager::PeerManager,
     rpc_server::{run_rpc_server, BitcoinRpcConfig, RpcProxyCommand},
     setup_tracing,
     stratum::{BlockTemplate, ConnectionMapping, Notifier, NotifyCmd, Server, StratumServerConfig},
-    SwarmCommand, TemplateId,
+    swarm::{
+        bootstrap::{dial_additional_nodes, setup_and_bootstrap},
+        builder::{build_swarm, parse_bind_address, SwarmConfig},
+        config::DEFAULT_P2P_PORT,
+        p2p_event_loop, SwarmContext,
+    },
+    SwarmCommand, SwarmHandler, TemplateId,
 };
-use std::collections::HashSet;
-use std::os::unix::fs::PermissionsExt;
-use std::path::Path;
-use std::sync::atomic::{AtomicBool, Ordering};
-use std::sync::Arc;
-use std::time::{SystemTime, UNIX_EPOCH};
-use std::{collections::HashMap, error::Error};
-use std::{fs, time::Duration};
+use std::{
+    collections::HashMap,
+    error::Error,
+    fs,
+    path::Path,
+    sync::{atomic::AtomicBool, Arc},
+    time::Duration,
+};
+use tokio::sync::{mpsc, RwLock};
 use tokio_util::sync::CancellationToken;
-#[allow(unused_imports)]
-use tracing::{debug, error, info, trace, warn};
+use tracing::{debug, error, info, warn};
 
-use behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent};
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
 
-use crate::behaviour::KADPROTOCOLNAME;
-const LATENCY_ALPHA: u64 = 10; // seconds
-                               //boot nodes peerIds
-const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
-//dns NS
-const SEED_DNS: &str = "/dnsaddr/french.braidpool.net";
-//combined addr for dns resolution and dialing of boot for peer discovery
-const ADDR_REFRENCE: &str =
-    "/dnsaddr/french.braidpool.net/p2p/12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3";
-use tokio::sync::{
-    mpsc::{self},
-    RwLock,
-};
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Initialize tracing with colors and module prefixes
+    // Initialize tracing
     setup_tracing()?;
+    //Parsing args
     let args = cli::Cli::parse();
+    //IBD manager for ibd handling
     let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
-    //IBD cache handler
     let _ibd_handler = tokio::spawn(async move {
         ibd_manager.run_ibd_handler().await;
     });
-    //False if not under ibd otherwise true at start will be in IBD by default
-    let ibd_or_not: AtomicBool = AtomicBool::new(true);
-    let ibd_spinlock = Arc::new(ibd_or_not);
-    // Initializing the braid object with read write lock
-    //for supporting concurrent readers and single writer
+
+    // IBD flag - true at start (will be in IBD by default)
+    let ibd_spinlock = Arc::new(AtomicBool::new(true));
+    //Local braid instance being shared across different tasks
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
-    //Initializing DB and db command handler
+    //DB task handler for persistant of beads onto disk
     let (mut _db_handler, db_tx) = DBHandler::new().await.map_err(|e| {
         std::io::Error::new(
             std::io::ErrorKind::Other,
@@ -82,31 +59,26 @@ async fn main() -> Result<(), Box<dyn Error>> {
         )
     })?;
     let db_connection_pool = _db_handler.db_connection_pool.clone();
-    //Reconstructing local braid upon startup
+
+    // Load beads from database
     let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
     let braid_ref = braid.clone();
-    // FIXME instead we should look 144 blocks back from the bitcoin tip (1 day) and load beads
-    // starting from that block as genesis
+    //Fetching beads from disk before initializing other tasks to pre-shutdown state
     let initial_bead_fetch_handle = tokio::spawn(async move {
         let mut guard = braid_ref.write().await;
         let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 50).await?;
         info!(beads = fetched_beads.len(), "Beads loaded from DB");
         for bead in &fetched_beads {
-            let curr_bead_status = guard.extend(&bead);
-            info!(
-                hash = ?bead.block_header.block_hash(),
-                status = ?curr_bead_status,
-                "Bead inserted"
-            );
+            let status = guard.extend(bead);
+            debug!(hash = ?bead.block_header.block_hash(), status = ?status, "Bead inserted");
         }
         Ok::<(), node::error::DBErrors>(())
     });
+
     match initial_bead_fetch_handle.await {
-        Ok(Ok(())) => {
-            info!("Initial bead fetch completed successfully");
-        }
+        Ok(Ok(())) => info!("Initial bead fetch completed"),
         Ok(Err(e)) => {
-            error!(error = ?e, "Failed to fetch beads from DB during startup");
+            error!(error = ?e, "Failed to fetch beads from DB");
             return Err(format!("Database bead fetch failed: {:?}", e).into());
         }
         Err(e) => {
@@ -114,64 +86,212 @@ async fn main() -> Result<(), Box<dyn Error>> {
             return Err(format!("Initial bead fetch task panicked: {}", e).into());
         }
     }
-    let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
-    let latest_template_id_for_notifier = latest_template_id.clone();
-    let latest_template_id_for_consumer = latest_template_id.clone();
-    //Starting the `query_handler` task
+
+    // Start DB query handler
     tokio::spawn(async move {
         let _res = _db_handler.insert_query_handler().await;
     });
-    // Initializing the peer manager (shared between swarm and RPC server)
-    // Using RwLock to allow concurrent reads (RPC server) while swarm handler can write
-    let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
 
-    //One will go into the IPC and the other will go to the `notifier`
-    let (notification_tx, notification_rx) = mpsc::channel::<NotifyCmd>(1024);
-    //latest available template to be cached for the newest connection until new job is received
+    let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
+    let latest_template_id_for_notifier = latest_template_id.clone();
+    let latest_template_id_for_consumer = latest_template_id.clone();
+    //Initial template being shared across the notification task and swarm_handler task
     let latest_template = Arc::new(Mutex::new(BlockTemplate::default()));
-
-    //latest available template merkle branch
     let latest_template_merkle_branch = Arc::new(Mutex::new(Vec::new()));
     let mut latest_template_ref = latest_template.clone();
     let mut latest_template_merkle_branch_ref = latest_template_merkle_branch.clone();
-    let ipc_socket_path_for_blocking = args.ipc_socket.clone();
 
+    let (notification_tx, notification_rx) = mpsc::channel::<NotifyCmd>(1024);
+    //Swarm handler for additional event other than p2p events related to swarm
+    let (swarm_handler, swarm_command_receiver) =
+        SwarmHandler::new(Arc::clone(&braid), db_tx.clone());
+    let swarm_command_sender = swarm_handler.command_sender.clone();
+    let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
+
+    let notification_tx_clone = notification_tx.clone();
+    //Global connection mapping for each downstream connected to stratum server along with their respective sender channels
+    let connection_mapping = Arc::new(tokio::sync::RwLock::new(ConnectionMapping::new()));
+    // Clone connection_mapping for RPC server before it's used in async move blocks
+    let connection_mapping_for_rpc = Arc::clone(&connection_mapping);
+    //Global mining mapping mapping peer to its jobs provided by upstream uptill now
+    let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
+    //Notifier task for providing jobs to downstream
+    let mut notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
+    let stratum_config = StratumServerConfig::default();
+    //Block submission channel after validation of PoW to bitcoin-node
+    let (block_submission_tx, block_submission_rx) =
+        tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
+
+    // IBD trigger task
+    let swarm_cmd_for_ibd = swarm_command_sender.clone();
+    let _ibd_trigger_handler = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+        if let Err(e) = swarm_cmd_for_ibd.send(SwarmCommand::InitiateIBD).await {
+            error!(error = ?e, "Failed to initiate IBD");
+        } else {
+            info!("IBD trigger sent");
+        }
+    });
+
+    // Start stratum server
+    let mut stratum_server = Server::new(
+        stratum_config,
+        connection_mapping.clone(),
+        Some(block_submission_tx),
+    );
+
+    // Run notifier
+    tokio::spawn(async move {
+        let _res = notifier
+            .run_notifier(
+                connection_mapping.clone(),
+                &mut latest_template_ref,
+                &mut latest_template_merkle_branch_ref,
+                latest_template_id_for_notifier,
+            )
+            .await;
+    });
+
+    // Run stratum service
+    let ibd_flag_for_stratum = ibd_spinlock.clone();
+    tokio::spawn(async move {
+        let _res = stratum_server
+            .run_stratum_service(
+                mining_job_map,
+                notification_tx_clone,
+                swarm_handler_arc.clone(),
+                ibd_flag_for_stratum,
+            )
+            .await;
+    });
+
+    let (main_shutdown_tx, _main_shutdown_rx) =
+        mpsc::channel::<tokio::signal::unix::SignalKind>(32);
+    let main_task_token = CancellationToken::new();
+    let ipc_task_token = main_task_token.clone();
+
+
+    let datadir_str = args.datadir.to_str().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Invalid datadir path encoding",
+        )
+    })?;
+    let datadir = shellexpand::full(datadir_str).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Shell expansion failed: {}", e),
+        )
+    })?;
+
+    // Create data directory if needed
+    match fs::metadata(&*datadir) {
+        Ok(m) if !m.is_dir() => {
+            error!(datadir = %datadir, "Data directory exists but is not a directory");
+        }
+        Ok(_) => {
+            info!(datadir = %datadir, "Using existing data directory");
+        }
+        Err(_) => {
+            info!(datadir = %datadir, "Creating data directory");
+            fs::create_dir_all(&*datadir)?;
+        }
+    }
+
+    let datadir_path = Path::new(&*datadir);
+    let keystore_path = datadir_path.join("keystore");
+
+    #[cfg(unix)]
+    {
+        if keystore_path.exists() {
+            let perms = fs::metadata(&keystore_path)?.permissions();
+            if perms.mode() & 0o777 != 0o400 {
+                warn!(
+                    perms = perms.mode() & 0o777,
+                    "Keystore permissions not secure, fixing"
+                );
+                let mut new_perms = perms.clone();
+                new_perms.set_mode(0o400);
+                fs::set_permissions(&keystore_path, new_perms)?;
+            }
+        }
+    }
+    //Generating ed25519 curve keypair for unique PeerId during initialization
+    let keypair = match fs::read(&keystore_path) {
+        Ok(bytes) => {
+            info!(path = %keystore_path.display(), "Loading keypair from keystore");
+            Keypair::from_protobuf_encoding(&bytes).map_err(|e| {
+                error!(error = %e, "Failed to read keypair");
+                e
+            })?
+        }
+        Err(_) => {
+            info!(path = %keystore_path.display(), "Generating new keypair");
+            let keypair = Keypair::generate_ed25519();
+            let bytes = keypair.to_protobuf_encoding()?;
+            fs::write(&keystore_path, bytes)?;
+
+            #[cfg(unix)]
+            {
+                let mut perms = fs::metadata(&keystore_path)?.permissions();
+                perms.set_mode(0o400);
+                fs::set_permissions(&keystore_path, perms)?;
+                info!(path = %keystore_path.display(), perms = "0o400", "Set keystore permissions");
+            }
+
+            keypair
+        }
+    };
+    // Initializing the peer manager (shared between swarm and RPC server)
+    // Using RwLock to allow concurrent reads (RPC server) while swarm handler can write
+    let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
+    //For local testing uncomment this keypair peer since it running to process will
+    //result in same peerID leading to OutgoingConnectionError
+    // let keypair = identity::Keypair::generate_ed25519();
+    //Configured network
+    let network = if let Some(network_name) = &args.network {
+        info!(network = %network_name, "Network selected");
+        match network_name.as_str() {
+            "main" | "mainnet" => Network::Bitcoin,
+            "testnet" | "testnet4" => Network::Testnet(bitcoin::TestnetVersion::V4),
+            "signet" => Network::Signet,
+            "regtest" => Network::Regtest,
+            "cpunet" => Network::CPUNet,
+            _ => {
+                error!(network = %network_name, "Invalid network");
+                info!("Using fallback: regtest");
+                Network::Regtest
+            }
+        }
+    } else {
+        Network::Bitcoin
+    };
+    //IPC node initializer including our capnp client
+    let ipc_socket_path = args.ipc_socket.clone();
     let notification_tx_for_ipc = notification_tx.clone();
     let latest_template_for_ipc = latest_template.clone();
     let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
 
-    //Connection mapping for all the downstream connection connected to the stratum server
-    let connection_mapping = Arc::new(tokio::sync::RwLock::new(ConnectionMapping::new()));
-    // Clone connection_mapping for RPC server before it's used in async move blocks
-    let connection_mapping_for_rpc = Arc::clone(&connection_mapping);
     // Create RPC proxy command channel - sender goes to RPC server, receiver goes to IPC handler
     let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
     // peer_manager_arc is created above and shared between swarm and RPC server
     //spawning the rpc server
-    let rpc_addr = args.rpc_bind.to_string();
+    let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
     let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args).unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     });
-
-    let rpc_braid = Arc::clone(&braid);
-    let rpc_peer_manager = peer_manager_arc.clone();
-    let rpc_connection_mapping = connection_mapping_for_rpc.clone();
-    let rpc_latest_template = latest_template.clone();
-    let server_join = tokio::spawn(async move {
-        run_rpc_server(
-            rpc_braid,
-            &rpc_addr,
-            rpc_peer_manager,
-            rpc_connection_mapping,
-            rpc_latest_template,
-            rpc_proxy_tx,
-            bitcoin_rpc_config,
-        )
-        .await
-    });
-    let (_rpc_addr, dashboard_notifier) = match server_join.await {
-        Ok(Ok(tuple)) => tuple,
+    let server_join = tokio::spawn(run_rpc_server(
+        Arc::clone(&braid),
+        rpc_addr,
+        peer_manager_arc.clone(),
+        connection_mapping_for_rpc.clone(),
+        latest_template.clone(),
+        rpc_proxy_tx,
+        bitcoin_rpc_config,
+    ));
+    match server_join.await {
+        Ok(Ok(_addr)) => {}
         Ok(Err(())) => {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
@@ -187,260 +307,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .into());
         }
     };
-    //Communication bridge between stratum and network swarm and swarm commands also, for communicating share population and propogating them further
-    let (swarm_handler, mut swarm_command_receiver) = SwarmHandler::new(
-        Arc::clone(&braid),
-        db_tx.clone(),
-        Arc::clone(&dashboard_notifier),
-    );
 
-    //Swarm command sender
-    let swarm_command_sender = swarm_handler.command_sender.clone();
-    let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
-    //cloning the channel to be sent across different interfaces
-    let notification_tx_clone = notification_tx.clone();
-    //Mining job map keeping all the jobs provided to the downstream
-    let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
-    //Intializing `notifier` for mining.notify
-    let mut notifier: Notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
-    //Stratum configuration initialization
-    let stratum_config = StratumServerConfig {
-        port: args.stratum_port,
-        ..StratumServerConfig::default()
-    };
-    let (block_submission_tx, block_submission_rx) =
-        tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
-    //IBD notifier task after peer_discovery
-    let swarm_command_sender_ref = swarm_command_sender.clone();
-    let _ibd_trigger_handler = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-        //Sending IBD initiating command
-        match swarm_command_sender_ref
-            .send(SwarmCommand::InitiateIBD)
-            .await
-        {
-            Ok(_) => {
-                info!("IBD trigger sent");
-            }
-            Err(error) => {
-                error!(error=?error,"An error occurred while initiating IBD after waiting for peer discovery - ");
-            }
-        };
-    });
-    //Initializing stratum server
-    let mut stratum_server = Server::new(
-        stratum_config,
-        connection_mapping.clone(),
-        Some(block_submission_tx),
-    );
-    //Running the notification service
-    tokio::spawn(async move {
-        let _res = notifier
-            .run_notifier(
-                connection_mapping.clone(),
-                &mut latest_template_ref,
-                &mut latest_template_merkle_branch_ref,
-                latest_template_id_for_notifier,
-            )
-            .await;
-    });
-    //Running the stratum service
-    let spin_lock_ref = ibd_spinlock.clone();
-    tokio::spawn(async move {
-        let _res = stratum_server
-            .run_stratum_service(
-                mining_job_map,
-                notification_tx_clone,
-                swarm_handler_arc.clone(),
-                spin_lock_ref,
-            )
-            .await;
-    });
+    info!(socket = %ipc_socket_path, "IPC socket path");
 
-    let (main_shutdown_tx, _main_shutdown_rx) =
-        mpsc::channel::<tokio::signal::unix::SignalKind>(32);
-    let main_task_token = CancellationToken::new();
-    let ipc_task_token = main_task_token.clone();
-    let datadir_str = args.datadir.to_str().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Invalid datadir path encoding",
-        )
-    })?;
-    let datadir = shellexpand::full(datadir_str).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Shell expansion failed: {}", e),
-        )
-    })?;
-    match fs::metadata(&*datadir) {
-        Ok(m) => {
-            if !m.is_dir() {
-                error!(datadir = %datadir, "Data directory exists but is not a directory");
-            }
-            info!(datadir = %datadir, "Using existing data directory");
-        }
-        Err(_) => {
-            info!(datadir = %datadir, "Creating data directory");
-            fs::create_dir_all(&*datadir)?;
-        }
-    }
-
-    let datadir_path = Path::new(&*datadir);
-    let keystore_path = datadir_path.join("keystore");
-    #[cfg(unix)]
-    {
-        if keystore_path.exists() {
-            let perms = fs::metadata(&keystore_path)?.permissions();
-            if perms.mode() & 0o777 != 0o400 {
-                warn!(
-                    permissions = perms.mode() & 0o777,
-                    "Keystore permissions are not secure, setting to 0o400"
-                );
-                let mut new_perms = perms.clone();
-                new_perms.set_mode(0o400);
-                fs::set_permissions(&keystore_path, new_perms)?;
-            }
-        }
-    }
-    let keypair = match fs::read(&keystore_path) {
-        Ok(keypair) => {
-            info!(path = %keystore_path.display(), "Loading keypair from keystore");
-            libp2p::identity::Keypair::from_protobuf_encoding(&keypair).map_err(|e| {
-                error!(error = %e, path = %keystore_path.display(), "Failed to read keypair from keystore");
-                e
-            })?
-        }
-        Err(_) => {
-            info!(path = %keystore_path.display(), "Generating new keypair");
-            let keypair: Keypair = libp2p::identity::Keypair::generate_ed25519();
-            let keypair_bytes = keypair.to_protobuf_encoding()?;
-            fs::write(&keystore_path, keypair_bytes)?;
-            #[cfg(unix)]
-            {
-                let mut perms = fs::metadata(&keystore_path)?.permissions();
-                perms.set_mode(0o400);
-                fs::set_permissions(&keystore_path, perms)?;
-                info!(path = %keystore_path.display(), perms = "0o400", "Set keystore permissions");
-            }
-            keypair
-        }
-    };
-    // load beads from db (if present) and insert in braid here
-    // Initializing the peer manager (shared between swarm and RPC server)
-    // Using RwLock to allow concurrent reads (RPC server) while swarm handler can write
-    let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
-    //For local testing uncomment this keypair peer since it running to process will
-    //result in same peerID leading to OutgoingConnectionError
-    // let keypair = identity::Keypair::generate_ed25519();
-    //creating a main topic subscribing to the current test topic
-    let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
-
-    let swarm_builder = libp2p::SwarmBuilder::with_existing_identity(keypair)
-        .with_tokio()
-        .with_quic()
-        .with_dns()
-        .map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("DNS setup failed: {:?}", e),
-            )
-        })?;
-    // Note: with_behaviour closure must return behaviour directly (not Result), using expect for clear error message
-    let mut swarm = swarm_builder
-        .with_behaviour(|local_key| {
-            BraidPoolBehaviour::new(local_key).expect(
-                "Failed to create BraidPoolBehaviour - check keypair and network configuration",
-            )
-        })?
-        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(Duration::from_secs(u64::MAX)))
-        .build();
-    let socket_addr: std::net::SocketAddr = match args.bind.parse() {
-        Ok(addr) => addr,
-        Err(_) => format!("{}:6680", args.bind).parse().map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Failed to parse bind address: {}", e),
-            )
-        })?,
-    };
-    let multi_addr: Multiaddr = format!(
-        "/ip4/{}/udp/{}/quic-v1",
-        socket_addr.ip(),
-        socket_addr.port()
-    )
-    .parse()
-    .map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Failed to create multiaddress: {}", e),
-        )
-    })?;
-    //subscribing to the braidpool topic for broadcasting bead_found and other peer_communications belonging to a particular topic
-    swarm
-        .behaviour_mut()
-        .bead_announce
-        .subscribe(current_broadcast_topic.clone());
-    //setting the server mode for the kademlia apart from the server
-    swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
-
-    //adding the boot nodes for peer discovery
-    swarm.listen_on(multi_addr.clone())?;
-    for boot_peer in BOOTNODES {
-        let peer_id = match boot_peer.parse::<PeerId>() {
-            Ok(id) => id,
-            Err(e) => {
-                error!(boot_peer = %boot_peer, error = %e, "Failed to parse boot peer ID, skipping");
-                continue;
-            }
-        };
-        let seed_addr = match SEED_DNS.parse::<Multiaddr>() {
-            Ok(addr) => addr,
-            Err(e) => {
-                error!(seed_dns = %SEED_DNS, error = %e, "Failed to parse seed DNS, skipping");
-                continue;
-            }
-        };
-        swarm
-            .behaviour_mut()
-            .kademlia
-            .add_address(&peer_id, seed_addr);
-    }
-    info!(boot_node_count = %BOOTNODES.len(), "Boot nodes added to DHT");
-    let boot_addr: Multiaddr = ADDR_REFRENCE.parse().map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Failed to parse boot address: {}", e),
-        )
-    })?;
-    swarm.dial(boot_addr)?;
-    info!(address = %ADDR_REFRENCE, "Dialed boot node");
-    // IPC(inter process communication) based `getblocktemplate` and `notification` to send to the downstream via the `cmempoold` architecture
-    info!(socket = %args.ipc_socket, "IPC socket path");
-
-    let network = if let Some(network_name) = &args.network {
-        info!(network = %network_name, "Network selected");
-        match network_name.as_str() {
-            "main" | "mainnet" => Network::Bitcoin,
-            "testnet" | "testnet4" => Network::Testnet(bitcoin::TestnetVersion::V4),
-            "signet" => Network::Signet,
-            "regtest" => Network::Regtest,
-            "cpunet" => Network::CPUNet,
-            _ => {
-                error!(
-                    network = %network_name,
-                    valid_networks = "main, testnet, testnet4, signet, regtest, cpunet",
-                    "Invalid network specified"
-                );
-                info!(fallback = "regtest", "Using fallback network");
-                Network::Regtest
-            }
-        }
-    } else {
-        Network::Bitcoin
-    };
-
-    // Spawn IPC handler
     let _ipc_handler = tokio::task::spawn_blocking(move || {
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -448,13 +317,13 @@ async fn main() -> Result<(), Box<dyn Error>> {
         {
             Ok(rt) => rt,
             Err(e) => {
-                error!(error = %e, "Failed to create tokio runtime for IPC handler");
+                error!(error = %e, "Failed to create tokio runtime for IPC");
                 return;
             }
         };
+
         rt.block_on(async {
             let local_set = tokio::task::LocalSet::new();
-
             local_set
                 .run_until(async {
                     let template_cache: Arc<
@@ -462,1113 +331,87 @@ async fn main() -> Result<(), Box<dyn Error>> {
                             HashMap<TemplateId, Arc<node::ipc::client::BlockTemplate>>,
                         >,
                     > = Arc::new(tokio::sync::Mutex::new(HashMap::new()));
-                    let template_cache_for_consumer = template_cache.clone();
-                    let template_cache_for_listener = template_cache.clone();
+
                     let (ipc_template_tx, ipc_template_rx) =
                         tokio::sync::mpsc::channel::<Arc<node::ipc::client::BlockTemplate>>(1);
 
                     let listener_task = tokio::task::spawn_local({
-                        let ipc_socket_path = ipc_socket_path_for_blocking.clone();
-                        let ipc_template_tx = ipc_template_tx.clone();
-                        let template_cache = template_cache_for_listener.clone();
+                        let ipc_socket = ipc_socket_path.clone();
+                        let tx = ipc_template_tx.clone();
+                        let cache = template_cache.clone();
                         let rpc_command_rx = rpc_proxy_rx;
-
                         async move {
                             match node::ipc::ipc_block_listener(
-                                ipc_socket_path,
-                                ipc_template_tx,
+                                ipc_socket,
+                                tx,
                                 network,
-                                template_cache,
+                                cache,
                                 block_submission_rx,
                                 rpc_command_rx,
                             )
                             .await
                             {
-                                Ok(_) => {
-                                    info!("IPC block listener exited");
-                                }
-                                Err(e) => {
-                                    error!(error = %e, "IPC block listener error");
-                                }
+                                Ok(_) => info!("IPC listener exited"),
+                                Err(e) => error!(error = %e, "IPC listener error"),
                             }
                         }
                     });
 
                     let consumer_task = tokio::task::spawn_local({
+                        let cache = template_cache.clone();
                         async move {
                             if let Err(e) = ipc_template_consumer(
                                 ipc_template_rx,
                                 notification_tx_for_ipc,
                                 &mut latest_template_for_ipc.clone(),
                                 &mut latest_template_merkle_branch_for_ipc.clone(),
-                                template_cache_for_consumer,
+                                cache,
                                 latest_template_id_for_consumer,
                             )
                             .await
                             {
-                                error!(error = ?e, "IPC template consumer error");
+                                error!(error = ?e, "IPC consumer error");
                             }
                         }
                     });
 
                     tokio::select! {
-                        _ = listener_task => info!(task = "listener", "IPC listener task completed"),
-                        _ = consumer_task => info!(task = "consumer", "Template consumer task completed"),
-                        _ = ipc_task_token.cancelled() => {
-                            info!("IPC task shutting down - cancellation token triggered");
-                        }
+                        _ = listener_task => info!("IPC listener completed"),
+                        _ = consumer_task => info!("IPC consumer completed"),
+                        _ = ipc_task_token.cancelled() => info!("IPC cancelled"),
                     }
                 })
                 .await;
         });
     });
+    //Default listening addr of spawned peer
+    let bind_addr = parse_bind_address(&args.bind, DEFAULT_P2P_PORT)?;
+    let swarm_config = SwarmConfig::new(keypair, bind_addr);
+    let listen_addr = swarm_config.to_multiaddr()?;
+    //Building swarm with `BraidpoolBeahaviour`
+    let mut swarm = build_swarm(swarm_config).await?;
 
+    // Bootstrap the swarm
+    let topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
+    setup_and_bootstrap(&mut swarm, listen_addr, topic)?;
+
+    // Dial additional nodes if provided
+    //This should be changed to a single dial function only
     if let Some(addnode) = args.addnode {
-        for node in addnode.iter() {
-            let node_multiaddr: Multiaddr = match node.parse() {
-                Ok(addr) => addr,
-                Err(e) => {
-                    error!(node = %node, error = %e, "Failed to parse multiaddr, skipping");
-                    continue;
-                }
-            };
-            let dial_result = swarm.dial(node_multiaddr.clone());
-            if let Some(err) = dial_result.err() {
-                error!(address = %node_multiaddr, error = %err, "Failed to dial peer node");
-                continue;
-            }
-            info!(address = %node_multiaddr, "Dialed peer node");
-        }
-    };
-    let peer_manager_arc_for_swarm = peer_manager_arc.clone();
+        dial_additional_nodes(&mut swarm, &addnode);
+    }
+    //Swarm context shared as reference among different handlers and task but keeping the Swarm centralized
+    let ctx = SwarmContext::new(
+        braid.clone(),
+        db_tx,
+        ibd_command_tx,
+        ibd_spinlock.clone(),
+        peer_manager_arc.clone(),
+        swarm_command_sender,
+    );
+    //Event loop for p2p related events
     let swarm_handle = tokio::spawn(async move {
-        let braid = std::sync::Arc::clone(&braid);
-        let peer_manager_arc = peer_manager_arc_for_swarm;
-        loop {
-            tokio::select! {
-             swarm_event = swarm.select_next_some()=>{
-                 match swarm_event{
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
-                         kad::Event::RoutingUpdated {
-                             peer,
-                             is_new_peer,
-                             addresses,
-                             bucket_range,
-                             old_peer,
-                         },
-                     )) => {
-                         info!(
-                             peer = %peer,
-                             is_new = %is_new_peer,
-                             addresses = ?addresses,
-                             bucket = ?bucket_range,
-                             old_peer = ?old_peer,
-                             "DHT routing updated"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Subscribed { peer_id, topic },
-                     )) => {
-                         info!(
-                             peer = ?peer_id,
-                             topic = ?topic,
-                             "Peer subscribed to topic"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Unsubscribed { peer_id, topic },
-                     )) => {
-                         info!(
-                             peer = ?peer_id,
-                             topic = ?topic,
-                             "Peer unsubscribed from topic"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Message(message),
-                     )) => {
-                         info!(
-                             topics = ?message.topics,
-                             source = ?message.source,
-                             size_bytes = %message.data.len(),
-                             "Floodsub message received"
-                         );
-                         let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&message.data);
-                         match result_bead {
-                             Ok(bead) => {
-                                // Handle the received bead here
-                                let mut braid_data = braid.write().await;
-                                let status = {
-                                     braid_data.extend(&bead)
-                                 };
-                                 if ibd_spinlock.load(Ordering::SeqCst){
-                                    let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
-                                    let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
-                                    if let Err(e) = ibd_command_tx
-                                        .send(IBDCommands::FetchAllTimestamps { sender: ts_tx })
-                                        .await {
-                                        tracing::warn!("Failed to request timestamp map: {:?}", e);
-                                    }
-                                    let timestamp_map = match ts_rx.await {
-                                        Ok(map) => map,
-                                        Err(_) => {
-                                            tracing::error!("Failed to receive timestamp map");
-                                            continue;
-                                        }
-                                    };
-                                      //If the received  bead exceeds the timestamp of ibd completion wrt to a sync node
-                                      if let braid::AddBeadStatus::ParentsNotYetReceived = status {
-                                        //request the parents using request response protocol
-                                        let peer_id = {
-                                            let peer_manager = peer_manager_arc.read().await;
-                                            peer_manager.get_top_k_peers_for_propagation(1)
-                                        };
-                                        if let Some(peer) = peer_id.first() {
-                                            swarm.behaviour_mut().bead_sync.send_request(
-                                                &peer,
-                                                BeadRequest::GetBeads(
-                                                    BeadHashes(
-                                                        bead.committed_metadata
-                                                            .parents
-                                                            .clone()
-                                                            .into_iter()
-                                                            .collect(),
-                                                    )
-                                                ),
-                                            );
-                                        } else {
-                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
-                                        }
-                                    } else if let braid::AddBeadStatus::InvalidBead = status {
-                                        // update the peer manager about the invalid bead
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.penalize_for_invalid_bead(&message.source);
-                                        }
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
-
-                                     //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
-                                                continue;
-                                            }
-                                        };
-                                        let bead_hash = bead.block_header.block_hash();
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
-                                            Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead_hash,error);
-                                                continue;
-                                            }
-                                        };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead.clone(),txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                           Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.update_score(&message.source, 1.0);
-                                        }
-                                        let res =  dashboard_notifier.new_bead.send(Some(bead));
-                                            match res {
-                                                Ok(_) => {
-                                                    debug!("Notification sent to dashboard notification sender from peer");
-                                                }
-                                                Err(error) => {
-                                                    error!("An error occurred while sending dashboard notification - {error}");
-                                            }
-                                }
-                                    }
-                                    for (sync_peer, ibd_ts) in timestamp_map.iter() {
-                                        let threshold = *ibd_ts + LATENCY_ALPHA * 10;
-                                        let sync_peer_id = match sync_peer.parse::<PeerId>() {
-                                            Ok(id) => id,
-                                            Err(e) => {
-                                                error!(sync_peer = %sync_peer, error = %e, "Failed to parse sync peer ID");
-                                                continue;
-                                            }
-                                        };
-                                        // broadcast_timestamp < timestamp + alpha * 10
-                                        if broadcast_ts  < threshold as u32 {
-                                            info!("Incoming BEAD received during IBD within threshold limit with broadcast timestamp - {:?} and threshold is - {:?}",broadcast_ts,threshold);
-                                           match status{
-                                            braid::AddBeadStatus::InvalidBead | braid::AddBeadStatus::ParentsNotYetReceived=>{
-                                                //Aborting/evicting the wait_ibd handler corresponding to the sync peer
-                                                match ibd_command_tx.send(IBDCommands::AbortWaitHandle { peer_id:sync_peer_id }).await{
-                                                    Ok(_)=>{
-                                                        warn!("Abort handle and evicting handler corresponding to sync peer sent successfully");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"An error occurred while sending abort handler wrt sync peer due to -");
-                                                    }
-                                                };
-                                                // If result is invalid then reinitiate IBD
-                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                    Ok(_)=>{
-                                                        warn!("Reinitiating IBD command sent to swarm handler");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                    }
-                                                }
-                                                continue;
-                                            },
-                                            braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
-                                                ibd_spinlock.store(false,Ordering::SeqCst);
-                                                continue;
-                                            },
-                                           }
-
-                                        }
-                                        else{
-                                            ibd_spinlock.store(false,Ordering::SeqCst);
-                                            continue;
-                                        }
-                                    }
-                                }
-                                else{
-                                    if let braid::AddBeadStatus::ParentsNotYetReceived = status {
-                                        //request the parents using request response protocol
-                                        let peer_id = {
-                                            let peer_manager = peer_manager_arc.read().await;
-                                            peer_manager.get_top_k_peers_for_propagation(1)
-                                        };
-                                        if let Some(peer) = peer_id.first() {
-                                            swarm.behaviour_mut().bead_sync.send_request(
-                                                &peer,
-                                                BeadRequest::GetBeads(
-                                                    BeadHashes(
-                                                        bead.committed_metadata
-                                                            .parents
-                                                            .clone()
-                                                            .into_iter()
-                                                            .collect(),
-                                                    )
-                                                ),
-                                            );
-                                        } else {
-                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
-                                        }
-                                    } else if let braid::AddBeadStatus::InvalidBead = status {
-                                        // update the peer manager about the invalid bead
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.penalize_for_invalid_bead(&message.source);
-                                        }
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
-                                                continue;
-                                            }
-                                        };
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
-                                            Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                continue;
-                                            }
-                                        };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                            Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
-                                        {
-                                            let mut peer_manager = peer_manager_arc.write().await;
-                                            peer_manager.update_score(&message.source, 1.0);
-                                        }
-                                    }
-                                }
-
-                             }
-                             Err(e) => {
-                                 error!(error = %e, "Failed to deserialize bead");
-                             }
-                         }
-                     }
-                     SwarmEvent::NewListenAddr { address, .. } => {
-                         info!(address = ?address, "P2P listening on address")
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Sent { peer_id, .. },
-                     )) => {
-                         debug!(peer = ?peer_id, "Sent identify info");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Received { peer_id, info,  .. },
-                     )) => {
-                         let info_reference = info.clone();
-                         info!(
-                             peer = ?peer_id,
-                             address_count = %info_reference.listen_addrs.len(),
-                             "Received listen addresses"
-                         );
-                         if info.protocols.iter().any(|p| *p == KADPROTOCOLNAME) {
-                             for addr in info.listen_addrs {
-                                 info!(address = %addr, "Received address via identify");
-                             }
-                         } else {
-                             info!(peer = ?peer_id, "Peer does not support Kademlia");
-                         }
-                         if info_reference
-                             .clone()
-                             .protocols
-                             .iter()
-                             .any(|p| *p != BEAD_ANNOUNCE_PROTOCOL)
-                         {
-
-                             info!(
-                                 peer_address = ?info_reference.observed_addr,
-                                 "Peer does not support floodsub"
-                             );
-                         }
-                         debug!(info = ?info_reference, "Received peer info");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
-                         kad::Event::OutboundQueryProgressed { result, .. },
-                     )) => match result {
-                         QueryResult::GetClosestPeers(Ok(ok)) => {
-                             info!(peers = ?ok.peers, peer_count = %ok.peers.len(), "Got closest peers");
-                         }
-                         QueryResult::GetClosestPeers(Err(err)) => {
-                             error!(error = %err, "Failed to get closest peers");
-                         }
-                        QueryResult::Bootstrap(Ok(BootstrapOk {
-                            peer, ..
-                        }))=>{
-                            info!(peer = ?peer, "New peer");
-                        }
-                         _ => info!(result = ?result, "Other DHT query result"),
-                     },
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Error {
-                             peer_id,
-                             error,
-                             connection_id: _,
-                         },
-                     )) => {
-                         error!(peer = %peer_id, error = ?error, "Identify event error");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Ping(ping::Event {
-                         peer,
-                         result,
-                         ..
-                     })) => {
-                         match result {
-                             Ok(latency) => {
-                                 info!(
-                                     peer = %peer,
-                                     latency_ms = %latency.as_millis(),
-                                     "Ping"
-                                 );
-                                {
-                                    let mut peer_manager = peer_manager_arc.write().await;
-                                    peer_manager.update_latency(&peer,latency);
-                                }
-                             }
-                             Err(err) => {
-                                 warn!(
-                                     peer = %peer,
-                                     error = %err,
-                                     "Ping failed"
-                                 );
-                             }
-                         }
-                     }
-                     SwarmEvent::ConnectionEstablished {
-                         peer_id, endpoint, ..
-                     } => {
-
-                         // Add the peer to the peer manager
-                         let remote_addr = endpoint.get_remote_address();
-                         swarm.behaviour_mut().kademlia.add_address(&peer_id,remote_addr.clone());
-                         info!(address = ?remote_addr, "DHT updated with peer address");
-                         swarm.behaviour_mut()
-                         .bead_announce
-                         .add_node_to_partial_view(peer_id);
-
-                         info!(peer = %peer_id, "Peer added to floodsub mesh");
-                         let ip = remote_addr.iter().find_map(|p| match p {
-                             libp2p::core::multiaddr::Protocol::Ip4(ip) => {
-                                 Some(std::net::IpAddr::V4(ip))
-                             }
-                             libp2p::core::multiaddr::Protocol::Ip6(ip) => {
-                                 Some(std::net::IpAddr::V6(ip))
-                             }
-                             _ => None,
-                         });
-                         {
-                             let mut peer_manager = peer_manager_arc.write().await;
-                             peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
-                         }
-                         info!(
-                            peer_id = ?peer_id,
-                            remote_addr = ?remote_addr,
-                            "Connection established to peer"
-                        );
-
-                     }
-                     SwarmEvent::ConnectionClosed {
-                         peer_id,
-                         connection_id,
-                         endpoint,
-                         num_established,
-                         cause,
-                     } => {
-                         info!(peer = %peer_id, connection_id = %connection_id, address = %endpoint.get_remote_address(), established = %num_established, cause = ?cause, "Connection closed");
-                         // Remove the peer from the peer manager
-                         {
-                             let mut peer_manager = peer_manager_arc.write().await;
-                             peer_manager.remove_peer(&peer_id);
-                         }
-                         swarm
-                             .behaviour_mut()
-                             .kademlia
-                             .remove_address(&peer_id, endpoint.get_remote_address());
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadSync(
-                    request_response::Event::Message {
-                        peer,
-                        message,
-                        connection_id,
-                    },
-                )) => {
-                    info!(
-                        peer = %peer,
-                        message = ?message,
-                        connection = ?connection_id,
-                        "Bead sync message received"
-                    );
-                    match message {
-                        request_response::Message::Request {
-                            request,
-                            request_id: _,
-                            channel,
-                        } => {
-                            // Handle the bead sync request here
-                            match request {
-                                BeadRequest::GetBeads(hashes) => {
-                                        let mut beads = Vec::new();
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            for hash in hashes.iter() {
-                                                if let Some(index) =
-                                                    braid_lock.bead_index_mapping.get(hash)
-                                                {
-                                                    if let Some(bead) = braid_lock.beads.get(*index) {
-                                                        beads.push(bead.clone());
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        //Sending all the beads requested in the hashes supplied during `GetData` request
-                                        swarm.behaviour_mut().respond_with_beads(channel, beads);
-                                }
-                                BeadRequest::GetTips => {
-                                        let tips;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            tips = braid_lock
-                                                .tips
-                                                .iter()
-                                                .filter_map(|index| braid_lock.beads.get(*index))
-                                                .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
-                                                .collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_tips(channel, tips);
-                                }
-                                BeadRequest::GetGenesis => {
-                                        let genesis;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            genesis = braid_lock
-                                                .genesis_beads
-                                                .iter()
-                                                .filter_map(|index| braid_lock.beads.get(*index))
-                                                .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
-                                                .collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_genesis(channel, genesis);
-                                }
-                                BeadRequest::GetAllBeads => {
-
-                                        let all_beads;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            all_beads = braid_lock.beads.iter().cloned().collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_beads(channel, all_beads);
-                                }
-                                BeadRequest::GetBeadsAfter(hashes) => {
-                                        let beads = braid.read().await.get_beads_after(hashes.into());
-                                        if let Some(response_beads) = beads {
-                                            let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
-                                            for bead in response_beads.into_iter(){
-                                                computed_beads_hashes.push(bead.block_header.block_hash());
-                                            }
-                                            //Sending the corresponding bead hashes requested by the new peer for IBD that will
-                                            //be after the new peer's `Tips`.
-                                            swarm
-                                                .behaviour_mut()
-                                                .respond_with_beadhashes(channel, computed_beads_hashes);
-                                        } else {
-                                            swarm.behaviour_mut().respond_with_error(
-                                                channel,
-                                                BeadSyncError::BeadHashNotFound,
-                                            );
-                                        }
-                                }
-                            }
-                        }
-                        request_response::Message::Response {
-                            request_id: _,
-                            response,
-                        } => {
-                            match response {
-                                BeadResponse::Beads(beads)
-                                | BeadResponse::GetAllBeads(beads) => {
-                                    let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    //Fetching the pruned bead-hashes received during `GetBeadAfter` request
-                                    match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
-                                        Ok(_)=>{
-                                            debug!("IBD command sent to handler successfully !");
-                                        },
-                                        Err(error)=>{
-                                            //Re-initiating IBD
-                                            error!("An error occurred while sending ibd command to ibd_handler - {:?}, re-trying IBD",error.0);
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    let pruned_beads = match beads_rx.await{
-                                        Ok(received_beads)=>{
-                                            received_beads
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error.to_string(),"An error occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    for bead in beads.into_iter() {
-                                        let mut braid_data = braid.write().await;
-                                        let status = braid_data.extend(&bead);
-                                        let curr_beadhash = bead.block_header.block_hash();
-                                        if let braid::AddBeadStatus::InvalidBead = status {
-                                            // update the peer manager about the invalid bead
-                                            {
-                                                let mut peer_manager = peer_manager_arc.write().await;
-                                                peer_manager.penalize_for_invalid_bead(&peer);
-                                            }
-                                        } else if let braid::AddBeadStatus::BeadAdded = status {
-
-                                            let bead_id = match braid_data
-                                                .bead_index_mapping
-                                                .get(&curr_beadhash) {
-                                                Some(id) => id,
-                                                None => {
-                                                    error!(bead_hash = ?curr_beadhash, "Bead ID not found in index mapping (GetBeadsAfter)");
-                                                    continue;
-                                                }
-                                            };
-                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                                &braid_data.beads,
-                                                &braid_data.bead_index_mapping,
-                                                &bead,
-                                            ){
-                                                Ok(received_tuples)=>received_tuples,
-                                                Err(error)=>{
-                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
-                                                    continue;
-                                                }
-                                            };
-                                            // update score of the peer
-                                            {
-                                                let mut peer_manager = peer_manager_arc.write().await;
-                                                peer_manager.update_score(&peer, 1.0);
-                                            }
-                                            //persisting the received beads from peer onto DB(disk)
-                                            let res =  dashboard_notifier.new_bead.send(Some(bead.clone()));
-                                            match res {
-                                                Ok(_) => {
-                                                    debug!("Notification sent to dashboard notification sender from IBD");
-                                                }
-                                                Err(error) => {
-                                                    error!("An error occurred while sending dashboard notification - {error}");
-                                                }
-                                            }
-                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
-                                                Ok(_)=>{
-                                                    debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
-                                                },
-                                                Err(error)=>{
-                                                    tracing::error!(
-                                                        peer = %peer,
-                                                        err = ?error.0,
-                                                        "An error occurred while persisting received bead from peer"
-                                                    );
-                                                }
-                                            };
-                                        }
-                                    }
-                                    //Preparing next batch request to be sent to the sync node
-                                    let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await{
-                                            Ok(_)=>{
-                                                debug!("Offset Updated");
-                                            },
-                                            Err(error)=>{
-                                                error!(error=?error,"An error occurred while sending the offset update command, re-trying IBD");
-                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                    Ok(_)=>{
-                                                        warn!("Reinitiating IBD command sent to swarm handler");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                    }
-                                                }
-                                                continue;
-                                            }
-                                    };
-                                    let next_batch_offset = match batch_rx.await{
-                                        Ok(next_offset)=>{
-                                            debug!(next_offset=?next_offset,"Newer offset for batch request received successfully ");
-                                            next_offset
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while receiving the offset, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)< pruned_beads.len()){
-                                        info!("Received beads within batch range");
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..(next_batch_offset+IBD_BATCH_SIZE)].to_vec());
-                                    }
-                                    else if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)>=pruned_beads.len()){
-                                        info!("Received beads within batch range");
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..].to_vec());
-
-                                    }
-                                    else{
-                                        //IBD completed
-                                        info!(
-                                            peer = %peer,
-                                            "Initial IBD has been completed with respect to peer"
-                                        );
-                                        // Get current time and create recent timestamps (within last hour)
-                                        let current_time = SystemTime::now()
-                                            .duration_since(UNIX_EPOCH)
-                                            .map(|d| d.as_secs())
-                                            .unwrap_or_else(|e| {
-                                                error!(error = %e, "System time before UNIX epoch");
-                                                0
-                                            });
-                                        match ibd_command_tx.send(IBDCommands::UpdateTimestampMapping { peer_id: peer.to_string(), end_timestamp: current_time }).await{
-                                            Ok(_)=>{
-                                                debug!("Timestamp updated command sent successfully");
-                                                //Scheduling a corresponding watcher task that will check after a latency period
-                                                //if no incoming is received during the instance of [initial_headers_fetched,(initial_headers_fetched+(alpha*10))]
-                                                let ibd_spinlock_ref = ibd_spinlock.clone();
-                                                let ibd_incoming_handler = tokio::spawn(async move{
-                                                    //Sleeping for a fixed duration to be set according to statistical estimates
-                                                    tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
-                                                    //We will check if no bead is `incoming` after the duration of 600 seconds then we will reset/set ibd_flag accordingly
-                                                    if ibd_spinlock_ref.load(Ordering::SeqCst){
-                                                        //If no incoming is received during the period then we can say
-                                                        //that ibd wrt the given sync node is successfully completed
-                                                        ibd_spinlock_ref.store(false,Ordering::SeqCst);
-                                                        warn!("Maximum threshold wrt IBD incoming exceeded thus ibd_flag being set to false");
-                                                    }
-
-                                                });
-                                                //At retry we will have to abort and evict the corresponding sync-peers's wait handle
-                                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:peer,retry_or_not:false,handle:Some(ibd_incoming_handler)}).await{
-                                                    Ok(_)=>{
-                                                        debug!("Incoming bead command sent successfully");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                                    }
-                                                };
-                                            },
-                                            Err(error)=>{
-                                                error!(error=?error,"An error occurred while sending timestamp update command for the given sync node");
-                                            }
-                                        };
-                                    }
-                                }
-                                 BeadResponse::GetBeadsAfter(bead_hashes)=>{
-                                    //Getting all the beadhashes after the common oldest in both the peers
-                                    let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    match ibd_command_tx.send(IBDCommands::FetchTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
-                                        Ok(_)=>{
-                                            debug!("Sync peer Tips received successfully.");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"Error occurred while receiving tips, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    let received_tips = match tips_rx.await{
-                                        Ok(received_tips)=>{
-                                            received_tips
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while receiving the Tips, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    //Pruning the hashes wrt cached `Tips`
-                                    let mut found_tips = HashSet::new();
-                                    let mut pruned = Vec::new();
-                                    let tips_set: HashSet<_> = received_tips.into_iter().collect();
-                                    for hash in bead_hashes {
-                                        if tips_set.contains(&hash) {
-                                            found_tips.insert(hash.clone());
-                                        }
-                                        pruned.push(hash);
-                                        // Stop once all tips have been matched
-                                        if found_tips.len() == tips_set.len() {
-                                            break;
-                                        }
-                                    }
-                                    let pruned_ref = pruned.clone();
-                                    // Storing them in cache
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncoming { get_bead_response: pruned, peer_id: peer.to_string() }).await{
-                                        Ok(_)=>{
-                                            debug!("Received beads to be fetched in GetBeads saved successfully");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while Caching pruned beadhashes to be fetched in GetBeads");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    // Initiating `GetBead` request cycle
-                                    if pruned_ref.len() <= IBD_BATCH_SIZE{
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref);
-                                    }
-                                    else{
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref[0..IBD_BATCH_SIZE].to_vec());
-                                    }
-
-                                }
-                                BeadResponse::Tips(tips) => {
-                                    info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
-                                    //If received tips are already present in the local braid arc then we can stop
-                                    //IBD and continue with mining
-                                    //Initializing the batch offset for the corresponding sync peer
-                                    let (ibd_bridge_tx, _ibd_bridge_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await{
-                                        Ok(_)=>{
-                                            debug!("Offset Initialized successfully");
-                                        },
-                                        Err(_error)=>{
-                                            error!("An error occurred while sending offset initalization command to ibd_handler");
-                                            continue;
-                                        }
-                                    };
-                                    let _val = match _ibd_bridge_rx.await {
-                                        Ok(v) => v,
-                                        Err(e) => {
-                                            error!(error = %e, "Failed to receive IBD batch offset");
-                                            continue;
-                                        }
-                                    };
-                                    let braid_data = braid.read().await;
-
-                                    let bead_hash_set: HashSet<BeadHash> = braid_data
-                                    .beads
-                                    .iter()
-                                    .map(|b| b.block_header.block_hash())
-                                    .collect();
-
-                                    let flag = tips.iter().all(|tip_hash| bead_hash_set.contains(tip_hash));
-
-                                    if flag{
-                                        //No need to proceed further and continue to next event
-                                        info!("Peer already synced to tip");
-                                        //IBD flag can be set  as the current bead is already synced//
-                                        ibd_spinlock.store(false, Ordering::SeqCst);
-                                        continue;
-                                    }
-                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips.0, peer_id: peer.to_string() }).await{
-                                    Ok(_)=>{
-                                        debug!("Sync peers Tip mapping update successfully");
-                                    },
-                                    Err(error)=>{
-                                        tracing::error!(
-                                            err = ?error,
-                                            "Error while sending update cache command"
-                                        );
-                                        continue;
-                                    }
-                                  };
-                                    // After storing tips we will issue `GetBeads` command that will find the oldest
-                                    // common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
-                                    // the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
-                                    let mut current_tip_hashes = Vec::new();
-                                    for curr_bead_idx in braid_data.tips.iter() {
-                                        if let Some(current_bead) = braid_data.beads.get(*curr_bead_idx) {
-                                            current_tip_hashes.push(current_bead.block_header.block_hash());
-                                        } else {
-                                            error!(bead_idx = %curr_bead_idx, "Tip bead not found in beads list");
-                                        }
-                                    }
-                                    // Sending the current bead hashes for the receiving of beads to start in batches
-                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
-                                    swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
-
-                                }
-                                BeadResponse::Genesis(genesis) => {
-                                    info!(genesis=?genesis,"Received genesis beads: ");
-                                    let status = {
-                                        let braid_lock = braid.read().await;
-                                        braid_lock.check_genesis_beads(&genesis.0)
-                                    };
-                                    match status {
-                                        braid::GenesisCheckStatus::GenesisBeadsValid => {
-                                            info!("Genesis beads are valid");
-                                        }
-                                        braid::GenesisCheckStatus::MissingGenesisBead => {
-                                            warn!(peer = %peer, "Missing genesis bead");
-                                            swarm
-                                                .behaviour_mut()
-                                                .request_beads(peer, &genesis.0);
-                                        }
-                                        braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
-                                            warn!(
-                                                received = %genesis.0.len(),
-                                                peer = %peer,
-                                                "Genesis bead count mismatch"
-                                            );
-                                        }
-                                    }
-                                }
-                                BeadResponse::Error(error) => match error {
-                                    BeadSyncError::GenesisMismatch => {
-                                        warn!("Genesis mismatch error received");
-                                        swarm.behaviour_mut().request_genesis(peer.clone());
-                                    }
-                                    BeadSyncError::BeadHashNotFound => {
-                                        warn!("Peer requested bead hashes not found in local store");
-                                    }
-                                },
-                            };
-                        }
-                    }
-                }
-                     other_event=>{
-                             debug!(event = ?other_event, "Other swarm event");
-                     }
-                 }
-
-             }
-             Some(swarm_command) = swarm_command_receiver.recv()=>{
-                 match swarm_command{
-                     SwarmCommand::PropagateValidBead {
-                         bead_bytes,
-                     } => {
-                         swarm
-                             .behaviour_mut()
-                             .bead_announce
-                             .publish(current_broadcast_topic.clone(), bead_bytes);
-                        info!(topic = ?current_broadcast_topic, "Published bead to floodsub topic");
-                     },
-                     SwarmCommand::InitiateIBD=>{
-                        info!("Initiating IBD after peer discovery and selecting peer with lowest latency score");
-                        //Evicting lowest latency peer id
-                        let peer_ids = {
-                            let peer_manager = peer_manager_arc.read().await;
-                            peer_manager.get_top_k_peers_for_propagation(1)
-                        };
-                        if peer_ids.len() == 0 {
-                            warn!("No peer available for syncing to take place");
-                                tokio::spawn({
-                                    let swarm_command_sender = swarm_command_sender.clone();
-                                    //Retrying at fixed interval in case of no sync peers being available
-                                    async move {
-                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
-                                            Ok(_) => {
-                                                info!("Retrying IBD when no sync peers are available");
-                                            }
-                                            Err(error) => {
-                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
-                                            }
-                                        }
-                                    }
-                                });
-                        }
-                        else{
-                            let mut sync_request_sent = false;
-                            for lowest_latency_peer in peer_ids.into_iter(){
-                                let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
-                                match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:lowest_latency_peer,retry_sender:retry_count_tx}).await{
-                                    Ok(_)=>{
-                                        info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
-                                    },
-                                    Err(error)=>{
-                                        error!(error=?error,"An error occurred while sending retry count to IBDHandler");
-                                    }
-                                }
-                                let retry_cnt = match retry_count_rx.await {
-                                    Ok(cnt) => cnt,
-                                    Err(e) => {
-                                        error!(error=?e, "Failed to receive retry count from IBDHandler, channel closed or sender dropped");
-                                        continue;
-                                    }
-                                };
-                                if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
-                                    warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
-                                    continue;
-                                }
-                                else if retry_cnt == u64::MAX{
-                                    //First time syncing is being done wrt the provided peer
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:false,handle:None}).await{
-                                        Ok(_)=>{
-                                            info!("Incoming bead command sent successfully");
-                                            let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                        }
-                                    };
-                                    sync_request_sent = true;
-                                    break;
-                                }
-                                else{
-                                    //Case of retry is there
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:true,handle:None}).await{
-                                        Ok(_)=>{
-                                            info!("Incoming bead command sent successfully");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                        }
-                                    };
-                                    //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
-                                    let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                    swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                    sync_request_sent = true;
-                                    break;
-                                }
-
-                            }
-                            if sync_request_sent{
-                                //The lowest latency avaialble sync peer whose retry count is not exceeded has been selected and requested to initiate IBD
-                                continue;
-                            }
-                            else{
-                                warn!("Retry count for all the available sync peers exceeded waiting for new peer connections");
-                                tokio::spawn({
-                                    let swarm_command_sender = swarm_command_sender.clone();
-                                    //Retrying at fixed interval in case of all available sync peer retry count has exceeded
-                                    //Probe at fixed interval for any new peer
-                                    async move {
-                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
-                                            Ok(_) => {
-                                                info!("Retrying IBD when no sync peers are available");
-                                            }
-                                            Err(error) => {
-                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
-                                            }
-                                        }
-                                    }
-                                });
-                            }
-                        }
-                     }
-                 }
-             }
-
-
-
-
-            }
-        }
+        p2p_event_loop::run(ctx, swarm, swarm_command_receiver).await;
     });
 
     //graceful shutdown via `Cancellation token`
@@ -1577,35 +420,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
         Ok(_) => {
             info!(component = "database", "Closing connection pool");
             let pool = db_connection_pool.lock().await;
-            //Closing all the existing connections to pool and committing from .db-wal to .db
             pool.close().await;
             info!(component = "database", "Connections closed");
-            info!(component = "swarm", "Shutting down network swarm");
+
+            info!(component = "swarm", "Shutting down");
             swarm_handle.abort();
             tokio::time::sleep(Duration::from_millis(1)).await;
-            #[allow(unused)]
-            let shutdown_sub_tasks = match main_shutdown_tx
+
+            if let Err(e) = main_shutdown_tx
                 .send(tokio::signal::unix::SignalKind::interrupt())
                 .await
             {
-                Ok(_) => {
-                    info!(
-                        component = "shutdown",
-                        "Sub-tasks interrupted - waiting for graceful shutdown"
-                    );
-                    main_task_token.cancel();
-                }
-                Err(error) => {
-                    error!(error = ?error, "Failed to send interrupt signal to sub-tasks");
-                }
-            };
+                error!(error = ?e, "Failed to send shutdown signal");
+            } else {
+                info!(component = "shutdown", "Graceful shutdown initiated");
+                main_task_token.cancel();
+            }
         }
-        Err(error) => {
-            error!(
-                error = ?error,
-                component = "shutdown",
-                "Shutdown signal error"
-            );
+        Err(e) => {
+            error!(error = ?e, "Shutdown signal error");
         }
     }
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -37,139 +37,8 @@ use std::os::unix::fs::PermissionsExt;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {
-    // Initialize tracing
     setup_tracing()?;
-    //Parsing args
     let args = cli::Cli::parse();
-    //IBD manager for ibd handling
-    let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
-    let _ibd_handler = tokio::spawn(async move {
-        ibd_manager.run_ibd_handler().await;
-    });
-
-    // IBD flag - true at start (will be in IBD by default)
-    let ibd_spinlock = Arc::new(AtomicBool::new(true));
-    //Local braid instance being shared across different tasks
-    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
-    //DB task handler for persistant of beads onto disk
-    let (mut _db_handler, db_tx) = DBHandler::new().await.map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Database initialization failed: {:?}", e),
-        )
-    })?;
-    let db_connection_pool = _db_handler.db_connection_pool.clone();
-
-    // Load beads from database
-    let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
-    let braid_ref = braid.clone();
-    //Fetching beads from disk before initializing other tasks to pre-shutdown state
-    let initial_bead_fetch_handle = tokio::spawn(async move {
-        let mut guard = braid_ref.write().await;
-        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 50).await?;
-        info!(beads = fetched_beads.len(), "Beads loaded from DB");
-        for bead in &fetched_beads {
-            let status = guard.extend(bead);
-            debug!(hash = ?bead.block_header.block_hash(), status = ?status, "Bead inserted");
-        }
-        Ok::<(), node::error::DBErrors>(())
-    });
-
-    match initial_bead_fetch_handle.await {
-        Ok(Ok(())) => info!("Initial bead fetch completed"),
-        Ok(Err(e)) => {
-            error!(error = ?e, "Failed to fetch beads from DB");
-            return Err(format!("Database bead fetch failed: {:?}", e).into());
-        }
-        Err(e) => {
-            error!(error = ?e, "Initial bead fetch task panicked");
-            return Err(format!("Initial bead fetch task panicked: {}", e).into());
-        }
-    }
-
-    // Start DB query handler
-    tokio::spawn(async move {
-        let _res = _db_handler.insert_query_handler().await;
-    });
-
-    let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
-    let latest_template_id_for_notifier = latest_template_id.clone();
-    let latest_template_id_for_consumer = latest_template_id.clone();
-    //Initial template being shared across the notification task and swarm_handler task
-    let latest_template = Arc::new(Mutex::new(BlockTemplate::default()));
-    let latest_template_merkle_branch = Arc::new(Mutex::new(Vec::new()));
-    let mut latest_template_ref = latest_template.clone();
-    let mut latest_template_merkle_branch_ref = latest_template_merkle_branch.clone();
-
-    let (notification_tx, notification_rx) = mpsc::channel::<NotifyCmd>(1024);
-    //Swarm handler for additional event other than p2p events related to swarm
-    let (swarm_handler, swarm_command_receiver) =
-        SwarmHandler::new(Arc::clone(&braid), db_tx.clone());
-    let swarm_command_sender = swarm_handler.command_sender.clone();
-    let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
-
-    let notification_tx_clone = notification_tx.clone();
-    //Global connection mapping for each downstream connected to stratum server along with their respective sender channels
-    let connection_mapping = Arc::new(tokio::sync::RwLock::new(ConnectionMapping::new()));
-    // Clone connection_mapping for RPC server before it's used in async move blocks
-    let connection_mapping_for_rpc = Arc::clone(&connection_mapping);
-    //Global mining mapping mapping peer to its jobs provided by upstream uptill now
-    let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
-    //Notifier task for providing jobs to downstream
-    let mut notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
-    let stratum_config = StratumServerConfig::default();
-    //Block submission channel after validation of PoW to bitcoin-node
-    let (block_submission_tx, block_submission_rx) =
-        tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
-
-    // IBD trigger task
-    let swarm_cmd_for_ibd = swarm_command_sender.clone();
-    let _ibd_trigger_handler = tokio::spawn(async move {
-        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-        if let Err(e) = swarm_cmd_for_ibd.send(SwarmCommand::InitiateIBD).await {
-            error!(error = ?e, "Failed to initiate IBD");
-        } else {
-            info!("IBD trigger sent");
-        }
-    });
-
-    // Start stratum server
-    let mut stratum_server = Server::new(
-        stratum_config,
-        connection_mapping.clone(),
-        Some(block_submission_tx),
-    );
-
-    // Run notifier
-    tokio::spawn(async move {
-        let _res = notifier
-            .run_notifier(
-                connection_mapping.clone(),
-                &mut latest_template_ref,
-                &mut latest_template_merkle_branch_ref,
-                latest_template_id_for_notifier,
-            )
-            .await;
-    });
-
-    // Run stratum service
-    let ibd_flag_for_stratum = ibd_spinlock.clone();
-    tokio::spawn(async move {
-        let _res = stratum_server
-            .run_stratum_service(
-                mining_job_map,
-                notification_tx_clone,
-                swarm_handler_arc.clone(),
-                ibd_flag_for_stratum,
-            )
-            .await;
-    });
-
-    let (main_shutdown_tx, _main_shutdown_rx) =
-        mpsc::channel::<tokio::signal::unix::SignalKind>(32);
-    let main_task_token = CancellationToken::new();
-    let ipc_task_token = main_task_token.clone();
-
 
     let datadir_str = args.datadir.to_str().ok_or_else(|| {
         std::io::Error::new(
@@ -242,9 +111,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             keypair
         }
     };
-    // Initializing the peer manager (shared between swarm and RPC server)
-    // Using RwLock to allow concurrent reads (RPC server) while swarm handler can write
-    let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
     //For local testing uncomment this keypair peer since it running to process will
     //result in same peerID leading to OutgoingConnectionError
     // let keypair = identity::Keypair::generate_ed25519();
@@ -266,16 +132,95 @@ async fn main() -> Result<(), Box<dyn Error>> {
     } else {
         Network::Bitcoin
     };
-    //IPC node initializer including our capnp client
-    let ipc_socket_path = args.ipc_socket.clone();
-    let notification_tx_for_ipc = notification_tx.clone();
-    let latest_template_for_ipc = latest_template.clone();
-    let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
 
-    // Create RPC proxy command channel - sender goes to RPC server, receiver goes to IPC handler
+    // IBD flag
+    let ibd_spinlock = Arc::new(AtomicBool::new(true));
+    //Local braid instance being shared across different tasks
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
+
+    //Latest template id shared across the notifier and IPC consumer tasks
+    let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
+    let latest_template_id_for_notifier = latest_template_id.clone();
+    let latest_template_id_for_consumer = latest_template_id.clone();
+    //Initial template being shared across the notification task and swarm_handler task
+    let latest_template = Arc::new(Mutex::new(BlockTemplate::default()));
+    let latest_template_merkle_branch = Arc::new(Mutex::new(Vec::new()));
+    let mut latest_template_ref = latest_template.clone();
+    let mut latest_template_merkle_branch_ref = latest_template_merkle_branch.clone();
+
+    //Global connection mapping for each downstream connected to stratum server along with their respective sender channels
+    let connection_mapping = Arc::new(tokio::sync::RwLock::new(ConnectionMapping::new()));
+    // Clone connection_mapping for RPC server before it's used in async move blocks
+    let connection_mapping_for_rpc = Arc::clone(&connection_mapping);
+    //Global mining mapping mapping peer to its jobs provided by upstream uptill now
+    let mining_job_map = Arc::new(Mutex::new(HashMap::new()));
+    // Peer manager shared between swarm and RPC server.
+    // RwLock allows concurrent reads (RPC server) while the swarm handler writes.
+    let peer_manager_arc = Arc::new(tokio::sync::RwLock::new(PeerManager::new(8)));
+
+    //IBD manager for ibd handling (sender goes to swarm context)
+    let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
+    //Notification channel feeding the notifier; cloned for stratum and IPC
+    let (notification_tx, notification_rx) = mpsc::channel::<NotifyCmd>(1024);
+    let notification_tx_clone = notification_tx.clone();
+    //Block submission channel after validation of PoW to bitcoin-node
+    let (block_submission_tx, block_submission_rx) =
+        tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
+    // RPC proxy command channel - sender goes to RPC server, receiver goes to IPC handler
     let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
-    // peer_manager_arc is created above and shared between swarm and RPC server
-    //spawning the rpc server
+    //Graceful shutdown wiring shared with the IPC handler
+    let (main_shutdown_tx, _main_shutdown_rx) =
+        mpsc::channel::<tokio::signal::unix::SignalKind>(32);
+    let main_task_token = CancellationToken::new();
+    let ipc_task_token = main_task_token.clone();
+
+    //DB task handler for persistant of beads onto disk
+    let (mut _db_handler, db_tx) = DBHandler::new().await.map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::Other,
+            format!("Database initialization failed: {:?}", e),
+        )
+    })?;
+    let db_connection_pool = _db_handler.db_connection_pool.clone();
+
+    // Load beads from database
+    let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
+    let braid_ref = braid.clone();
+    //Fetching beads from disk before initializing other tasks to pre-shutdown state
+    let initial_bead_fetch_handle = tokio::spawn(async move {
+        let mut guard = braid_ref.write().await;
+        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 50).await?;
+        info!(beads = fetched_beads.len(), "Beads loaded from DB");
+        for bead in &fetched_beads {
+            let status = guard.extend(bead);
+            debug!(hash = ?bead.block_header.block_hash(), status = ?status, "Bead inserted");
+        }
+        Ok::<(), node::error::DBErrors>(())
+    });
+
+    match initial_bead_fetch_handle.await {
+        Ok(Ok(())) => info!("Initial bead fetch completed"),
+        Ok(Err(e)) => {
+            error!(error = ?e, "Failed to fetch beads from DB");
+            return Err(format!("Database bead fetch failed: {:?}", e).into());
+        }
+        Err(e) => {
+            error!(error = ?e, "Initial bead fetch task panicked");
+            return Err(format!("Initial bead fetch task panicked: {}", e).into());
+        }
+    }
+
+    // Start DB query handler
+    tokio::spawn(async move {
+        let _res = _db_handler.insert_query_handler().await;
+    });
+
+    // IBD manager loop
+    let _ibd_handler = tokio::spawn(async move {
+        ibd_manager.run_ibd_handler().await;
+    });
+
+    //spawning the rpc server (await readiness to obtain the dashboard notifier)
     let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
     let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args).unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
@@ -290,8 +235,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
         rpc_proxy_tx,
         bitcoin_rpc_config,
     ));
-    match server_join.await {
-        Ok(Ok(_addr)) => {}
+    let (_rpc_addr, dashboard_notifier) = match server_join.await {
+        Ok(Ok(tuple)) => tuple,
         Ok(Err(())) => {
             return Err(std::io::Error::new(
                 std::io::ErrorKind::Other,
@@ -307,6 +252,61 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .into());
         }
     };
+    //Swarm handler for additional event other than p2p events related to swarm
+    let (swarm_handler, swarm_command_receiver) =
+        SwarmHandler::new(Arc::clone(&braid), db_tx.clone(), dashboard_notifier);
+    let swarm_command_sender = swarm_handler.command_sender.clone();
+    let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
+    // IBD trigger task
+    let swarm_cmd_for_ibd = swarm_command_sender.clone();
+    let _ibd_trigger_handler = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+        if let Err(e) = swarm_cmd_for_ibd.send(SwarmCommand::InitiateIBD).await {
+            error!(error = ?e, "Failed to initiate IBD");
+        } else {
+            info!("IBD trigger sent");
+        }
+    });
+
+    // Start stratum server (created before the notifier consumes `connection_mapping`)
+    let stratum_config = StratumServerConfig::default();
+    let mut stratum_server = Server::new(
+        stratum_config,
+        connection_mapping.clone(),
+        Some(block_submission_tx),
+    );
+
+    // Run notifier
+    let mut notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
+    tokio::spawn(async move {
+        let _res = notifier
+            .run_notifier(
+                connection_mapping.clone(),
+                &mut latest_template_ref,
+                &mut latest_template_merkle_branch_ref,
+                latest_template_id_for_notifier,
+            )
+            .await;
+    });
+
+    // Run stratum service
+    let ibd_flag_for_stratum = ibd_spinlock.clone();
+    tokio::spawn(async move {
+        let _res = stratum_server
+            .run_stratum_service(
+                mining_job_map,
+                notification_tx_clone,
+                swarm_handler_arc.clone(),
+                ibd_flag_for_stratum,
+            )
+            .await;
+    });
+
+    //IPC node initializer including our capnp client
+    let ipc_socket_path = args.ipc_socket.clone();
+    let notification_tx_for_ipc = notification_tx.clone();
+    let latest_template_for_ipc = latest_template.clone();
+    let latest_template_merkle_branch_for_ipc = latest_template_merkle_branch.clone();
 
     info!(socket = %ipc_socket_path, "IPC socket path");
 

--- a/node/src/swarm/bootstrap.rs
+++ b/node/src/swarm/bootstrap.rs
@@ -1,0 +1,64 @@
+//! Boot node connection and network bootstrapping.
+
+use libp2p::{core::multiaddr::Multiaddr, floodsub::Topic, kad::Mode, Swarm};
+use tracing::{error, info};
+
+use crate::behaviour::BraidPoolBehaviour;
+
+use super::config::{parse_boot_addr, parse_boot_nodes};
+
+/// Sets up the swarm with boot nodes and starts listening.
+pub fn setup_and_bootstrap(
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    listen_addr: Multiaddr,
+    topic: Topic,
+) -> Result<(), Box<dyn std::error::Error>> {
+    // Subscribe to the braidpool topic
+    swarm.behaviour_mut().bead_announce.subscribe(topic);
+
+    // Set Kademlia to server mode for DHT participation
+    swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
+
+    // Start listening
+    swarm.listen_on(listen_addr.clone())?;
+
+    // Add boot nodes to DHT
+    let boot_nodes = parse_boot_nodes();
+    for (peer_id, addr) in &boot_nodes {
+        swarm
+            .behaviour_mut()
+            .kademlia
+            .add_address(peer_id, addr.clone());
+    }
+    info!(boot_node_count = %boot_nodes.len(), "Boot nodes added to DHT");
+
+    // Dial primary boot node
+    let boot_addr =
+        parse_boot_addr().map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidInput, e))?;
+    swarm.dial(boot_addr.clone())?;
+    info!(address = %boot_addr, "Dialed boot node");
+
+    Ok(())
+}
+
+/// Dials additional nodes specified via CLI.
+pub fn dial_additional_nodes(swarm: &mut Swarm<BraidPoolBehaviour>, nodes: &[String]) {
+    for node in nodes {
+        let node_multiaddr: Multiaddr = match node.parse() {
+            Ok(addr) => addr,
+            Err(e) => {
+                error!(node = %node, error = %e, "Failed to parse multiaddr, skipping");
+                continue;
+            }
+        };
+
+        match swarm.dial(node_multiaddr.clone()) {
+            Ok(_) => {
+                info!(address = %node_multiaddr, "Dialed peer node");
+            }
+            Err(e) => {
+                error!(address = %node_multiaddr, error = %e, "Failed to dial peer node");
+            }
+        }
+    }
+}

--- a/node/src/swarm/builder.rs
+++ b/node/src/swarm/builder.rs
@@ -1,0 +1,83 @@
+use std::{error::Error, net::SocketAddr};
+
+use libp2p::{core::multiaddr::Multiaddr, identity::Keypair, Swarm};
+
+use crate::behaviour::BraidPoolBehaviour;
+
+use super::config::IDLE_CONNECTION_TIMEOUT;
+
+/// Configuration for building a swarm.
+pub struct SwarmConfig {
+    /// The node's cryptographic identity.
+    pub keypair: Keypair,
+    /// Socket address to bind to.
+    pub bind_addr: SocketAddr,
+}
+
+impl SwarmConfig {
+    /// Creates a new SwarmConfig.
+    pub fn new(keypair: Keypair, bind_addr: SocketAddr) -> Self {
+        Self { keypair, bind_addr }
+    }
+
+    /// Converts the bind address to a libp2p Multiaddr (QUIC).
+    pub fn to_multiaddr(&self) -> Result<Multiaddr, Box<dyn Error>> {
+        let multi_addr: Multiaddr = format!(
+            "/ip4/{}/udp/{}/quic-v1",
+            self.bind_addr.ip(),
+            self.bind_addr.port()
+        )
+        .parse()
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Failed to create multiaddress: {}", e),
+            )
+        })?;
+
+        Ok(multi_addr)
+    }
+}
+
+/// Builds a configured libp2p swarm.
+pub async fn build_swarm(config: SwarmConfig) -> Result<Swarm<BraidPoolBehaviour>, Box<dyn Error>> {
+    let swarm_builder = libp2p::SwarmBuilder::with_existing_identity(config.keypair)
+        .with_tokio()
+        .with_quic()
+        .with_dns()
+        .map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("DNS setup failed: {:?}", e),
+            )
+        })?;
+
+    let swarm = swarm_builder
+        .with_behaviour(|local_key| {
+            BraidPoolBehaviour::new(local_key).expect(
+                "Failed to create BraidPoolBehaviour - check keypair and network configuration",
+            )
+        })?
+        .with_swarm_config(|cfg| cfg.with_idle_connection_timeout(IDLE_CONNECTION_TIMEOUT))
+        .build();
+
+    Ok(swarm)
+}
+
+/// Parses a bind address string into a SocketAddr.
+///
+/// Handles both full addresses (ip:port) and IP-only strings (adds default port).
+pub fn parse_bind_address(bind: &str, default_port: u16) -> Result<SocketAddr, Box<dyn Error>> {
+    match bind.parse() {
+        Ok(addr) => Ok(addr),
+        Err(_) => {
+            let with_port = format!("{}:{}", bind, default_port);
+            with_port.parse().map_err(|e| {
+                Box::new(std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Failed to parse bind address: {}", e),
+                )) as Box<dyn Error>
+            })
+        }
+    }
+}

--- a/node/src/swarm/config.rs
+++ b/node/src/swarm/config.rs
@@ -1,0 +1,71 @@
+//! Swarm configuration constants.
+//!
+//! Centralizes all network configuration including boot nodes,
+//! protocol parameters, and timing constants.
+
+use libp2p::{core::multiaddr::Multiaddr, PeerId};
+use std::time::Duration;
+
+/// Boot node peer IDs for initial peer discovery.
+pub const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
+
+/// DNS seed for boot node resolution.
+pub const SEED_DNS: &str = "/dnsaddr/french.braidpool.net";
+
+/// Combined address for DNS resolution and dialing boot nodes.
+pub const BOOT_ADDR: &str =
+    "/dnsaddr/french.braidpool.net/p2p/12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3";
+
+/// Latency smoothing factor for peer scoring (in seconds).
+pub const LATENCY_ALPHA: u64 = 10;
+
+/// Connection idle timeout (effectively infinite).
+pub const IDLE_CONNECTION_TIMEOUT: Duration = Duration::from_secs(u64::MAX);
+
+/// Default P2P port.
+pub const DEFAULT_P2P_PORT: u16 = 6680;
+
+/// Parses boot node configurations into peer IDs and addresses.
+///
+/// Returns a vector of (PeerId, Multiaddr) tuples for all valid boot nodes.
+/// Invalid entries are logged and skipped.
+pub fn parse_boot_nodes() -> Vec<(PeerId, Multiaddr)> {
+    let mut result = Vec::new();
+
+    for boot_peer in BOOTNODES {
+        let peer_id = match boot_peer.parse::<PeerId>() {
+            Ok(id) => id,
+            Err(e) => {
+                tracing::error!(
+                    boot_peer = %boot_peer,
+                    error = %e,
+                    "Failed to parse boot peer ID, skipping"
+                );
+                continue;
+            }
+        };
+
+        let seed_addr = match SEED_DNS.parse::<Multiaddr>() {
+            Ok(addr) => addr,
+            Err(e) => {
+                tracing::error!(
+                    seed_dns = %SEED_DNS,
+                    error = %e,
+                    "Failed to parse seed DNS, skipping"
+                );
+                continue;
+            }
+        };
+
+        result.push((peer_id, seed_addr));
+    }
+
+    result
+}
+
+/// Parses the boot address for initial dialing.
+pub fn parse_boot_addr() -> Result<Multiaddr, String> {
+    BOOT_ADDR
+        .parse()
+        .map_err(|e| format!("Failed to parse boot address: {}", e))
+}

--- a/node/src/swarm/handlers/bead_processing.rs
+++ b/node/src/swarm/handlers/bead_processing.rs
@@ -1,0 +1,141 @@
+use libp2p::PeerId;
+use tokio::sync::RwLockWriteGuard;
+use tracing::{debug, error};
+
+use crate::{
+    bead::Bead,
+    braid::{AddBeadStatus, Braid},
+    db::{db_handlers::prepare_bead_tuple_data, BraidpoolDBTypes, InsertTupleTypes},
+    swarm::SwarmContext,
+};
+
+/// Result of processing an incoming bead.
+#[derive(Debug)]
+pub struct BeadProcessingResult {
+    /// The status returned by braid.extend()
+    pub status: AddBeadStatus,
+    /// Whether the bead was successfully persisted to DB
+    pub persisted: bool,
+}
+
+/// Processes an incoming bead by extending the braid and persisting to DB.
+///
+/// This is the central bead processing function that handles:
+/// - Extending the braid with the new bead
+/// - Preparing tuple data for DB insertion
+/// - Sending the bead to the database
+/// - Updating peer scores
+///
+/// # Arguments
+/// * `ctx` - The swarm context containing shared state
+/// * `braid_guard` - Write lock on the braid (caller must acquire)
+/// * `bead` - The bead to process
+/// * `source` - The peer that sent the bead
+///
+/// # Returns
+/// The processing result including status and persistence state
+pub async fn process_incoming_bead(
+    ctx: &SwarmContext,
+    braid_guard: &mut RwLockWriteGuard<'_, Braid>,
+    bead: &Bead,
+    source: PeerId,
+) -> BeadProcessingResult {
+    let status = braid_guard.extend(bead);
+
+    match &status {
+        AddBeadStatus::BeadAdded => {
+            let bead_hash = bead.block_header.block_hash();
+
+            // Get the bead ID from the mapping
+            let bead_id = match braid_guard.bead_index_mapping.get(&bead_hash) {
+                Some(id) => *id,
+                None => {
+                    error!(
+                        bead_hash = ?bead_hash,
+                        "Bead ID not found in index mapping after insertion"
+                    );
+                    return BeadProcessingResult {
+                        status,
+                        persisted: false,
+                    };
+                }
+            };
+
+            // Prepare tuple data for database
+            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                &braid_guard.beads,
+                &braid_guard.bead_index_mapping,
+                bead,
+            ) {
+                Ok(tuples) => tuples,
+                Err(e) => {
+                    error!(
+                        bead_hash = ?bead_hash,
+                        error = ?e,
+                        "Failed to prepare bead tuple data"
+                    );
+                    return BeadProcessingResult {
+                        status,
+                        persisted: false,
+                    };
+                }
+            };
+
+            // Send to db handler
+            let persisted = match ctx
+                .db_tx
+                .send(BraidpoolDBTypes::InsertTupleTypes {
+                    query: InsertTupleTypes::InsertBeadSequentially {
+                        bead_to_insert: bead.clone(),
+                        txs_json,
+                        relative_json,
+                        parent_timestamp_json,
+                        bead_id,
+                    },
+                })
+                .await
+            {
+                Ok(_) => {
+                    debug!(
+                        bead_hash = ?bead_hash,
+                        source = ?source,
+                        "Bead persisted to database"
+                    );
+                    true
+                }
+                Err(e) => {
+                    error!(
+                        bead_hash = ?bead_hash,
+                        source = ?source,
+                        error = ?e.0,
+                        "Failed to send bead to database"
+                    );
+                    false
+                }
+            };
+
+            BeadProcessingResult { status, persisted }
+        }
+        AddBeadStatus::InvalidBead => {
+            // Peer sent invalid bead penalize peer
+            BeadProcessingResult {
+                status,
+                persisted: false,
+            }
+        }
+        AddBeadStatus::ParentsNotYetReceived => {
+            // Request parents
+            BeadProcessingResult {
+                status,
+                persisted: false,
+            }
+        }
+        AddBeadStatus::DagAlreadyContainsBead => {
+            // Duplicate bead
+            BeadProcessingResult {
+                status,
+                persisted: false,
+            }
+        }
+    }
+}

--- a/node/src/swarm/handlers/bead_sync.rs
+++ b/node/src/swarm/handlers/bead_sync.rs
@@ -1,0 +1,501 @@
+//! BeadSync request/response protocol handlers.
+
+use std::{
+    collections::HashSet,
+    time::{Duration, SystemTime, UNIX_EPOCH},
+};
+
+use libp2p::{request_response::ResponseChannel, PeerId, Swarm};
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    bead::{BeadHashes, BeadRequest, BeadResponse, BeadSyncError, Beads},
+    behaviour::BraidPoolBehaviour,
+    braid::{AddBeadStatus, GenesisCheckStatus},
+    db::{db_handlers::prepare_bead_tuple_data, BraidpoolDBTypes, InsertTupleTypes},
+    ibd_manager::{IBDCommands, IBD_BATCH_SIZE, MAX_IBD_INCOMING_THRESHOLD},
+    swarm::SwarmContext,
+    utils::BeadHash,
+    SwarmCommand,
+};
+
+/// Handles a GetBeads request - returns beads for the requested hashes.
+pub async fn handle_get_beads(
+    ctx: &SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    hashes: BeadHashes,
+    channel: ResponseChannel<BeadResponse>,
+) {
+    let mut beads = Vec::new();
+    {
+        let braid_lock = ctx.braid.read().await;
+        for hash in hashes.iter() {
+            if let Some(index) = braid_lock.bead_index_mapping.get(hash) {
+                if let Some(bead) = braid_lock.beads.get(*index) {
+                    beads.push(bead.clone());
+                }
+            }
+        }
+    }
+    swarm.behaviour_mut().respond_with_beads(channel, beads);
+}
+
+/// Handles a GetTips request - returns current DAG tips.
+pub async fn handle_get_tips(
+    ctx: &SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    channel: ResponseChannel<BeadResponse>,
+) {
+    let tips;
+    {
+        let braid_lock = ctx.braid.read().await;
+        tips = braid_lock
+            .tips
+            .iter()
+            .filter_map(|index| braid_lock.beads.get(*index))
+            .map(|bead| bead.block_header.block_hash())
+            .collect();
+    }
+    swarm.behaviour_mut().respond_with_tips(channel, tips);
+}
+
+/// Handles a GetGenesis request - returns genesis beads.
+pub async fn handle_get_genesis(
+    ctx: &SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    channel: ResponseChannel<BeadResponse>,
+) {
+    let genesis;
+    {
+        let braid_lock = ctx.braid.read().await;
+        genesis = braid_lock
+            .genesis_beads
+            .iter()
+            .filter_map(|index| braid_lock.beads.get(*index))
+            .map(|bead| bead.block_header.block_hash())
+            .collect();
+    }
+    swarm.behaviour_mut().respond_with_genesis(channel, genesis);
+}
+
+/// Handles a GetAllBeads request - returns all beads in the DAG.
+pub async fn handle_get_all_beads(
+    ctx: &SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    channel: ResponseChannel<BeadResponse>,
+) {
+    let all_beads;
+    {
+        let braid_lock = ctx.braid.read().await;
+        all_beads = braid_lock.beads.iter().cloned().collect();
+    }
+    swarm.behaviour_mut().respond_with_beads(channel, all_beads);
+}
+
+/// Handles a GetBeadsAfter request - returns bead hashes after the given tips.
+pub async fn handle_get_beads_after(
+    ctx: &SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    hashes: BeadHashes,
+    channel: ResponseChannel<BeadResponse>,
+) {
+    let beads = ctx.braid.read().await.get_beads_after(hashes.into());
+
+    if let Some(response_beads) = beads {
+        let bead_hashes: Vec<BeadHash> = response_beads
+            .into_iter()
+            .map(|bead| bead.block_header.block_hash())
+            .collect();
+        swarm
+            .behaviour_mut()
+            .respond_with_beadhashes(channel, bead_hashes);
+    } else {
+        swarm
+            .behaviour_mut()
+            .respond_with_error(channel, BeadSyncError::BeadHashNotFound);
+    }
+}
+
+/// Handles a Beads response during IBD.
+pub async fn handle_beads_response(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer: PeerId,
+    beads: Beads,
+) {
+    // Fetch cached bead hashes from IBD manager
+    let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
+
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::FetchGetBeadMapping {
+            peer_id: peer.to_string(),
+            beadhash_sender: beads_tx,
+        })
+        .await
+    {
+        error!(error = ?e.0, "Failed to fetch bead mapping from IBD handler");
+        reinitiate_ibd(ctx).await;
+        return;
+    }
+
+    let pruned_beads = match beads_rx.await {
+        Ok(beads) => beads,
+        Err(e) => {
+            error!(error = ?e, "Failed to receive cached beads");
+            reinitiate_ibd(ctx).await;
+            return;
+        }
+    };
+
+    // Process each bead
+    for bead in beads.into_iter() {
+        let mut braid_data = ctx.braid.write().await;
+        let status = braid_data.extend(&bead);
+        let bead_hash = bead.block_header.block_hash();
+
+        match status {
+            AddBeadStatus::InvalidBead => {
+                ctx.peer_manager
+                    .write()
+                    .await
+                    .penalize_for_invalid_bead(&peer);
+            }
+            AddBeadStatus::BeadAdded => {
+                let bead_id = match braid_data.bead_index_mapping.get(&bead_hash) {
+                    Some(id) => *id,
+                    None => {
+                        error!(bead_hash = ?bead_hash, "Bead ID not found");
+                        continue;
+                    }
+                };
+
+                let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                    &braid_data.beads,
+                    &braid_data.bead_index_mapping,
+                    &bead,
+                ) {
+                    Ok(tuples) => tuples,
+                    Err(e) => {
+                        error!(error = ?e, "Failed to prepare tuple data");
+                        continue;
+                    }
+                };
+
+                ctx.peer_manager.write().await.update_score(&peer, 1.0);
+
+                if let Err(e) = ctx
+                    .db_tx
+                    .send(BraidpoolDBTypes::InsertTupleTypes {
+                        query: InsertTupleTypes::InsertBeadSequentially {
+                            bead_to_insert: bead,
+                            txs_json,
+                            relative_json,
+                            parent_timestamp_json,
+                            bead_id,
+                        },
+                    })
+                    .await
+                {
+                    error!(error = ?e.0, "Failed to send bead to database");
+                } else {
+                    debug!(bead_hash = ?bead_hash, "Bead persisted");
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Request next batch
+    request_next_batch(ctx, swarm, peer, &pruned_beads).await;
+}
+
+/// Handles a GetBeadsAfter response - receives bead hashes to fetch.
+pub async fn handle_get_beads_after_response(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer: PeerId,
+    bead_hashes: BeadHashes,
+) {
+    // Fetch cached tips from IBD manager
+    let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
+
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::FetchTips {
+            peer_id: peer.to_string(),
+            tips_sender: tips_tx,
+        })
+        .await
+    {
+        error!(error = ?e, "Failed to fetch tips");
+        reinitiate_ibd(ctx).await;
+        return;
+    }
+
+    let received_tips = match tips_rx.await {
+        Ok(tips) => tips,
+        Err(e) => {
+            error!(error = ?e, "Failed to receive tips");
+            reinitiate_ibd(ctx).await;
+            return;
+        }
+    };
+
+    // Prune hashes up to our tips
+    let tips_set: HashSet<_> = received_tips.into_iter().collect();
+    let mut found_tips = HashSet::new();
+    let mut pruned = Vec::new();
+
+    for hash in bead_hashes.0 {
+        if tips_set.contains(&hash) {
+            found_tips.insert(hash.clone());
+        }
+        pruned.push(hash);
+        if found_tips.len() == tips_set.len() {
+            break;
+        }
+    }
+
+    // Cache pruned hashes
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::UpdateIncoming {
+            get_bead_response: pruned.clone(),
+            peer_id: peer.to_string(),
+        })
+        .await
+    {
+        error!(error = ?e, "Failed to cache pruned hashes");
+        reinitiate_ibd(ctx).await;
+        return;
+    }
+
+    // Request first batch of beads
+    let batch_end = std::cmp::min(IBD_BATCH_SIZE, pruned.len());
+    swarm
+        .behaviour_mut()
+        .request_beads(peer, &pruned[..batch_end].to_vec());
+}
+
+/// Handles a Tips response during IBD.
+pub async fn handle_tips_response(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer: PeerId,
+    tips: BeadHashes,
+) {
+    info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
+
+    // Initialize batch offset
+    let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::UpdateAndFetchBatchOffset {
+            peer_id: peer.to_string(),
+            offset_sender: batch_tx,
+            batch_size: IBD_BATCH_SIZE,
+        })
+        .await
+    {
+        error!(error = ?e, "Failed to initialize batch offset");
+        return;
+    }
+
+    if let Err(e) = batch_rx.await {
+        error!(error = ?e, "Failed to receive batch offset");
+        return;
+    }
+
+    // Check if we already have these tips
+    let braid_data = ctx.braid.read().await;
+    let bead_hash_set: HashSet<BeadHash> = braid_data
+        .beads
+        .iter()
+        .map(|b| b.block_header.block_hash())
+        .collect();
+
+    let already_synced = tips.iter().all(|tip| bead_hash_set.contains(tip));
+
+    if already_synced {
+        info!("Peer already synced to tip");
+        ctx.set_ibd(false);
+        return;
+    }
+
+    // Cache the received tips
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::UpdateIBDTipsMapping {
+            received_tips: tips.0,
+            peer_id: peer.to_string(),
+        })
+        .await
+    {
+        error!(error = ?e, "Failed to cache tips");
+        return;
+    }
+
+    // Get our current tips and request beads after them
+    let current_tip_hashes: Vec<_> = braid_data
+        .tips
+        .iter()
+        .filter_map(|idx| braid_data.beads.get(*idx))
+        .map(|bead| bead.block_header.block_hash())
+        .collect();
+
+    drop(braid_data);
+
+    let request = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
+    swarm.behaviour_mut().bead_sync.send_request(&peer, request);
+}
+
+/// Handles a Genesis response.
+pub async fn handle_genesis_response(
+    ctx: &SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer: PeerId,
+    genesis: BeadHashes,
+) {
+    info!(genesis = ?genesis, "Received genesis beads");
+
+    let status = {
+        let braid_lock = ctx.braid.read().await;
+        braid_lock.check_genesis_beads(&genesis.0)
+    };
+
+    match status {
+        GenesisCheckStatus::GenesisBeadsValid => {
+            info!("Genesis beads are valid");
+        }
+        GenesisCheckStatus::MissingGenesisBead => {
+            warn!(peer = %peer, "Missing genesis bead");
+            swarm.behaviour_mut().request_beads(peer, &genesis.0);
+        }
+        GenesisCheckStatus::GenesisBeadsCountMismatch => {
+            warn!(
+                received = %genesis.0.len(),
+                peer = %peer,
+                "Genesis bead count mismatch"
+            );
+        }
+    }
+}
+
+/// Handles a sync error response.
+pub fn handle_error_response(
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer: PeerId,
+    error: BeadSyncError,
+) {
+    match error {
+        BeadSyncError::GenesisMismatch => {
+            warn!("Genesis mismatch - requesting genesis");
+            swarm.behaviour_mut().request_genesis(peer);
+        }
+        BeadSyncError::BeadHashNotFound => {
+            warn!("Requested bead hashes not found");
+        }
+    }
+}
+
+/// Requests the next batch of beads during IBD.
+async fn request_next_batch(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer: PeerId,
+    pruned_beads: &[BeadHash],
+) {
+    // Get next batch offset
+    let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
+
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::UpdateAndFetchBatchOffset {
+            peer_id: peer.to_string(),
+            offset_sender: batch_tx,
+            batch_size: IBD_BATCH_SIZE,
+        })
+        .await
+    {
+        error!(error = ?e, "Failed to update batch offset");
+        reinitiate_ibd(ctx).await;
+        return;
+    }
+
+    let offset = match batch_rx.await {
+        Ok(o) => o,
+        Err(e) => {
+            error!(error = ?e, "Failed to receive batch offset");
+            reinitiate_ibd(ctx).await;
+            return;
+        }
+    };
+
+    if offset < pruned_beads.len() {
+        let end = std::cmp::min(offset + IBD_BATCH_SIZE, pruned_beads.len());
+        info!("Requesting beads batch {}..{}", offset, end);
+        swarm
+            .behaviour_mut()
+            .request_beads(peer, &pruned_beads[offset..end].to_vec());
+    } else {
+        // IBD complete for this peer
+        info!(peer = %peer, "IBD completed with peer");
+        complete_ibd(ctx, peer).await;
+    }
+}
+
+/// Marks IBD as complete and sets up incoming bead watcher.
+async fn complete_ibd(ctx: &SwarmContext, peer: PeerId) {
+    let current_time = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or_else(|e| {
+            error!(error = %e, "System time error");
+            0
+        });
+
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::UpdateTimestampMapping {
+            peer_id: peer.to_string(),
+            end_timestamp: current_time,
+        })
+        .await
+    {
+        error!(error = ?e, "Failed to update timestamp mapping");
+        return;
+    }
+
+    // Spawn watcher task for incoming beads
+    let ibd_spinlock = ctx.ibd_spinlock.clone();
+    let ibd_tx = ctx.ibd_tx.clone();
+
+    let incoming_handler = tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
+        if ibd_spinlock.load(std::sync::atomic::Ordering::SeqCst) {
+            ibd_spinlock.store(false, std::sync::atomic::Ordering::SeqCst);
+            warn!("IBD incoming threshold exceeded, setting IBD complete");
+        }
+    });
+
+    if let Err(e) = ibd_tx
+        .send(IBDCommands::UpdateIncomingBeadMapping {
+            peer_id: peer,
+            retry_or_not: false,
+            handle: Some(incoming_handler),
+        })
+        .await
+    {
+        error!(error = ?e, "Failed to register incoming handler");
+    }
+}
+
+/// Reinitiates IBD process.
+async fn reinitiate_ibd(ctx: &SwarmContext) {
+    if let Err(e) = ctx.swarm_cmd_tx.send(SwarmCommand::InitiateIBD).await {
+        error!(error = ?e, "Failed to reinitiate IBD");
+    } else {
+        warn!("Reinitiating IBD");
+    }
+}

--- a/node/src/swarm/handlers/connection.rs
+++ b/node/src/swarm/handlers/connection.rs
@@ -1,0 +1,96 @@
+//! Connection establishment and closure handlers.
+
+use std::net::IpAddr;
+use std::sync::Arc;
+
+use libp2p::{
+    core::{ConnectedPoint, Multiaddr},
+    swarm::ConnectionId,
+    PeerId, Swarm,
+};
+use tokio::sync::RwLock;
+use tracing::info;
+
+use crate::{behaviour::BraidPoolBehaviour, peer_manager::PeerManager};
+
+/// Handles a new connection being established.
+pub async fn handle_connection_established(
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer_manager: &Arc<RwLock<PeerManager>>,
+    peer_id: PeerId,
+    endpoint: &ConnectedPoint,
+) {
+    let remote_addr = endpoint.get_remote_address();
+
+    // Add to Kademlia DHT
+    swarm
+        .behaviour_mut()
+        .kademlia
+        .add_address(&peer_id, remote_addr.clone());
+    info!(address = ?remote_addr, "DHT updated with peer address");
+
+    // Add to FloodSub mesh
+    swarm
+        .behaviour_mut()
+        .bead_announce
+        .add_node_to_partial_view(peer_id);
+    info!(peer = %peer_id, "Peer added to floodsub mesh");
+
+    // Extract IP address from multiaddr
+    let ip = extract_ip_from_multiaddr(remote_addr);
+
+    // Register in peer manager
+    {
+        let mut peer_manager = peer_manager.write().await;
+        peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
+    }
+
+    info!(
+        peer_id = ?peer_id,
+        remote_addr = ?remote_addr,
+        "Connection established to peer"
+    );
+}
+
+/// Handles a connection being closed.
+pub async fn handle_connection_closed(
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer_manager: &Arc<RwLock<PeerManager>>,
+    peer_id: PeerId,
+    connection_id: ConnectionId,
+    endpoint: &ConnectedPoint,
+    num_established: u32,
+    cause: Option<&libp2p::swarm::ConnectionError>,
+) {
+    let remote_addr = endpoint.get_remote_address();
+
+    info!(
+        peer = %peer_id,
+        connection_id = %connection_id,
+        address = %remote_addr,
+        established = %num_established,
+        cause = ?cause,
+        "Connection closed"
+    );
+
+    // Remove from peer manager
+    {
+        let mut peer_manager = peer_manager.write().await;
+        peer_manager.remove_peer(&peer_id);
+    }
+
+    // Remove from Kademlia DHT
+    swarm
+        .behaviour_mut()
+        .kademlia
+        .remove_address(&peer_id, remote_addr);
+}
+
+/// Extracts IP address from a multiaddr.
+fn extract_ip_from_multiaddr(addr: &Multiaddr) -> Option<IpAddr> {
+    addr.iter().find_map(|p| match p {
+        libp2p::core::multiaddr::Protocol::Ip4(ip) => Some(IpAddr::V4(ip)),
+        libp2p::core::multiaddr::Protocol::Ip6(ip) => Some(IpAddr::V6(ip)),
+        _ => None,
+    })
+}

--- a/node/src/swarm/handlers/floodsub.rs
+++ b/node/src/swarm/handlers/floodsub.rs
@@ -1,0 +1,225 @@
+//! FloodSub (bead announcement) event handlers.
+
+use bitcoin::consensus::encode::deserialize;
+use libp2p::{floodsub::FloodsubMessage, PeerId, Swarm};
+use tracing::{error, info, warn};
+
+use crate::{
+    bead::{Bead, BeadHashes, BeadRequest},
+    behaviour::BraidPoolBehaviour,
+    braid::AddBeadStatus,
+    ibd_manager::IBDCommands,
+    swarm::{
+        config::LATENCY_ALPHA, handlers::bead_processing::process_incoming_bead, SwarmContext,
+    },
+    SwarmCommand,
+};
+
+/// Handles a subscription event.
+pub fn handle_subscribed(peer_id: PeerId, topic: libp2p::floodsub::Topic) {
+    info!(
+        peer = ?peer_id,
+        topic = ?topic,
+        "Peer subscribed to topic"
+    );
+}
+
+/// Handles an unsubscription event.
+pub fn handle_unsubscribed(peer_id: PeerId, topic: libp2p::floodsub::Topic) {
+    info!(
+        peer = ?peer_id,
+        topic = ?topic,
+        "Peer unsubscribed from topic"
+    );
+}
+
+/// Handles a FloodSub message (bead announcement).
+///
+/// This is the main handler for incoming beads via p2p nodes.
+/// Behavior differs based on whether node is in IBD mode.
+pub async fn handle_message(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    message: FloodsubMessage,
+) {
+    info!(
+        topics = ?message.topics,
+        source = ?message.source,
+        size_bytes = %message.data.len(),
+        "Floodsub message received"
+    );
+
+    // Deserialize the bead
+    let bead: Bead = match deserialize::<Bead>(&message.data) {
+        Ok(b) => {
+            info!(
+                hash = %b.block_header.block_hash(),
+                "Received bead"
+            );
+            b
+        }
+        Err(e) => {
+            error!(error = %e, "Failed to deserialize bead");
+            return;
+        }
+    };
+
+    if ctx.is_in_ibd() {
+        handle_message_during_ibd(ctx, swarm, &bead, message.source).await;
+    } else {
+        handle_message_normal(ctx, swarm, &bead, message.source).await;
+    }
+}
+
+/// Handles bead message during normal operation (not IBD).
+async fn handle_message_normal(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    bead: &Bead,
+    source: PeerId,
+) {
+    let mut braid_guard = ctx.braid.write().await;
+    let result = process_incoming_bead(ctx, &mut braid_guard, bead, source).await;
+
+    match result.status {
+        AddBeadStatus::ParentsNotYetReceived => {
+            request_parents(ctx, swarm, bead).await;
+        }
+        AddBeadStatus::InvalidBead => {
+            ctx.peer_manager
+                .write()
+                .await
+                .penalize_for_invalid_bead(&source);
+        }
+        AddBeadStatus::BeadAdded => {
+            ctx.peer_manager.write().await.update_score(&source, 1.0);
+        }
+        _ => {}
+    }
+}
+
+/// Handles bead message during Initial Block Download.
+async fn handle_message_during_ibd(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    bead: &Bead,
+    source: PeerId,
+) {
+    // Process bead
+    let (status, bead_persisted) = {
+        let mut braid_guard = ctx.braid.write().await;
+        let result = process_incoming_bead(ctx, &mut braid_guard, bead, source).await;
+        (result.status, result.persisted)
+    };
+    // Guard is dropped here
+    let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.to_u32();
+
+    match &status {
+        AddBeadStatus::ParentsNotYetReceived => {
+            request_parents(ctx, swarm, bead).await;
+        }
+        AddBeadStatus::InvalidBead => {
+            ctx.peer_manager
+                .write()
+                .await
+                .penalize_for_invalid_bead(&source);
+        }
+        AddBeadStatus::BeadAdded => {
+            if bead_persisted {
+                ctx.peer_manager.write().await.update_score(&source, 1.0);
+            }
+        }
+        _ => {}
+    }
+
+    // Fetch timestamp map from IBD manager
+    let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::FetchAllTimestamps { sender: ts_tx })
+        .await
+    {
+        warn!("Failed to request timestamp map: {:?}", e);
+        return;
+    }
+
+    let timestamp_map = match ts_rx.await {
+        Ok(map) => map,
+        Err(_) => {
+            error!("Failed to receive timestamp map");
+            return;
+        }
+    };
+
+    // Check timestamp thresholds for each sync peer
+    for (sync_peer_str, ibd_ts) in timestamp_map.iter() {
+        let threshold = *ibd_ts + LATENCY_ALPHA * 10;
+
+        let sync_peer_id = match sync_peer_str.parse::<PeerId>() {
+            Ok(id) => id,
+            Err(e) => {
+                error!(sync_peer = %sync_peer_str, error = %e, "Failed to parse sync peer ID");
+                continue;
+            }
+        };
+
+        if broadcast_ts < threshold as u32 {
+            info!(
+                broadcast_ts = ?broadcast_ts,
+                threshold = ?threshold,
+                "Incoming bead during IBD within threshold"
+            );
+
+            match status {
+                AddBeadStatus::InvalidBead | AddBeadStatus::ParentsNotYetReceived => {
+                    // Abort IBD handler for this sync peer and reinitiate
+                    abort_and_reinitiate_ibd(ctx, sync_peer_id).await;
+                }
+                AddBeadStatus::BeadAdded | AddBeadStatus::DagAlreadyContainsBead => {
+                    // IBD can complete
+                    ctx.set_ibd(false);
+                }
+            }
+        } else {
+            // Timestamp exceeded threshold, IBD complete
+            ctx.set_ibd(false);
+        }
+    }
+}
+
+/// Requests missing parent beads from peers.
+async fn request_parents(ctx: &SwarmContext, swarm: &mut Swarm<BraidPoolBehaviour>, bead: &Bead) {
+    if let Some(peer) = ctx.get_sync_peer().await {
+        let parent_hashes: Vec<_> = bead.committed_metadata.parents.iter().cloned().collect();
+        swarm
+            .behaviour_mut()
+            .bead_sync
+            .send_request(&peer, BeadRequest::GetBeads(BeadHashes(parent_hashes)));
+    } else {
+        warn!(
+            parent_count = %bead.committed_metadata.parents.len(),
+            "Insufficient peers for bead sync"
+        );
+    }
+}
+
+/// Aborts IBD handler for a sync peer and reinitiates IBD.
+async fn abort_and_reinitiate_ibd(ctx: &SwarmContext, sync_peer: PeerId) {
+    // Abort the wait handle
+    if let Err(e) = ctx
+        .ibd_tx
+        .send(IBDCommands::AbortWaitHandle { peer_id: sync_peer })
+        .await
+    {
+        error!(error = ?e, "Failed to send abort handler command");
+    } else {
+        warn!("Abort handle sent for sync peer");
+    }
+
+    // Reinitiate IBD
+    if let Err(e) = ctx.swarm_cmd_tx.send(SwarmCommand::InitiateIBD).await {
+        error!(error = ?e, "Failed to reinitiate IBD");
+    } else {
+        warn!("Reinitiating IBD");
+    }
+}

--- a/node/src/swarm/handlers/identify.rs
+++ b/node/src/swarm/handlers/identify.rs
@@ -1,0 +1,48 @@
+//! Identify protocol event handlers.
+
+use libp2p::{identify, PeerId};
+use tracing::{debug, error, info};
+
+use crate::behaviour::{BEAD_ANNOUNCE_PROTOCOL, KADPROTOCOLNAME};
+
+/// Handles identify info sent to a peer.
+pub fn handle_sent(peer_id: PeerId) {
+    debug!(peer = ?peer_id, "Sent identify info");
+}
+
+/// Handles identify info received from a peer.
+pub fn handle_received(peer_id: PeerId, info: identify::Info) {
+    info!(
+        peer = ?peer_id,
+        address_count = %info.listen_addrs.len(),
+        "Received listen addresses"
+    );
+
+    // Check if peer supports Kademlia
+    if info.protocols.iter().any(|p| *p == KADPROTOCOLNAME) {
+        for addr in &info.listen_addrs {
+            info!(address = %addr, "Received address via identify");
+        }
+    } else {
+        info!(peer = ?peer_id, "Peer does not support Kademlia");
+    }
+
+    // Check if peer supports FloodSub
+    if !info.protocols.iter().any(|p| *p == BEAD_ANNOUNCE_PROTOCOL) {
+        info!(
+            peer_address = ?info.observed_addr,
+            "Peer does not support floodsub"
+        );
+    }
+
+    debug!(info = ?info, "Received peer info");
+}
+
+/// Handles identify protocol errors.
+pub fn handle_error<E: std::fmt::Debug>(peer_id: PeerId, error: E) {
+    error!(
+        peer = %peer_id,
+        error = ?error,
+        "Identify event error"
+    );
+}

--- a/node/src/swarm/handlers/kademlia.rs
+++ b/node/src/swarm/handlers/kademlia.rs
@@ -1,0 +1,44 @@
+//! Kademlia DHT event handlers.
+
+use libp2p::kad;
+use tracing::{error, info};
+
+/// Handles Kademlia routing table updates.
+pub fn handle_routing_updated(
+    peer: libp2p::PeerId,
+    is_new_peer: bool,
+    addresses: kad::Addresses,
+    bucket_range: (libp2p::kad::KBucketDistance, libp2p::kad::KBucketDistance),
+    old_peer: Option<libp2p::PeerId>,
+) {
+    info!(
+        peer = %peer,
+        is_new = %is_new_peer,
+        addresses = ?addresses,
+        bucket = ?bucket_range,
+        old_peer = ?old_peer,
+        "DHT routing updated"
+    );
+}
+
+/// Handles Kademlia outbound query progress.
+pub fn handle_outbound_query(result: kad::QueryResult) {
+    match result {
+        kad::QueryResult::GetClosestPeers(Ok(ok)) => {
+            info!(
+                peers = ?ok.peers,
+                peer_count = %ok.peers.len(),
+                "Got closest peers"
+            );
+        }
+        kad::QueryResult::GetClosestPeers(Err(err)) => {
+            error!(error = %err, "Failed to get closest peers");
+        }
+        kad::QueryResult::Bootstrap(Ok(kad::BootstrapOk { peer, .. })) => {
+            info!(peer = ?peer, "Bootstrap discovered new peer");
+        }
+        other => {
+            info!(result = ?other, "Other DHT query result");
+        }
+    }
+}

--- a/node/src/swarm/handlers/mod.rs
+++ b/node/src/swarm/handlers/mod.rs
@@ -1,0 +1,9 @@
+pub mod bead_processing;
+pub mod bead_sync;
+pub mod connection;
+pub mod floodsub;
+pub mod identify;
+pub mod kademlia;
+pub mod ping;
+
+pub use bead_processing::{process_incoming_bead, BeadProcessingResult};

--- a/node/src/swarm/handlers/ping.rs
+++ b/node/src/swarm/handlers/ping.rs
@@ -1,0 +1,34 @@
+//! Ping protocol event handlers.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use libp2p::PeerId;
+use tokio::sync::RwLock;
+use tracing::{info, warn};
+
+use crate::peer_manager::PeerManager;
+
+/// Handles successful ping responses.
+pub async fn handle_ping_success(
+    peer: PeerId,
+    latency: Duration,
+    peer_manager: &Arc<RwLock<PeerManager>>,
+) {
+    info!(
+        peer = %peer,
+        latency_ms = %latency.as_millis(),
+        "Ping"
+    );
+    let mut peer_manager = peer_manager.write().await;
+    peer_manager.update_latency(&peer, latency);
+}
+
+/// Handles ping failures.
+pub fn handle_ping_failure(peer: PeerId, error: libp2p::ping::Failure) {
+    warn!(
+        peer = %peer,
+        error = %error,
+        "Ping failed"
+    );
+}

--- a/node/src/swarm/mod.rs
+++ b/node/src/swarm/mod.rs
@@ -1,0 +1,89 @@
+//! Swarm module for P2P networking functionality.
+//!
+//! This module encapsulates all libp2p swarm-related code including:
+//! - Swarm construction and configuration
+//! - Boot node discovery and connection
+//! - Event handling and dispatch
+//! - Bead processing utilities
+
+pub mod bootstrap;
+pub mod builder;
+pub mod config;
+pub mod handlers;
+pub mod p2p_event_loop;
+
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc,
+};
+
+use libp2p::PeerId;
+use tokio::sync::{mpsc::Sender, RwLock};
+
+use crate::{
+    braid::Braid, db::BraidpoolDBTypes, ibd_manager::IBDCommands, peer_manager::PeerManager,
+    SwarmCommand,
+};
+
+/// Shared context for swarm event handlers.
+///
+/// Bundles all dependencies needed by event handlers into a single struct,
+/// holding lock at granular level for better lock management
+pub struct SwarmContext {
+    /// The shared braid DAG structure
+    pub braid: Arc<RwLock<Braid>>,
+    /// Channel to send database commands
+    pub db_tx: Sender<BraidpoolDBTypes>,
+    /// Channel to send IBD commands
+    pub ibd_tx: Sender<IBDCommands>,
+    /// Flag indicating if node is in Initial Block Download mode
+    pub ibd_spinlock: Arc<AtomicBool>,
+    /// Peer scoring and management
+    pub peer_manager: Arc<RwLock<PeerManager>>,
+    /// Channel to send swarm commands other than p2p
+    pub swarm_cmd_tx: Sender<SwarmCommand>,
+}
+
+impl SwarmContext {
+    /// Creates a new SwarmContext with all required dependencies.
+    pub fn new(
+        braid: Arc<RwLock<Braid>>,
+        db_tx: Sender<BraidpoolDBTypes>,
+        ibd_tx: Sender<IBDCommands>,
+        ibd_spinlock: Arc<AtomicBool>,
+        peer_manager: Arc<RwLock<PeerManager>>,
+        swarm_cmd_tx: Sender<SwarmCommand>,
+    ) -> Self {
+        Self {
+            braid,
+            db_tx,
+            ibd_tx,
+            ibd_spinlock,
+            peer_manager,
+            swarm_cmd_tx,
+        }
+    }
+
+    /// Check if the node is currently in IBD mode.
+    #[inline]
+    pub fn is_in_ibd(&self) -> bool {
+        self.ibd_spinlock.load(Ordering::SeqCst)
+    }
+
+    /// Set the IBD flag.
+    #[inline]
+    pub fn set_ibd(&self, value: bool) {
+        self.ibd_spinlock.store(value, Ordering::SeqCst);
+    }
+
+    /// Get the best peer for syncing (lowest latency).
+    pub async fn get_sync_peer(&self) -> Option<PeerId> {
+        {
+            let peer_manager = self.peer_manager.read().await;
+            peer_manager
+                .get_top_k_peers_for_propagation(1)
+                .into_iter()
+                .next()
+        }
+    }
+}

--- a/node/src/swarm/p2p_event_loop.rs
+++ b/node/src/swarm/p2p_event_loop.rs
@@ -1,0 +1,354 @@
+//! Main event loop for the swarm.
+//!
+//! This module contains the event dispatch logic that routes swarm events
+//! to their appropriate handlers.
+
+use std::time::Duration;
+
+use futures::StreamExt;
+use libp2p::{floodsub, identify, kad, ping, request_response, swarm::SwarmEvent, Swarm};
+use tokio::sync::mpsc::Receiver;
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    bead::{BeadRequest, BeadResponse},
+    behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent},
+    ibd_manager::{IBDCommands, IBD_TRIGGER_AFTER, MAX_IBD_RETRIES},
+    SwarmCommand,
+};
+
+use super::{
+    handlers::{
+        bead_sync, connection, floodsub as floodsub_handler, identify as identify_handler,
+        kademlia, ping as ping_handler,
+    },
+    SwarmContext,
+};
+
+/// Runs the main swarm event loop.
+///
+/// This function processes swarm events and swarm commands, dispatching
+/// them to appropriate handlers.
+///
+/// # Arguments
+/// * `ctx` - The swarm context containing shared state
+/// * `swarm` - The libp2p swarm
+/// * `cmd_rx` - Receiver for swarm commands
+pub async fn run(
+    mut ctx: SwarmContext,
+    mut swarm: Swarm<BraidPoolBehaviour>,
+    mut cmd_rx: Receiver<SwarmCommand>,
+) {
+    loop {
+        tokio::select! {
+            //Swarm events
+            swarm_event = swarm.select_next_some() => {
+                dispatch_swarm_event(&mut ctx, &mut swarm, swarm_event).await;
+            }
+            //Events other than p2p
+            Some(cmd) = cmd_rx.recv() => {
+                handle_swarm_command(&mut ctx, &mut swarm, cmd).await;
+            }
+        }
+    }
+}
+
+/// Dispatches a swarm event to the appropriate handler.
+async fn dispatch_swarm_event(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    event: SwarmEvent<BraidPoolBehaviourEvent>,
+) {
+    match event {
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(kad::Event::RoutingUpdated {
+            peer,
+            is_new_peer,
+            addresses,
+            bucket_range,
+            old_peer,
+        })) => {
+            kademlia::handle_routing_updated(peer, is_new_peer, addresses, bucket_range, old_peer);
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
+            kad::Event::OutboundQueryProgressed { result, .. },
+        )) => {
+            kademlia::handle_outbound_query(result);
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
+            floodsub::FloodsubEvent::Subscribed { peer_id, topic },
+        )) => {
+            floodsub_handler::handle_subscribed(peer_id, topic);
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
+            floodsub::FloodsubEvent::Unsubscribed { peer_id, topic },
+        )) => {
+            floodsub_handler::handle_unsubscribed(peer_id, topic);
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
+            floodsub::FloodsubEvent::Message(message),
+        )) => {
+            floodsub_handler::handle_message(ctx, swarm, message).await;
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(identify::Event::Sent {
+            peer_id,
+            ..
+        })) => {
+            identify_handler::handle_sent(peer_id);
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(identify::Event::Received {
+            peer_id,
+            info,
+            ..
+        })) => {
+            identify_handler::handle_received(peer_id, info);
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(identify::Event::Error {
+            peer_id,
+            error,
+            ..
+        })) => {
+            identify_handler::handle_error(peer_id, error);
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Ping(ping::Event {
+            peer, result, ..
+        })) => match result {
+            Ok(latency) => {
+                ping_handler::handle_ping_success(peer, latency, &ctx.peer_manager).await;
+            }
+            Err(err) => {
+                ping_handler::handle_ping_failure(peer, err);
+            }
+        },
+
+        SwarmEvent::ConnectionEstablished {
+            peer_id, endpoint, ..
+        } => {
+            connection::handle_connection_established(swarm, &ctx.peer_manager, peer_id, &endpoint)
+                .await;
+        }
+
+        SwarmEvent::ConnectionClosed {
+            peer_id,
+            connection_id,
+            endpoint,
+            num_established,
+            cause,
+        } => {
+            connection::handle_connection_closed(
+                swarm,
+                &ctx.peer_manager,
+                peer_id,
+                connection_id,
+                &endpoint,
+                num_established,
+                cause.as_ref(),
+            )
+            .await;
+        }
+
+        SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadSync(
+            request_response::Event::Message {
+                peer,
+                message,
+                connection_id,
+            },
+        )) => {
+            info!(
+                peer = %peer,
+                connection = ?connection_id,
+                "Bead sync message"
+            );
+
+            match message {
+                request_response::Message::Request {
+                    request, channel, ..
+                } => {
+                    dispatch_bead_sync_request(ctx, swarm, peer, request, channel).await;
+                }
+                request_response::Message::Response { response, .. } => {
+                    dispatch_bead_sync_response(ctx, swarm, peer, response).await;
+                }
+            }
+        }
+
+        SwarmEvent::NewListenAddr { address, .. } => {
+            info!(address = ?address, "P2P listening on address");
+        }
+
+        other => {
+            debug!(event = ?other, "Other swarm event");
+        }
+    }
+}
+
+/// Dispatches a BeadSync(IBD) request to the appropriate handler.
+async fn dispatch_bead_sync_request(
+    ctx: &SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    _peer: libp2p::PeerId,
+    request: BeadRequest,
+    channel: request_response::ResponseChannel<BeadResponse>,
+) {
+    match request {
+        BeadRequest::GetBeads(hashes) => {
+            bead_sync::handle_get_beads(ctx, swarm, hashes, channel).await;
+        }
+        BeadRequest::GetTips => {
+            bead_sync::handle_get_tips(ctx, swarm, channel).await;
+        }
+        BeadRequest::GetGenesis => {
+            bead_sync::handle_get_genesis(ctx, swarm, channel).await;
+        }
+        BeadRequest::GetAllBeads => {
+            bead_sync::handle_get_all_beads(ctx, swarm, channel).await;
+        }
+        BeadRequest::GetBeadsAfter(hashes) => {
+            bead_sync::handle_get_beads_after(ctx, swarm, hashes, channel).await;
+        }
+    }
+}
+
+/// Dispatches a BeadSync(IBD) response to the appropriate handler.
+async fn dispatch_bead_sync_response(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    peer: libp2p::PeerId,
+    response: BeadResponse,
+) {
+    match response {
+        BeadResponse::Beads(beads) | BeadResponse::GetAllBeads(beads) => {
+            bead_sync::handle_beads_response(ctx, swarm, peer, beads).await;
+        }
+        BeadResponse::GetBeadsAfter(hashes) => {
+            bead_sync::handle_get_beads_after_response(ctx, swarm, peer, hashes).await;
+        }
+        BeadResponse::Tips(tips) => {
+            bead_sync::handle_tips_response(ctx, swarm, peer, tips).await;
+        }
+        BeadResponse::Genesis(genesis) => {
+            bead_sync::handle_genesis_response(ctx, swarm, peer, genesis).await;
+        }
+        BeadResponse::Error(error) => {
+            bead_sync::handle_error_response(swarm, peer, error);
+        }
+    }
+}
+
+/// Handles a swarm command.
+async fn handle_swarm_command(
+    ctx: &mut SwarmContext,
+    swarm: &mut Swarm<BraidPoolBehaviour>,
+    command: SwarmCommand,
+) {
+    match command {
+        SwarmCommand::PropagateValidBead { bead_bytes } => {
+            let topic = libp2p::floodsub::Topic::new(crate::behaviour::BRAIDPOOL_TOPIC);
+            swarm
+                .behaviour_mut()
+                .bead_announce
+                .publish(topic.clone(), bead_bytes);
+            info!(topic = ?topic, "Published bead to floodsub topic");
+        }
+
+        SwarmCommand::InitiateIBD => {
+            initiate_ibd(ctx, swarm).await;
+        }
+    }
+}
+
+/// Initiates the Initial Block Download process.
+async fn initiate_ibd(ctx: &mut SwarmContext, swarm: &mut Swarm<BraidPoolBehaviour>) {
+    info!("Initiating IBD - selecting lowest latency peer");
+
+    let peer_ids = {
+        let peer_manager = ctx.peer_manager.read().await;
+        peer_manager.get_top_k_peers_for_propagation(1)
+    };
+
+    if peer_ids.is_empty() {
+        warn!("No peers available for sync");
+        schedule_ibd_retry(ctx.swarm_cmd_tx.clone());
+        return;
+    }
+
+    let mut sync_request_sent = false;
+
+    for peer in peer_ids {
+        // Check retry count
+        let (retry_tx, retry_rx) = tokio::sync::oneshot::channel();
+
+        if let Err(e) = ctx
+            .ibd_tx
+            .send(IBDCommands::GetIncomingBeadRetryCount {
+                peer_id: peer,
+                retry_sender: retry_tx,
+            })
+            .await
+        {
+            error!(error = ?e, "Failed to get retry count");
+            continue;
+        }
+
+        let retry_count = match retry_rx.await {
+            Ok(count) => count,
+            Err(e) => {
+                error!(error = ?e, "Failed to receive retry count");
+                continue;
+            }
+        };
+
+        if retry_count >= MAX_IBD_RETRIES && retry_count != u64::MAX {
+            warn!(peer = ?peer, retries = retry_count, "Peer exceeded retry limit");
+            continue;
+        }
+
+        // Update incoming bead mapping
+        let is_retry = retry_count != u64::MAX;
+
+        if let Err(e) = ctx
+            .ibd_tx
+            .send(IBDCommands::UpdateIncomingBeadMapping {
+                peer_id: peer,
+                retry_or_not: is_retry,
+                handle: None,
+            })
+            .await
+        {
+            error!(error = ?e, "Failed to update incoming mapping");
+            continue;
+        }
+
+        // Send GetTips request
+        let request = BeadRequest::GetTips;
+        swarm.behaviour_mut().bead_sync.send_request(&peer, request);
+
+        info!(peer = ?peer, "IBD started with peer");
+        sync_request_sent = true;
+        break;
+    }
+
+    if !sync_request_sent {
+        warn!("All sync peers exceeded retry limits");
+        schedule_ibd_retry(ctx.swarm_cmd_tx.clone());
+    }
+}
+
+/// Schedules an IBD retry after a delay.
+fn schedule_ibd_retry(cmd_tx: tokio::sync::mpsc::Sender<SwarmCommand>) {
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+        if let Err(e) = cmd_tx.send(SwarmCommand::InitiateIBD).await {
+            error!(error = ?e, "Failed to schedule IBD retry");
+        } else {
+            info!("Retrying IBD after delay");
+        }
+    });
+}


### PR DESCRIPTION
- Current entry_point of braidpool which was `main.rs` was single module managed hence leading to difficulty management and alteration with the codebase.
- In this i introduce `SwarmContext` which helps us to share the Swarm owner states to be shared with better ownership per-say as well as separate `dispatchers` and `handlers` for different p2p events as well as other functionalities related to `IBD` etc.
- It decouples the logic leading to better lock management and sharing of states across different tasks with a central control by the `p2p_event_loop` .