### PR TITLE
node: Replace custom rust-bitcoin fork with official crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,10 +385,10 @@ dependencies = [
 [[package]]
 name = "base58ck"
 version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
+source = "git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185#a419fc9aa689b576e4d605aa00b77a5298d2b185"
 dependencies = [
  "bitcoin-internals 0.4.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
+ "bitcoin_hashes 0.16.0 (git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185)",
 ]
 
 [[package]]
@@ -411,11 +411,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
-source = "git+https://github.com/braidpool/rust-bech32.git?branch=cpunet#34d8ea70211b4178b6b5c540e17981719faccdd2"
-
-[[package]]
-name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
@@ -431,31 +426,12 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.7-pre-cpunet"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "base58ck 0.2.0",
- "base64 0.22.1",
- "bech32 0.11.0",
- "bitcoin-internals 0.4.0",
- "bitcoin-io 0.2.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "bitcoin-primitives",
- "bitcoin-units 0.2.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "bitcoinconsensus",
- "hex-conservative 0.3.1",
- "secp256k1 0.30.0",
- "serde",
-]
-
-[[package]]
-name = "bitcoin"
 version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
  "base58ck 0.1.0",
- "bech32 0.11.1",
+ "bech32",
  "bitcoin-internals 0.3.0",
  "bitcoin-io 0.1.4",
  "bitcoin-units 0.1.2",
@@ -463,6 +439,25 @@ dependencies = [
  "hex-conservative 0.2.2",
  "hex_lit",
  "secp256k1 0.29.1",
+ "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.33.0-alpha.0"
+source = "git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185#a419fc9aa689b576e4d605aa00b77a5298d2b185"
+dependencies = [
+ "base58ck 0.2.0",
+ "base64 0.22.1",
+ "bech32",
+ "bitcoin-internals 0.4.0",
+ "bitcoin-io 0.2.0 (git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185)",
+ "bitcoin-primitives",
+ "bitcoin-units 0.2.0",
+ "bitcoin_hashes 0.16.0 (git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185)",
+ "bitcoinconsensus",
+ "hex-conservative 0.3.1",
+ "secp256k1 0.30.0",
  "serde",
 ]
 
@@ -478,7 +473,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-internals"
 version = "0.4.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
+source = "git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185#a419fc9aa689b576e4d605aa00b77a5298d2b185"
 dependencies = [
  "hex-conservative 0.3.1",
  "serde",
@@ -508,21 +503,21 @@ dependencies = [
 [[package]]
 name = "bitcoin-io"
 version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
+source = "git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185#a419fc9aa689b576e4d605aa00b77a5298d2b185"
 dependencies = [
  "bitcoin-internals 0.4.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
+ "bitcoin_hashes 0.16.0 (git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185)",
 ]
 
 [[package]]
 name = "bitcoin-primitives"
 version = "0.101.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
+source = "git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185#a419fc9aa689b576e4d605aa00b77a5298d2b185"
 dependencies = [
  "arrayvec",
  "bitcoin-internals 0.4.0",
  "bitcoin-units 0.2.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
+ "bitcoin_hashes 0.16.0 (git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185)",
  "hex-conservative 0.3.1",
  "serde",
 ]
@@ -540,7 +535,7 @@ dependencies = [
 [[package]]
 name = "bitcoin-units"
 version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
+source = "git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185#a419fc9aa689b576e4d605aa00b77a5298d2b185"
 dependencies = [
  "bitcoin-internals 0.4.0",
  "serde",
@@ -570,7 +565,7 @@ dependencies = [
 [[package]]
 name = "bitcoin_hashes"
 version = "0.16.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
+source = "git+https://github.com/rust-bitcoin/rust-bitcoin.git?rev=a419fc9aa689b576e4d605aa00b77a5298d2b185#a419fc9aa689b576e4d605aa00b77a5298d2b185"
 dependencies = [
  "bitcoin-internals 0.4.0",
  "hex-conservative 0.3.1",
@@ -3114,7 +3109,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bitcoin 0.32.7-pre-cpunet",
+ "bitcoin 0.33.0-alpha.0",
  "bitcoin_hashes 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = { version = "0.3.28", features = ["thread-pool"]}
 bytes = "1.4.0"
 serde_json = "1.0.140"
 clap = { version = "4.4.2", features = ["derive", "string"] }
-bitcoin = { git = "https://github.com/braidpool/rust-bitcoin.git", branch = "cpunet",features=["serde"]}
+bitcoin = { git = "https://github.com/rust-bitcoin/rust-bitcoin.git", rev = "a419fc9aa689b576e4d605aa00b77a5298d2b185", features = ["serde"] }
 bitcoin_hashes = { version = "0.16" }
 bitcoincore-rpc = { version = "0.19.0"}
 bitcoincore-rpc-json = { version = "0.19.0"}

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -44,6 +44,17 @@ pub struct Bead {
 }
 impl_consensus_encoding!(Bead, block_header, committed_metadata, uncommitted_metadata);
 
+impl Bead {
+    /// Returns the CPUNet-aware block hash for this bead.
+    ///
+    /// On CPUNet, block hashes are computed with an additional `"cpunet\0"` suffix
+    /// appended to the SHA256d preimage. This method provides a single point of
+    /// dispatch for all bead identification in the DAG.
+    pub fn bead_hash(&self) -> BlockHash {
+        crate::cpunet::cpunet_block_hash(&self.block_header)
+    }
+}
+
 impl Default for Bead {
     fn default() -> Self {
         let empty_merkle_bytes: [u8; 32] = [0; 32];

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -331,7 +331,7 @@ fn test_bead_response_codec() {
         BeadResponse::Tips(BeadHashes(vec![test_hash, test_hash2])),
         BeadResponse::Genesis(BeadHashes(vec![test_hash])),
         BeadResponse::GetAllBeads(Beads(vec![test_bead.clone(), test_bead.clone()])),
-        BeadResponse::GetBeadsAfter(BeadHashes(vec![test_bead.block_header.block_hash()])),
+        BeadResponse::GetBeadsAfter(BeadHashes(vec![test_bead.bead_hash()])),
         BeadResponse::Error(BeadSyncError::GenesisMismatch),
         BeadResponse::Error(BeadSyncError::BeadHashNotFound),
     ];

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -138,7 +138,7 @@ async fn test_bead_request_handling() {
     let local_peer_id = swarm1.local_peer_id().clone();
     // Connect swarm2 to swarm1
     let test_bead = create_test_bead();
-    let bead_hash = test_bead.block_header.block_hash();
+    let bead_hash = test_bead.bead_hash();
     swarm2.dial(addr.clone()).unwrap();
     // wait for connection to be established
 
@@ -331,7 +331,7 @@ async fn test_floodsub_message_propagation() {
     // Connect swarm2 to swarm1
     let test_bead = create_test_bead();
     let test_bead_ref = test_bead.clone();
-    let bead_hash = test_bead.block_header.block_hash();
+    let bead_hash = test_bead.bead_hash();
 
     let topic = Topic::new("test");
     swarm1
@@ -430,8 +430,8 @@ async fn test_floodsub_message_propagation() {
     let result = rx.recv().await.unwrap();
     let received_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&result);
     assert_eq!(
-        received_bead.unwrap().block_header.block_hash(),
-        test_bead_ref.clone().block_header.block_hash()
+        received_bead.unwrap().bead_hash(),
+        test_bead_ref.clone().bead_hash()
     );
     _ = tokio::time::timeout(
         tokio::time::Duration::from_secs(20),

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -44,7 +44,7 @@ impl Braid {
         for (index, bead) in genesis_beads.into_iter().enumerate() {
             beads.push(bead.clone());
             bead_indices.insert(index);
-            bead_index_mapping.insert(bead.block_header.block_hash(), index);
+            bead_index_mapping.insert(bead.bead_hash(), index);
         }
         let mut genesis_cohort: Vec<Cohort> = Vec::new();
         if bead_indices.len() != 0 {
@@ -98,11 +98,11 @@ impl Braid {
             }
         }
         // Already seen this bead
-        let bead_hash = bead.block_header.block_hash();
+        let bead_hash = bead.bead_hash();
         if self
             .beads
             .iter()
-            .any(|b| b.block_header.block_hash() == bead_hash)
+            .any(|b| b.bead_hash() == bead_hash)
         {
             return AddBeadStatus::DagAlreadyContainsBead;
         }
@@ -245,7 +245,7 @@ impl Braid {
 
     pub fn insert_genesis_beads(&mut self, genesis_beads: Vec<Bead>) {
         for bead in genesis_beads {
-            let bead_hash = bead.block_header.block_hash();
+            let bead_hash = bead.bead_hash();
             if !self.bead_index_mapping.contains_key(&bead_hash) {
                 self.beads.push(bead.clone());
                 let new_index = self.beads.len() - 1;
@@ -303,7 +303,7 @@ impl Braid {
             for bead_index in &cohort.0 {
                 let curr_bead = self.beads[*bead_index].clone();
                 //Not including the beads that are already present in old_tips
-                if !old_tips.contains(&curr_bead.block_header.block_hash()) {
+                if !old_tips.contains(&curr_bead.bead_hash()) {
                     response_beads.push(curr_bead);
                 } else {
                     tracing::debug!("This bead is already present in old tips thus skipping");
@@ -378,7 +378,7 @@ pub mod consensus_functions {
         //utilizing the passed arguments as of parents instead of the internal braid one
         let current_beads = &braid_obj.beads;
         for bead in current_beads {
-            let current_bead_index = braid_obj.bead_index_mapping[&bead.block_header.block_hash()];
+            let current_bead_index = braid_obj.bead_index_mapping[&bead.bead_hash()];
             let parents = match parents.get(&current_bead_index) {
                 Some(b) => b,
                 _ => {
@@ -423,7 +423,7 @@ pub mod consensus_functions {
 
         let current_beads = &braid_obj.beads;
         for bead in current_beads {
-            let current_bead_idx = braid_obj.bead_index_mapping[&bead.block_header.block_hash()];
+            let current_bead_idx = braid_obj.bead_index_mapping[&bead.bead_hash()];
             let parents = &parents[&current_bead_idx];
 
             for parent_bead_idx in parents.iter() {
@@ -590,7 +590,7 @@ pub mod consensus_functions {
             ancestors.insert(current_block_idx, value_set);
         }
         for parent_idx in &parents[&current_block_idx] {
-            let current_parent_blockhash = braid_obj.beads[*parent_idx].block_header.block_hash();
+            let current_parent_blockhash = braid_obj.beads[*parent_idx].bead_hash();
             if ancestors.contains_key(&parent_idx) == false {
                 updating_ancestors(&braid_obj, current_parent_blockhash, ancestors, &parents);
             }
@@ -693,7 +693,7 @@ pub mod consensus_functions {
                 oldcohort = cohort.clone();
                 let mut key_set: HashSet<usize> = ancestor.keys().copied().collect();
                 for bead in tail.difference(&key_set) {
-                    let current_bead_blockhash = braid_obj.beads[*bead].block_header.block_hash();
+                    let current_bead_blockhash = braid_obj.beads[*bead].bead_hash();
                     updating_ancestors(braid_obj, current_bead_blockhash, &mut ancestor, parents);
                 }
 
@@ -917,7 +917,7 @@ pub mod consensus_functions {
             let sub_children = get_sub_braid(braid_obj, &curr_cohort, &children);
             let mut sub_descendants: HashMap<usize, HashSet<usize>> = HashMap::new();
             for bead in &curr_cohort {
-                let current_bead_hash = braid_obj.beads[*bead].block_header.block_hash();
+                let current_bead_hash = braid_obj.beads[*bead].bead_hash();
                 get_all_ancestors(
                     braid_obj,
                     current_bead_hash,
@@ -1144,7 +1144,7 @@ pub mod consensus_functions {
         let head = cohort_head(braid_obj, cohort, parents, Some(children));
 
         for bead in cohort {
-            let current_bead_hash = braid_obj.beads[*bead].block_header.block_hash();
+            let current_bead_hash = braid_obj.beads[*bead].bead_hash();
             get_all_ancestors(braid_obj, current_bead_hash, &mut ancestors, parents);
             if let Some(ancestor_beads) = ancestors.get(&bead) {
                 for ancestor_bead in ancestor_beads {

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -99,11 +99,7 @@ impl Braid {
         }
         // Already seen this bead
         let bead_hash = bead.bead_hash();
-        if self
-            .beads
-            .iter()
-            .any(|b| b.bead_hash() == bead_hash)
-        {
+        if self.beads.iter().any(|b| b.bead_hash() == bead_hash) {
             return AddBeadStatus::DagAlreadyContainsBead;
         }
 

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -34,7 +34,7 @@ pub fn test_extend_functionality() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([(
-            test_bead_0.block_header.block_hash(),
+            test_bead_0.bead_hash(),
             0,
         )]),
     };
@@ -50,7 +50,7 @@ pub fn test_extend_functionality() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
 
     test_braid.extend(&test_bead_1);
     // After adding a new bead that extends the zeroth one, we should have two cohorts
@@ -64,7 +64,7 @@ pub fn test_extend_functionality() {
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_braid.extend(&test_bead_2);
 
     // After adding the second bead, we should have three cohorts
@@ -96,7 +96,7 @@ pub fn test_extend_functionality() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_braid.extend(&test_bead_3);
 
     // Create bead 4 with parent 2
@@ -104,7 +104,7 @@ pub fn test_extend_functionality() {
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_braid.extend(&test_bead_4);
 
     // Create bead 5 with parent 2
@@ -112,7 +112,7 @@ pub fn test_extend_functionality() {
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_braid.extend(&test_bead_5);
 
     assert_eq!(
@@ -131,21 +131,21 @@ pub fn test_extend_functionality() {
     test_bead_6
         .committed_metadata
         .parents
-        .insert(test_bead_4.block_header.block_hash());
+        .insert(test_bead_4.bead_hash());
     test_braid.extend(&test_bead_6);
 
     let mut test_bead_7 = emit_bead();
     test_bead_7
         .committed_metadata
         .parents
-        .insert(test_bead_6.block_header.block_hash());
+        .insert(test_bead_6.bead_hash());
     test_braid.extend(&test_bead_7);
 
     let mut test_bead_8 = emit_bead();
     test_bead_8
         .committed_metadata
         .parents
-        .insert(test_bead_7.block_header.block_hash());
+        .insert(test_bead_7.bead_hash());
     test_braid.extend(&test_bead_8);
 
     assert_eq!(
@@ -163,21 +163,21 @@ pub fn test_extend_functionality() {
     test_bead_9
         .committed_metadata
         .parents
-        .insert(test_bead_5.block_header.block_hash());
+        .insert(test_bead_5.bead_hash());
     test_braid.extend(&test_bead_9);
 
     let mut test_bead_10 = emit_bead();
     test_bead_10
         .committed_metadata
         .parents
-        .insert(test_bead_9.block_header.block_hash());
+        .insert(test_bead_9.bead_hash());
     test_braid.extend(&test_bead_10);
 
     let mut test_bead_11 = emit_bead();
     test_bead_11
         .committed_metadata
         .parents
-        .insert(test_bead_10.block_header.block_hash());
+        .insert(test_bead_10.bead_hash());
     test_braid.extend(&test_bead_11);
 
     assert_eq!(
@@ -194,15 +194,15 @@ pub fn test_extend_functionality() {
     test_bead_12
         .committed_metadata
         .parents
-        .insert(test_bead_8.block_header.block_hash());
+        .insert(test_bead_8.bead_hash());
     test_bead_12
         .committed_metadata
         .parents
-        .insert(test_bead_11.block_header.block_hash());
+        .insert(test_bead_11.bead_hash());
     test_bead_12
         .committed_metadata
         .parents
-        .insert(test_bead_3.block_header.block_hash());
+        .insert(test_bead_3.bead_hash());
     test_braid.extend(&test_bead_12);
 
     assert_eq!(
@@ -220,7 +220,7 @@ pub fn test_extend_functionality() {
     test_bead_13
         .committed_metadata
         .parents
-        .insert(test_bead_12.block_header.block_hash());
+        .insert(test_bead_12.bead_hash());
     test_braid.extend(&test_bead_13);
     assert_eq!(
         test_braid.cohorts,
@@ -247,7 +247,7 @@ pub fn test_orphan_beads_functinality() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([(
-            test_bead_0.block_header.block_hash(),
+            test_bead_0.bead_hash(),
             0,
         )]),
     };
@@ -263,7 +263,7 @@ pub fn test_orphan_beads_functinality() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
 
     test_braid.extend(&test_bead_1);
     assert_eq!(
@@ -275,7 +275,7 @@ pub fn test_orphan_beads_functinality() {
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_braid.extend(&test_bead_2);
 
     // After adding the second bead, we should have three cohorts
@@ -302,16 +302,16 @@ pub fn test_genesis1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -326,10 +326,10 @@ pub fn test_genesis1() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
         ]),
     };
 
@@ -376,10 +376,10 @@ pub fn test_genesis2() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
         ]),
     };
     //mapping of the indices with set of indices representing its parents
@@ -408,11 +408,11 @@ pub fn test_genesis3() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -428,11 +428,11 @@ pub fn test_genesis3() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
-            (test_bead_4.block_header.block_hash(), 4),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
+            (test_bead_4.bead_hash(), 4),
         ]),
     };
     //mapping of the indices with set of indices representing its parents
@@ -492,16 +492,16 @@ pub fn test_tips1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -516,10 +516,10 @@ pub fn test_tips1() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
         ]),
     };
 
@@ -548,16 +548,16 @@ pub fn test_tips2() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -572,10 +572,10 @@ pub fn test_tips2() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
         ]),
     };
 
@@ -608,39 +608,39 @@ pub fn test_tips3() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     let test_braid = Braid {
         beads: vec![
             test_bead_0.clone(),
@@ -656,12 +656,12 @@ pub fn test_tips3() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
-            (test_bead_4.block_header.block_hash(), 4),
-            (test_bead_5.block_header.block_hash(), 5),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
+            (test_bead_4.bead_hash(), 4),
+            (test_bead_5.bead_hash(), 5),
         ]),
     };
     //mapping of the indices with set of indices representing its parents
@@ -696,39 +696,39 @@ pub fn test_reverse() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     let test_braid = Braid {
         beads: vec![
             test_bead_0.clone(),
@@ -744,12 +744,12 @@ pub fn test_reverse() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
-            (test_bead_4.block_header.block_hash(), 4),
-            (test_bead_5.block_header.block_hash(), 5),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
+            (test_bead_4.bead_hash(), 4),
+            (test_bead_5.bead_hash(), 5),
         ]),
     };
     //mapping of the indices with set of indices representing its parents
@@ -796,8 +796,7 @@ pub fn test_all_ancestors() {
         }
         for bead_index in current_braid_parents.clone() {
             let current_bead_hash = current_file_braid.beads[bead_index.0]
-                .block_header
-                .block_hash();
+                .bead_hash();
             let mut d1_compute: HashMap<usize, HashSet<usize>> = HashMap::new();
             get_all_ancestors(
                 &current_file_braid,
@@ -830,16 +829,16 @@ pub fn test_cohorts_parents_1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -854,10 +853,10 @@ pub fn test_cohorts_parents_1() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
         ]),
     };
 
@@ -965,16 +964,16 @@ pub fn test_highest_work_path_1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -989,10 +988,10 @@ pub fn test_highest_work_path_1() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
         ]),
     };
 
@@ -1024,23 +1023,23 @@ pub fn test_diamond_path_highest_work() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .insert(test_bead_0.bead_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .insert(test_bead_1.bead_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .insert(test_bead_2.bead_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_3.block_header.block_hash());
+        .insert(test_bead_3.bead_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -1056,11 +1055,11 @@ pub fn test_diamond_path_highest_work() {
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
         bead_index_mapping: std::collections::HashMap::from([
-            (test_bead_0.block_header.block_hash(), 0),
-            (test_bead_1.block_header.block_hash(), 1),
-            (test_bead_2.block_header.block_hash(), 2),
-            (test_bead_3.block_header.block_hash(), 3),
-            (test_bead_4.block_header.block_hash(), 4),
+            (test_bead_0.bead_hash(), 0),
+            (test_bead_1.bead_hash(), 1),
+            (test_bead_2.bead_hash(), 2),
+            (test_bead_3.bead_hash(), 3),
+            (test_bead_4.bead_hash(), 4),
         ]),
     };
     //mapping of the indices with set of indices representing its parents
@@ -1367,7 +1366,7 @@ fn test_extend_function() {
             let mut hashes = Vec::new();
             for &parent_idx in parents {
                 if let Some(parent_bead) = index_to_bead.get(&parent_idx) {
-                    hashes.push(parent_bead.block_header.block_hash());
+                    hashes.push(parent_bead.bead_hash());
                 }
             }
             parent_hashes.insert(*index, hashes);
@@ -1399,7 +1398,7 @@ fn test_extend_function() {
             if let Some(bead) = index_to_bead.get(&idx) {
                 genesis_beads.push(bead.clone());
                 genesis_set.insert(idx);
-                bead_index_mapping.insert(bead.block_header.block_hash(), idx);
+                bead_index_mapping.insert(bead.bead_hash(), idx);
             }
         }
 
@@ -1427,7 +1426,7 @@ fn test_extend_function() {
         for cohort in &test_braid.cohorts {
             let mut cohort_hashes = HashSet::new();
             for &bead_idx in &cohort.0 {
-                let bead_hash = test_braid.beads[bead_idx].block_header.block_hash();
+                let bead_hash = test_braid.beads[bead_idx].bead_hash();
                 cohort_hashes.insert(bead_hash);
             }
             computed_cohorts_by_hash.push(cohort_hashes);
@@ -1438,7 +1437,7 @@ fn test_extend_function() {
             let mut cohort_hashes = HashSet::new();
             for &bead_idx in cohort {
                 if let Some(bead) = index_to_bead.get(&bead_idx) {
-                    let bead_hash = bead.block_header.block_hash();
+                    let bead_hash = bead.bead_hash();
                     cohort_hashes.insert(bead_hash);
                 }
             }
@@ -1474,7 +1473,7 @@ fn test_get_beads_after() {
     for (index, parents) in &parent_relationships {
         let mut hashes = Vec::new();
         for &parent_idx in parents {
-            hashes.push(beads[parent_idx].block_header.block_hash());
+            hashes.push(beads[parent_idx].bead_hash());
         }
         parent_hashes.insert(*index, hashes);
     }
@@ -1489,7 +1488,7 @@ fn test_get_beads_after() {
     // Create braid with genesis
     let genesis_set = HashSet::from([0]);
     let mut bead_index_mapping = HashMap::new();
-    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+    bead_index_mapping.insert(beads[0].bead_hash(), 0);
 
     let mut test_braid = Braid {
         beads: vec![beads[0].clone()],
@@ -1507,7 +1506,7 @@ fn test_get_beads_after() {
     }
 
     // Test 1: Get beads after genesis (should return beads 1, 2, 3)
-    let genesis_hash = beads[0].block_header.block_hash();
+    let genesis_hash = beads[0].bead_hash();
     let result = test_braid.get_beads_after(vec![genesis_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
@@ -1522,27 +1521,27 @@ fn test_get_beads_after() {
     // Verify the returned beads contain the expected hashes
     let returned_hashes: HashSet<_> = returned_beads
         .iter()
-        .map(|b| b.block_header.block_hash())
+        .map(|b| b.bead_hash())
         .collect();
-    assert!(returned_hashes.contains(&beads[1].block_header.block_hash()));
-    assert!(returned_hashes.contains(&beads[2].block_header.block_hash()));
-    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[1].bead_hash()));
+    assert!(returned_hashes.contains(&beads[2].bead_hash()));
+    assert!(returned_hashes.contains(&beads[3].bead_hash()));
 
     // Test 2: Get beads after bead1 (should return beads 2, 3)
-    let bead1_hash = beads[1].block_header.block_hash();
+    let bead1_hash = beads[1].bead_hash();
     let result = test_braid.get_beads_after(vec![bead1_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
     let returned_hashes: HashSet<_> = returned_beads
         .iter()
-        .map(|b| b.block_header.block_hash())
+        .map(|b| b.bead_hash())
         .collect();
-    assert!(returned_hashes.contains(&beads[2].block_header.block_hash()));
-    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[2].bead_hash()));
+    assert!(returned_hashes.contains(&beads[3].bead_hash()));
 
     // Test 3: Get beads after the last bead (should return empty or just that bead)
-    let last_hash = beads[3].block_header.block_hash();
+    let last_hash = beads[3].bead_hash();
     let result = test_braid.get_beads_after(vec![last_hash]);
     assert!(result.is_none());
 
@@ -1577,7 +1576,7 @@ fn test_get_beads_after_diamond_structure() {
     for (index, parents) in &parent_relationships {
         let mut hashes = Vec::new();
         for &parent_idx in parents {
-            hashes.push(beads[parent_idx].block_header.block_hash());
+            hashes.push(beads[parent_idx].bead_hash());
         }
         parent_hashes.insert(*index, hashes);
     }
@@ -1592,7 +1591,7 @@ fn test_get_beads_after_diamond_structure() {
     // Create braid with genesis
     let genesis_set = HashSet::from([0]);
     let mut bead_index_mapping = HashMap::new();
-    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+    bead_index_mapping.insert(beads[0].bead_hash(), 0);
 
     let mut test_braid = Braid {
         beads: vec![beads[0].clone()],
@@ -1610,7 +1609,7 @@ fn test_get_beads_after_diamond_structure() {
     }
 
     // Test 1: Get beads after genesis
-    let genesis_hash = beads[0].block_header.block_hash();
+    let genesis_hash = beads[0].bead_hash();
     let result = test_braid.get_beads_after(vec![genesis_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
@@ -1618,24 +1617,24 @@ fn test_get_beads_after_diamond_structure() {
     // Should include all beads after genesis
     let returned_hashes: HashSet<_> = returned_beads
         .iter()
-        .map(|b| b.block_header.block_hash())
+        .map(|b| b.bead_hash())
         .collect();
-    assert!(returned_hashes.contains(&beads[1].block_header.block_hash()));
-    assert!(returned_hashes.contains(&beads[2].block_header.block_hash()));
-    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[1].bead_hash()));
+    assert!(returned_hashes.contains(&beads[2].bead_hash()));
+    assert!(returned_hashes.contains(&beads[3].bead_hash()));
 
     // Test 2: Get beads after both middle beads (should return bead3)
-    let bead1_hash = beads[1].block_header.block_hash();
-    let bead2_hash = beads[2].block_header.block_hash();
+    let bead1_hash = beads[1].bead_hash();
+    let bead2_hash = beads[2].bead_hash();
     let result = test_braid.get_beads_after(vec![bead1_hash, bead2_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
     let returned_hashes: HashSet<_> = returned_beads
         .iter()
-        .map(|b| b.block_header.block_hash())
+        .map(|b| b.bead_hash())
         .collect();
-    assert!(returned_hashes.contains(&beads[3].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[3].bead_hash()));
 
     println!("Diamond structure tests passed");
 }
@@ -1674,7 +1673,7 @@ fn test_get_beads_after_complex_braid() {
     for (index, parents) in &parent_relationships {
         let mut hashes = Vec::new();
         for &parent_idx in parents {
-            hashes.push(beads[parent_idx].block_header.block_hash());
+            hashes.push(beads[parent_idx].bead_hash());
         }
         parent_hashes.insert(*index, hashes);
     }
@@ -1689,7 +1688,7 @@ fn test_get_beads_after_complex_braid() {
     // Create braid with genesis
     let genesis_set = HashSet::from([0]);
     let mut bead_index_mapping = HashMap::new();
-    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+    bead_index_mapping.insert(beads[0].bead_hash(), 0);
 
     let mut test_braid = Braid {
         beads: vec![beads[0].clone()],
@@ -1707,7 +1706,7 @@ fn test_get_beads_after_complex_braid() {
     }
 
     // Test 1: Get beads after genesis (should return all other beads)
-    let genesis_hash = beads[0].block_header.block_hash();
+    let genesis_hash = beads[0].bead_hash();
     let result = test_braid.get_beads_after(vec![genesis_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
@@ -1717,36 +1716,36 @@ fn test_get_beads_after_complex_braid() {
     );
 
     // Test 2: Get beads after first cohort (B1, B2, B3)
-    let b1_hash = beads[1].block_header.block_hash();
+    let b1_hash = beads[1].bead_hash();
     let result = test_braid.get_beads_after(vec![b1_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
     let returned_hashes: HashSet<_> = returned_beads
         .iter()
-        .map(|b| b.block_header.block_hash())
+        .map(|b| b.bead_hash())
         .collect();
 
     // Should include beads from the cohort containing B1 onwards
     assert!(
-        returned_hashes.contains(&beads[4].block_header.block_hash())
-            || returned_hashes.contains(&beads[5].block_header.block_hash())
-            || returned_hashes.contains(&beads[6].block_header.block_hash())
-            || returned_hashes.contains(&beads[7].block_header.block_hash())
+        returned_hashes.contains(&beads[4].bead_hash())
+            || returned_hashes.contains(&beads[5].bead_hash())
+            || returned_hashes.contains(&beads[6].bead_hash())
+            || returned_hashes.contains(&beads[7].bead_hash())
     );
 
     // Test 3: Get beads after multiple tips from second level
-    let b4_hash = beads[4].block_header.block_hash();
-    let b5_hash = beads[5].block_header.block_hash();
+    let b4_hash = beads[4].bead_hash();
+    let b5_hash = beads[5].bead_hash();
     let result = test_braid.get_beads_after(vec![b4_hash, b5_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
     let returned_hashes: HashSet<_> = returned_beads
         .iter()
-        .map(|b| b.block_header.block_hash())
+        .map(|b| b.bead_hash())
         .collect();
-    assert!(returned_hashes.contains(&beads[7].block_header.block_hash()));
+    assert!(returned_hashes.contains(&beads[7].bead_hash()));
 
     println!("Complex braid tests passed");
 }
@@ -1763,14 +1762,14 @@ fn test_get_beads_after_edge_cases() {
 
     // Simple chain: Genesis -> Bead1 -> Bead2
     // Collect parent hashes first to avoid borrowing issues
-    let parent0_hash = beads[0].block_header.block_hash();
-    let parent1_hash = beads[1].block_header.block_hash();
+    let parent0_hash = beads[0].bead_hash();
+    let parent1_hash = beads[1].bead_hash();
     beads[1].committed_metadata.parents.insert(parent0_hash);
     beads[2].committed_metadata.parents.insert(parent1_hash);
 
     let genesis_set = HashSet::from([0]);
     let mut bead_index_mapping = HashMap::new();
-    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+    bead_index_mapping.insert(beads[0].bead_hash(), 0);
 
     let mut test_braid = Braid {
         beads: vec![beads[0].clone()],
@@ -1797,7 +1796,7 @@ fn test_get_beads_after_edge_cases() {
     // Should handle non-existent hash gracefully
 
     // Test 3: Mix of valid and invalid hashes
-    let genesis_hash = beads[0].block_header.block_hash();
+    let genesis_hash = beads[0].bead_hash();
     let result = test_braid.get_beads_after(vec![genesis_hash, fake_hash]);
     assert!(result.is_some());
     let returned_beads = result.unwrap();
@@ -1805,15 +1804,15 @@ fn test_get_beads_after_edge_cases() {
     // Should still work with valid hash and ignore invalid one
     let returned_hashes: HashSet<_> = returned_beads
         .iter()
-        .map(|b| b.block_header.block_hash())
+        .map(|b| b.bead_hash())
         .collect();
     assert!(
-        returned_hashes.contains(&beads[1].block_header.block_hash())
-            || returned_hashes.contains(&beads[2].block_header.block_hash())
+        returned_hashes.contains(&beads[1].bead_hash())
+            || returned_hashes.contains(&beads[2].bead_hash())
     );
 
     // Test 4: Get beads after the tip (last bead)
-    let tip_hash = beads[2].block_header.block_hash();
+    let tip_hash = beads[2].bead_hash();
     let result = test_braid.get_beads_after(vec![tip_hash]);
     assert!(result.is_none());
     // Should return at least the tip bead itself or beads from its cohort
@@ -1851,7 +1850,7 @@ fn test_get_beads_after_multiple_tips() {
     for (index, parents) in &parent_relationships {
         let mut hashes = Vec::new();
         for &parent_idx in parents {
-            hashes.push(beads[parent_idx].block_header.block_hash());
+            hashes.push(beads[parent_idx].bead_hash());
         }
         parent_hashes.insert(*index, hashes);
     }
@@ -1866,7 +1865,7 @@ fn test_get_beads_after_multiple_tips() {
     // Create and build braid
     let genesis_set = HashSet::from([0]);
     let mut bead_index_mapping = HashMap::new();
-    bead_index_mapping.insert(beads[0].block_header.block_hash(), 0);
+    bead_index_mapping.insert(beads[0].bead_hash(), 0);
 
     let mut test_braid = Braid {
         beads: vec![beads[0].clone()],
@@ -1883,8 +1882,8 @@ fn test_get_beads_after_multiple_tips() {
     }
 
     // Test: Get beads after multiple tips with different indices
-    let b3_hash = beads[3].block_header.block_hash(); // Index 3
-    let b5_hash = beads[5].block_header.block_hash(); // Index 5
+    let b3_hash = beads[3].bead_hash(); // Index 3
+    let b5_hash = beads[5].bead_hash(); // Index 5
 
     let result = test_braid.get_beads_after(vec![b3_hash, b5_hash]);
     assert!(result.is_some());

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -33,10 +33,7 @@ pub fn test_extend_functionality() {
         orphan_beads: Vec::new(),
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
-        bead_index_mapping: std::collections::HashMap::from([(
-            test_bead_0.bead_hash(),
-            0,
-        )]),
+        bead_index_mapping: std::collections::HashMap::from([(test_bead_0.bead_hash(), 0)]),
     };
     assert_eq!(
         test_braid.cohorts,
@@ -246,10 +243,7 @@ pub fn test_orphan_beads_functinality() {
         orphan_beads: Vec::new(),
         cohorts: vec![Cohort(HashSet::from([0]))],
         cohort_tips: vec![HashSet::from([0])],
-        bead_index_mapping: std::collections::HashMap::from([(
-            test_bead_0.bead_hash(),
-            0,
-        )]),
+        bead_index_mapping: std::collections::HashMap::from([(test_bead_0.bead_hash(), 0)]),
     };
     assert_eq!(
         test_braid.cohorts,
@@ -795,8 +789,7 @@ pub fn test_all_ancestors() {
             current_braid_parents.insert(beads.0, current_bead_parents);
         }
         for bead_index in current_braid_parents.clone() {
-            let current_bead_hash = current_file_braid.beads[bead_index.0]
-                .bead_hash();
+            let current_bead_hash = current_file_braid.beads[bead_index.0].bead_hash();
             let mut d1_compute: HashMap<usize, HashSet<usize>> = HashMap::new();
             get_all_ancestors(
                 &current_file_braid,
@@ -1519,10 +1512,7 @@ fn test_get_beads_after() {
     );
 
     // Verify the returned beads contain the expected hashes
-    let returned_hashes: HashSet<_> = returned_beads
-        .iter()
-        .map(|b| b.bead_hash())
-        .collect();
+    let returned_hashes: HashSet<_> = returned_beads.iter().map(|b| b.bead_hash()).collect();
     assert!(returned_hashes.contains(&beads[1].bead_hash()));
     assert!(returned_hashes.contains(&beads[2].bead_hash()));
     assert!(returned_hashes.contains(&beads[3].bead_hash()));
@@ -1533,10 +1523,7 @@ fn test_get_beads_after() {
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
-    let returned_hashes: HashSet<_> = returned_beads
-        .iter()
-        .map(|b| b.bead_hash())
-        .collect();
+    let returned_hashes: HashSet<_> = returned_beads.iter().map(|b| b.bead_hash()).collect();
     assert!(returned_hashes.contains(&beads[2].bead_hash()));
     assert!(returned_hashes.contains(&beads[3].bead_hash()));
 
@@ -1615,10 +1602,7 @@ fn test_get_beads_after_diamond_structure() {
     let returned_beads = result.unwrap();
 
     // Should include all beads after genesis
-    let returned_hashes: HashSet<_> = returned_beads
-        .iter()
-        .map(|b| b.bead_hash())
-        .collect();
+    let returned_hashes: HashSet<_> = returned_beads.iter().map(|b| b.bead_hash()).collect();
     assert!(returned_hashes.contains(&beads[1].bead_hash()));
     assert!(returned_hashes.contains(&beads[2].bead_hash()));
     assert!(returned_hashes.contains(&beads[3].bead_hash()));
@@ -1630,10 +1614,7 @@ fn test_get_beads_after_diamond_structure() {
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
-    let returned_hashes: HashSet<_> = returned_beads
-        .iter()
-        .map(|b| b.bead_hash())
-        .collect();
+    let returned_hashes: HashSet<_> = returned_beads.iter().map(|b| b.bead_hash()).collect();
     assert!(returned_hashes.contains(&beads[3].bead_hash()));
 
     println!("Diamond structure tests passed");
@@ -1721,10 +1702,7 @@ fn test_get_beads_after_complex_braid() {
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
-    let returned_hashes: HashSet<_> = returned_beads
-        .iter()
-        .map(|b| b.bead_hash())
-        .collect();
+    let returned_hashes: HashSet<_> = returned_beads.iter().map(|b| b.bead_hash()).collect();
 
     // Should include beads from the cohort containing B1 onwards
     assert!(
@@ -1741,10 +1719,7 @@ fn test_get_beads_after_complex_braid() {
     assert!(result.is_some());
     let returned_beads = result.unwrap();
 
-    let returned_hashes: HashSet<_> = returned_beads
-        .iter()
-        .map(|b| b.bead_hash())
-        .collect();
+    let returned_hashes: HashSet<_> = returned_beads.iter().map(|b| b.bead_hash()).collect();
     assert!(returned_hashes.contains(&beads[7].bead_hash()));
 
     println!("Complex braid tests passed");
@@ -1802,10 +1777,7 @@ fn test_get_beads_after_edge_cases() {
     let returned_beads = result.unwrap();
 
     // Should still work with valid hash and ignore invalid one
-    let returned_hashes: HashSet<_> = returned_beads
-        .iter()
-        .map(|b| b.bead_hash())
-        .collect();
+    let returned_hashes: HashSet<_> = returned_beads.iter().map(|b| b.bead_hash()).collect();
     assert!(
         returned_hashes.contains(&beads[1].bead_hash())
             || returned_hashes.contains(&beads[2].bead_hash())

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -1,4 +1,4 @@
-use bitcoin::Network;
+use crate::cpunet::BraidpoolNetwork;
 use core::panic;
 use serde::{Deserialize, Serialize};
 use std::fs;
@@ -11,7 +11,7 @@ pub struct NetworkConfig {
 }
 #[derive(Serialize, Deserialize, Clone)]
 pub struct BitcoinConfig {
-    pub network: bitcoin::Network,
+    pub network: BraidpoolNetwork,
     pub username: String,
     pub password: String,
     pub port: String,
@@ -68,7 +68,7 @@ impl BraidpoolConfig {
         self
     }
 
-    pub fn with_network(mut self, network: bitcoin::Network) -> Self {
+    pub fn with_network(mut self, network: BraidpoolNetwork) -> Self {
         self.bitcoin_config.network = network;
         self
     }
@@ -106,21 +106,14 @@ impl BraidpoolConfig {
 
 #[derive(Debug, Clone)]
 pub struct CoinbaseConfig {
-    pub network: Network,
+    pub network: BraidpoolNetwork,
     pub pool_payout_address: String,
     pub pool_identifier: String,
 }
 
 impl CoinbaseConfig {
-    pub fn for_network(network: Network) -> Self {
-        let pool_payout_address = match network {
-            Network::Bitcoin => "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
-            Network::Testnet(_) => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
-            Network::Signet => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
-            Network::Regtest => "bcrt1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
-            Network::CPUNet => "tc1qu3cdq9unyhdc3d2hw8mvpfgnnhvp6ucckkl6ft".to_string(),
-            _ => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
-        };
+    pub fn for_network(network: BraidpoolNetwork) -> Self {
+        let pool_payout_address = crate::cpunet::default_payout_address(&network);
 
         Self {
             network,
@@ -134,9 +127,8 @@ impl CoinbaseConfig {
 mod test {
     use std::path::Path;
 
-    use bitcoin::Network;
-
     use crate::config::{BraidRpcConfig, MinerConfig};
+    use crate::cpunet::BraidpoolNetwork;
 
     use super::{BitcoinConfig, BraidDirectoryConfig, BraidpoolConfig, NetworkConfig};
     #[test]
@@ -156,7 +148,7 @@ mod test {
                 ],
             },
             bitcoin_config: BitcoinConfig {
-                network: Network::CPUNet,
+                network: BraidpoolNetwork::CPUNet,
                 username: "username".to_string(),
                 password: "password".to_string(),
                 port: "18443".to_string(),

--- a/node/src/cpunet.rs
+++ b/node/src/cpunet.rs
@@ -1,0 +1,275 @@
+use bitcoin::blockdata::block::ValidationError;
+use bitcoin::hashes::{sha256d, HashEngine};
+use bitcoin::{BlockHash, BlockHeader, Target};
+use bitcoin::block::HeaderExt;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+
+/// A network enum that extends `bitcoin::Network` with CPUNet support.
+///
+/// This avoids maintaining a full fork of rust-bitcoin just for the CPUNet variant.
+/// Convert to `bitcoin::Network` via `.bitcoin_network()` when interacting with
+/// upstream bitcoin library functions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BraidpoolNetwork {
+    Bitcoin(bitcoin::Network),
+    CPUNet,
+}
+
+impl BraidpoolNetwork {
+    /// Returns the underlying `bitcoin::Network`, mapping CPUNet to Regtest
+    /// for operations that require a standard network variant.
+    pub fn bitcoin_network(&self) -> bitcoin::Network {
+        match self {
+            BraidpoolNetwork::Bitcoin(n) => *n,
+            BraidpoolNetwork::CPUNet => bitcoin::Network::Regtest,
+        }
+    }
+
+    pub fn is_cpunet(&self) -> bool {
+        matches!(self, BraidpoolNetwork::CPUNet)
+    }
+
+    pub fn from_str_name(s: &str) -> Option<Self> {
+        match s {
+            "main" | "mainnet" | "bitcoin" => {
+                Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Bitcoin))
+            }
+            "testnet" | "testnet4" => Some(BraidpoolNetwork::Bitcoin(
+                bitcoin::Network::Testnet(bitcoin::TestnetVersion::V4),
+            )),
+            "signet" => Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Signet)),
+            "regtest" => Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Regtest)),
+            "cpunet" => Some(BraidpoolNetwork::CPUNet),
+            _ => None,
+        }
+    }
+}
+
+impl fmt::Display for BraidpoolNetwork {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BraidpoolNetwork::Bitcoin(n) => write!(f, "{}", n),
+            BraidpoolNetwork::CPUNet => write!(f, "cpunet"),
+        }
+    }
+}
+
+impl Serialize for BraidpoolNetwork {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        match self {
+            BraidpoolNetwork::Bitcoin(n) => n.serialize(serializer),
+            BraidpoolNetwork::CPUNet => serializer.serialize_str("cpunet"),
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for BraidpoolNetwork {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        BraidpoolNetwork::from_str_name(&s)
+            .ok_or_else(|| serde::de::Error::custom(format!("unknown network: {}", s)))
+    }
+}
+
+impl From<bitcoin::Network> for BraidpoolNetwork {
+    fn from(n: bitcoin::Network) -> Self {
+        BraidpoolNetwork::Bitcoin(n)
+    }
+}
+
+// --- CPUNet block hash ---
+
+/// Computes the CPUNet block hash for a given header.
+///
+/// CPUNet appends `"cpunet\0"` to the standard 80-byte header serialization
+/// before double-SHA256 hashing. This produces a different hash than the
+/// standard Bitcoin `block_hash()`.
+pub fn cpunet_block_hash(header: &BlockHeader) -> BlockHash {
+    let mut engine = sha256d::Hash::engine();
+    engine.input(&header.version.to_consensus().to_le_bytes());
+    engine.input(header.prev_blockhash.as_byte_array());
+    engine.input(header.merkle_root.as_byte_array());
+    engine.input(&header.time.to_u32().to_le_bytes());
+    engine.input(&header.bits.to_consensus().to_le_bytes());
+    engine.input(&header.nonce.to_le_bytes());
+    engine.input(b"cpunet\0");
+
+    BlockHash::from_byte_array(sha256d::Hash::from_engine(engine).to_byte_array())
+}
+
+/// Returns the appropriate block hash for the given network.
+/// Uses cpunet-modified hash for CPUNet, standard hash for all others.
+pub fn block_hash_for_network(header: &BlockHeader, network: &BraidpoolNetwork) -> BlockHash {
+    if network.is_cpunet() {
+        cpunet_block_hash(header)
+    } else {
+        header.block_hash()
+    }
+}
+
+/// Validates proof-of-work for a CPUNet block header.
+///
+/// This mirrors `HeaderExt::validate_pow` but uses the CPUNet-specific block hash
+/// (with the `"cpunet\0"` suffix in the preimage).
+pub fn cpunet_validate_pow(
+    header: &BlockHeader,
+    required_target: Target,
+) -> Result<BlockHash, ValidationError> {
+    let target: Target = header.bits.into();
+    if target != required_target {
+        return Err(ValidationError::BadTarget);
+    }
+    let block_hash = cpunet_block_hash(header);
+    if target.is_met_by(block_hash) {
+        Ok(block_hash)
+    } else {
+        Err(ValidationError::BadProofOfWork)
+    }
+}
+
+/// Validates proof-of-work using the appropriate hash function for the network.
+pub fn validate_pow_for_network(
+    header: &BlockHeader,
+    required_target: Target,
+    network: &BraidpoolNetwork,
+) -> Result<BlockHash, ValidationError> {
+    if network.is_cpunet() {
+        cpunet_validate_pow(header, required_target)
+    } else {
+        header.validate_pow(required_target)
+    }
+}
+
+// --- CPUNet network constants ---
+
+/// P2P magic bytes for CPUNet: ASCII "cpun"
+pub const CPUNET_MAGIC: [u8; 4] = [0x63, 0x70, 0x75, 0x6E];
+
+/// ChainHash for CPUNet (genesis block hash, reversed byte order).
+pub const CPUNET_CHAIN_HASH: [u8; 32] = [
+    155, 244, 9, 169, 207, 188, 132, 171, 5, 153, 89, 228, 109, 99, 3, 243, 57, 98, 248, 5, 188,
+    141, 147, 51, 119, 165, 255, 187, 0, 0, 0, 0,
+];
+
+/// CPUNet genesis block timestamp.
+pub const CPUNET_GENESIS_TIME: u32 = 1723652721;
+
+/// CPUNet genesis block nonce.
+pub const CPUNET_GENESIS_NONCE: u32 = 961348305;
+
+/// CPUNet genesis block difficulty target (same as mainnet initial: 0x1d00ffff).
+pub const CPUNET_GENESIS_BITS: u32 = 0x1d00ffff;
+
+/// Default pool payout address for CPUNet.
+///
+/// Uses `bcrt1` (regtest) encoding since the standard bitcoin crate cannot parse
+/// the cpunet-specific `tc1` bech32 HRP. CPUNet maps to regtest for address handling.
+/// Operators should configure their own payout address.
+pub const CPUNET_DEFAULT_PAYOUT_ADDRESS: &str = "bcrt1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7";
+
+/// Default IPC socket path for CPUNet.
+pub const CPUNET_DEFAULT_IPC_SOCKET: &str = "/tmp/bitcoin-cpunet.sock";
+
+// --- CPUNet address helpers ---
+
+/// Returns the default pool payout address for the given network.
+pub fn default_payout_address(network: &BraidpoolNetwork) -> String {
+    match network {
+        BraidpoolNetwork::CPUNet => CPUNET_DEFAULT_PAYOUT_ADDRESS.to_string(),
+        BraidpoolNetwork::Bitcoin(n) => match n {
+            bitcoin::Network::Bitcoin => {
+                "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string()
+            }
+            bitcoin::Network::Testnet(_) | bitcoin::Network::Signet => {
+                "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string()
+            }
+            bitcoin::Network::Regtest => {
+                "bcrt1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string()
+            }
+            _ => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::{BlockTime, BlockVersion, CompactTarget, TxMerkleNode};
+
+    fn test_header() -> BlockHeader {
+        let zero_hash = BlockHash::from_byte_array([0u8; 32]);
+        let zero_merkle = TxMerkleNode::from_byte_array([0u8; 32]);
+        BlockHeader {
+            version: BlockVersion::TWO,
+            prev_blockhash: zero_hash,
+            merkle_root: zero_merkle,
+            time: BlockTime::from_u32(1653195600),
+            bits: CompactTarget::from_consensus(0x1d00ffff),
+            nonce: 42,
+        }
+    }
+
+    #[test]
+    fn cpunet_hash_differs_from_standard() {
+        let header = test_header();
+        let standard = header.block_hash();
+        let cpunet = cpunet_block_hash(&header);
+        assert_ne!(standard, cpunet, "CPUNet hash must differ from standard hash");
+    }
+
+    #[test]
+    fn block_hash_for_network_dispatches_correctly() {
+        let header = test_header();
+        let btc = BraidpoolNetwork::Bitcoin(bitcoin::Network::Bitcoin);
+        let cpu = BraidpoolNetwork::CPUNet;
+
+        assert_eq!(block_hash_for_network(&header, &btc), header.block_hash());
+        assert_eq!(block_hash_for_network(&header, &cpu), cpunet_block_hash(&header));
+    }
+
+    #[test]
+    fn braidpool_network_serde_roundtrip() {
+        let networks = vec![
+            (BraidpoolNetwork::CPUNet, "\"cpunet\""),
+            (
+                BraidpoolNetwork::Bitcoin(bitcoin::Network::Bitcoin),
+                "\"bitcoin\"",
+            ),
+        ];
+        for (net, expected_json) in &networks {
+            let json = serde_json::to_string(net).unwrap();
+            assert_eq!(&json, expected_json);
+            let back: BraidpoolNetwork = serde_json::from_str(&json).unwrap();
+            assert_eq!(&back, net);
+        }
+    }
+
+    #[test]
+    fn braidpool_network_from_str() {
+        assert_eq!(
+            BraidpoolNetwork::from_str_name("cpunet"),
+            Some(BraidpoolNetwork::CPUNet)
+        );
+        assert_eq!(
+            BraidpoolNetwork::from_str_name("main"),
+            Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Bitcoin))
+        );
+        assert_eq!(BraidpoolNetwork::from_str_name("unknown"), None);
+    }
+
+    #[test]
+    fn braidpool_network_display() {
+        assert_eq!(BraidpoolNetwork::CPUNet.to_string(), "cpunet");
+        assert_eq!(
+            BraidpoolNetwork::Bitcoin(bitcoin::Network::Bitcoin).to_string(),
+            "bitcoin"
+        );
+    }
+}

--- a/node/src/cpunet.rs
+++ b/node/src/cpunet.rs
@@ -1,7 +1,7 @@
+use bitcoin::block::HeaderExt;
 use bitcoin::blockdata::block::ValidationError;
 use bitcoin::hashes::{sha256d, HashEngine};
 use bitcoin::{BlockHash, BlockHeader, Target};
-use bitcoin::block::HeaderExt;
 use serde::{Deserialize, Serialize};
 use std::fmt;
 
@@ -35,9 +35,9 @@ impl BraidpoolNetwork {
             "main" | "mainnet" | "bitcoin" => {
                 Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Bitcoin))
             }
-            "testnet" | "testnet4" => Some(BraidpoolNetwork::Bitcoin(
-                bitcoin::Network::Testnet(bitcoin::TestnetVersion::V4),
-            )),
+            "testnet" | "testnet4" => Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Testnet(
+                bitcoin::TestnetVersion::V4,
+            ))),
             "signet" => Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Signet)),
             "regtest" => Some(BraidpoolNetwork::Bitcoin(bitcoin::Network::Regtest)),
             "cpunet" => Some(BraidpoolNetwork::CPUNet),
@@ -184,15 +184,11 @@ pub fn default_payout_address(network: &BraidpoolNetwork) -> String {
     match network {
         BraidpoolNetwork::CPUNet => CPUNET_DEFAULT_PAYOUT_ADDRESS.to_string(),
         BraidpoolNetwork::Bitcoin(n) => match n {
-            bitcoin::Network::Bitcoin => {
-                "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string()
-            }
+            bitcoin::Network::Bitcoin => "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
             bitcoin::Network::Testnet(_) | bitcoin::Network::Signet => {
                 "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string()
             }
-            bitcoin::Network::Regtest => {
-                "bcrt1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string()
-            }
+            bitcoin::Network::Regtest => "bcrt1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
             _ => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
         },
     }
@@ -221,7 +217,10 @@ mod tests {
         let header = test_header();
         let standard = header.block_hash();
         let cpunet = cpunet_block_hash(&header);
-        assert_ne!(standard, cpunet, "CPUNet hash must differ from standard hash");
+        assert_ne!(
+            standard, cpunet,
+            "CPUNet hash must differ from standard hash"
+        );
     }
 
     #[test]
@@ -231,7 +230,10 @@ mod tests {
         let cpu = BraidpoolNetwork::CPUNet;
 
         assert_eq!(block_hash_for_network(&header, &btc), header.block_hash());
-        assert_eq!(block_hash_for_network(&header, &cpu), cpunet_block_hash(&header));
+        assert_eq!(
+            block_hash_for_network(&header, &cpu),
+            cpunet_block_hash(&header)
+        );
     }
 
     #[test]

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -224,9 +224,7 @@ pub fn prepare_bead_tuple_data(
         parent_set.insert(idx, set);
     }
 
-    let bead_id = *bead_index_mapping
-        .get(&bead.bead_hash())
-        .unwrap();
+    let bead_id = *bead_index_mapping.get(&bead.bead_hash()).unwrap();
     let current_parents = parent_set.get(&bead_id).cloned().unwrap_or_default();
 
     let mut relatives = Vec::new();
@@ -800,17 +798,12 @@ pub mod test {
                     panic!("An error occurred while committing transaction");
                 }
             };
-            let fetched_test_bead = fetch_bead_by_bead_hash(
-                Arc::new(Mutex::new(test_pool.clone())),
-                bead.bead_hash(),
-            )
-            .await
-            .unwrap();
+            let fetched_test_bead =
+                fetch_bead_by_bead_hash(Arc::new(Mutex::new(test_pool.clone())), bead.bead_hash())
+                    .await
+                    .unwrap();
             assert_eq!(
-                fetched_test_bead
-                    .unwrap()
-                    .bead_hash()
-                    .to_string(),
+                fetched_test_bead.unwrap().bead_hash().to_string(),
                 bead.bead_hash().to_string()
             );
         }

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -88,7 +88,7 @@ impl DBHandler {
             hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes());
         let hex_converted_extranonce_2 =
             hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes());
-        let block_header_bytes = bead.block_header.block_hash().to_byte_array().to_vec();
+        let block_header_bytes = bead.bead_hash().to_byte_array().to_vec();
         let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
         let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
         let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
@@ -174,7 +174,7 @@ impl DBHandler {
                         parent_timestamp_json,
                         bead_id,
                     } => {
-                        let bead_hash = bead_to_insert.block_header.block_hash();
+                        let bead_hash = bead_to_insert.bead_hash();
                         match self
                             .insert_bead(
                                 bead_to_insert,
@@ -225,7 +225,7 @@ pub fn prepare_bead_tuple_data(
     }
 
     let bead_id = *bead_index_mapping
-        .get(&bead.block_header.block_hash())
+        .get(&bead.bead_hash())
         .unwrap();
     let current_parents = parent_set.get(&bead_id).cloned().unwrap_or_default();
 
@@ -675,13 +675,13 @@ pub mod test {
             let mut ancestor_mapping: HashMap<usize, HashSet<usize>> = HashMap::new();
             consensus_functions::updating_ancestors(
                 &current_file_braid,
-                bead.block_header.block_hash(),
+                bead.bead_hash(),
                 &mut ancestor_mapping,
                 &braid_parent_set,
             );
             let bead_id = current_file_braid
                 .bead_index_mapping
-                .get(&bead.block_header.block_hash())
+                .get(&bead.bead_hash())
                 .unwrap();
             let current_bead_parent_set = braid_parent_set.get(&(bead_id)).unwrap();
             let mut relative_tuples: Vec<(u64, u64)> = Vec::new();
@@ -746,7 +746,7 @@ pub mod test {
                 hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes());
             let hex_converted_extranonce_2 =
                 hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes());
-            let block_header_bytes = bead.block_header.block_hash().to_byte_array().to_vec();
+            let block_header_bytes = bead.bead_hash().to_byte_array().to_vec();
             let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
             let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
             let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
@@ -802,17 +802,16 @@ pub mod test {
             };
             let fetched_test_bead = fetch_bead_by_bead_hash(
                 Arc::new(Mutex::new(test_pool.clone())),
-                bead.block_header.block_hash(),
+                bead.bead_hash(),
             )
             .await
             .unwrap();
             assert_eq!(
                 fetched_test_bead
                     .unwrap()
-                    .block_header
-                    .block_hash()
+                    .bead_hash()
                     .to_string(),
-                bead.block_header.block_hash().to_string()
+                bead.bead_hash().to_string()
             );
         }
     }

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -10,7 +10,7 @@ use tokio::sync::mpsc::Sender;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 pub mod client;
-use bitcoin::Network;
+use crate::cpunet::BraidpoolNetwork;
 pub use client::{
     BitcoinNotification, BlockTemplateComponents, CheckBlockResult, RequestPriority,
     SharedBitcoinClient,
@@ -29,7 +29,7 @@ const MAX_BACKOFF: u64 = 300;
 pub async fn ipc_block_listener(
     ipc_socket_path: String,
     block_template_tx: Sender<Arc<client::BlockTemplate>>,
-    network: Network,
+    network: BraidpoolNetwork,
     template_cache: Arc<tokio::sync::Mutex<HashMap<TemplateId, Arc<client::BlockTemplate>>>>,
     mut block_submission_rx: tokio::sync::mpsc::UnboundedReceiver<
         crate::stratum::BlockSubmissionRequest,
@@ -253,7 +253,7 @@ pub async fn ipc_block_listener(
                             header,
                             coinbase_transaction,
                         } = submission;
-                        let block_hash = header.block_hash();
+                        let block_hash = crate::cpunet::block_hash_for_network(&header, &network);
                         let template_opt = template_cache.lock().await.get(&template_id).cloned();
 
                         if let Some(ipc_template) = template_opt {
@@ -399,7 +399,7 @@ async fn get_template(
     priority: RequestPriority,
     context: &str,
     block_height: u32,
-    network: Network,
+    network: BraidpoolNetwork,
 ) -> Result<client::BlockTemplate, Box<dyn std::error::Error>> {
     const MIN_TRANSACTION_COUNT: u64 = 1;
     const NONCE: u32 = 0;

--- a/node/src/ipc/client.rs
+++ b/node/src/ipc/client.rs
@@ -978,7 +978,7 @@ impl SharedBitcoinClient {
                 response,
                 ..
             } => {
-                let block_hash = header.block_hash();
+                let block_hash = crate::cpunet::cpunet_block_hash(&header);
                 let version = header.version.to_consensus() as u32;
                 let timestamp = header.time.to_u32();
                 let nonce = header.nonce;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -43,6 +43,7 @@ pub mod braid;
 pub mod cli;
 pub mod committed_metadata;
 pub mod config;
+pub mod cpunet;
 pub mod db;
 pub mod error;
 pub mod ibd_manager;
@@ -302,7 +303,7 @@ impl SwarmHandler {
         //Committing parents data in bead
         for tip_bead in tips_index {
             let current_tip_bead = braid_data.beads.get(*tip_bead).unwrap();
-            parent_hash_set.insert(current_tip_bead.block_header.block_hash());
+            parent_hash_set.insert(current_tip_bead.bead_hash());
             time_hash_set
                 .0
                 .push(current_tip_bead.committed_metadata.start_timestamp);
@@ -366,14 +367,14 @@ impl SwarmHandler {
             AddBeadStatus::BeadAdded => {
                 let new_tips: Vec<_> = braid_data.tips.iter().map(|&idx| idx).collect();
                 info!(
-                    hash = %weak_share.block_header.block_hash(),
+                    hash = %weak_share.bead_hash(),
                     new_tips = ?new_tips,
                     "Braid extended successfully"
                 );
                 //Considering the index of the beads in braid will be same as the (insertion ids-1)
                 let bead_id = braid_data
                     .bead_index_mapping
-                    .get(&weak_share.block_header.block_hash())
+                    .get(&weak_share.bead_hash())
                     .unwrap();
                 let (txs_json, relative_json, parent_timestamp_json) = prepare_bead_tuple_data(
                     &braid_data.beads,
@@ -396,7 +397,7 @@ impl SwarmHandler {
                 {
                     Ok(_) => {
                         debug!(
-                            hash = %weak_share.block_header.block_hash(),
+                            hash = %weak_share.bead_hash(),
                             "InsertBeadSequentially sent to DB thread"
                         );
                     }
@@ -415,13 +416,13 @@ impl SwarmHandler {
                 {
                     Ok(_) => {
                         info!(
-                            hash = %weak_share.block_header.block_hash(),
+                            hash = %weak_share.bead_hash(),
                             "Bead sent to swarm"
                         );
                     }
                     Err(e) => {
                         error!(
-                            hash = %weak_share.block_header.block_hash(),
+                            hash = %weak_share.bead_hash(),
                             error = %e,
                             "Failed to send candidate block to swarm"
                         );
@@ -432,7 +433,7 @@ impl SwarmHandler {
                 };
             }
             _ => {
-                warn!(status = ?status, hash = %weak_share.block_header.block_hash(),
+                warn!(status = ?status, hash = %weak_share.bead_hash(),
                     "Failed to extend Braid")
             }
         }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,5 @@
 use bitcoin::consensus::encode::deserialize;
-use bitcoin::Network;
+use node::cpunet::BraidpoolNetwork;
 use clap::Parser;
 use futures::lock::Mutex;
 use futures::StreamExt;
@@ -92,7 +92,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
         for bead in &fetched_beads {
             let curr_bead_status = guard.extend(&bead);
             debug!(
-                hash = ?bead.block_header.block_hash(),
+                hash = ?bead.bead_hash(),
                 status = ?curr_bead_status,
                 "Bead inserted"
             );
@@ -381,24 +381,20 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let network = if let Some(network_name) = &args.network {
         info!(network = %network_name, "Network selected");
-        match network_name.as_str() {
-            "main" | "mainnet" => Network::Bitcoin,
-            "testnet" | "testnet4" => Network::Testnet(bitcoin::TestnetVersion::V4),
-            "signet" => Network::Signet,
-            "regtest" => Network::Regtest,
-            "cpunet" => Network::CPUNet,
-            _ => {
+        match BraidpoolNetwork::from_str_name(network_name.as_str()) {
+            Some(net) => net,
+            None => {
                 error!(
                     network = %network_name,
                     valid_networks = "main, testnet, testnet4, signet, regtest, cpunet",
                     "Invalid network specified"
                 );
                 info!(fallback = "regtest", "Using fallback network");
-                Network::Regtest
+                BraidpoolNetwork::Bitcoin(bitcoin::Network::Regtest)
             }
         }
     } else {
-        Network::Bitcoin
+        BraidpoolNetwork::Bitcoin(bitcoin::Network::Bitcoin)
     };
 
     let ipc_socket_path_for_blocking = args.ipc_socket.clone();
@@ -558,7 +554,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                          let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&message.data);
                          match result_bead {
                              Ok(bead) => {
-                                info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
+                                info!(bead = ?bead, hash = %bead.bead_hash(), "Received bead");
                                 // Handle the received bead here
                                 let mut braid_data = braid.write().await;
                                 let status = {
@@ -606,10 +602,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      //Considering the index of the beads in braid will be same as the (insertion ids-1)
                                         let bead_id = match braid_data
                                             .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
+                                            .get(&bead.bead_hash()) {
                                             Some(id) => id,
                                             None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
+                                                error!(bead_hash = ?bead.bead_hash(), "Bead ID not found in index mapping");
                                                 continue;
                                             }
                                         };
@@ -620,7 +616,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         ){
                                             Ok(received_tuples)=>received_tuples,
                                             Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.bead_hash(),error);
                                                 continue;
                                             }
                                         };
@@ -712,10 +708,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
                                         let bead_id = match braid_data
                                             .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
+                                            .get(&bead.bead_hash()) {
                                             Some(id) => id,
                                             None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
+                                                error!(bead_hash = ?bead.bead_hash(), "Bead ID not found in index mapping (GetAllBeads)");
                                                 continue;
                                             }
                                         };
@@ -726,7 +722,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         ){
                                             Ok(received_tuples)=>received_tuples,
                                             Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.bead_hash(),error);
                                                 continue;
                                             }
                                         };
@@ -931,7 +927,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 .iter()
                                                 .filter_map(|index| braid_lock.beads.get(*index))
                                                 .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
+                                                .map(|bead| bead.bead_hash())
                                                 .collect();
                                         }
                                         swarm.behaviour_mut().respond_with_tips(channel, tips);
@@ -945,7 +941,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 .iter()
                                                 .filter_map(|index| braid_lock.beads.get(*index))
                                                 .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
+                                                .map(|bead| bead.bead_hash())
                                                 .collect();
                                         }
                                         swarm.behaviour_mut().respond_with_genesis(channel, genesis);
@@ -964,7 +960,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         if let Some(response_beads) = beads {
                                             let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
                                             for bead in response_beads.into_iter(){
-                                                computed_beads_hashes.push(bead.block_header.block_hash());
+                                                computed_beads_hashes.push(bead.bead_hash());
                                             }
                                             //Sending the corresponding bead hashes requested by the new peer for IBD that will
                                             //be after the new peer's `Tips`.
@@ -1027,17 +1023,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     for bead in beads.into_iter() {
                                         let mut braid_data = braid.write().await;
                                         let status = braid_data.extend(&bead);
-                                        let curr_beadhash = bead.block_header.block_hash().to_string();
+                                        let curr_beadhash = bead.bead_hash().to_string();
                                         if let braid::AddBeadStatus::InvalidBead = status {
                                             // update the peer manager about the invalid bead
                                             peer_manager.penalize_for_invalid_bead(&peer);
                                         } else if let braid::AddBeadStatus::BeadAdded = status {
                                             let bead_id = match braid_data
                                                 .bead_index_mapping
-                                                .get(&bead.block_header.block_hash()) {
+                                                .get(&bead.bead_hash()) {
                                                 Some(id) => id,
                                                 None => {
-                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
+                                                    error!(bead_hash = ?bead.bead_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
                                                     continue;
                                                 }
                                             };
@@ -1269,7 +1265,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     let bead_hash_set: HashSet<BeadHash> = braid_data
                                     .beads
                                     .iter()
-                                    .map(|b| b.block_header.block_hash())
+                                    .map(|b| b.bead_hash())
                                     .collect();
 
                                     let flag = tips.iter().all(|tip_hash| bead_hash_set.contains(tip_hash));
@@ -1299,7 +1295,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                     let mut current_tip_hashes = Vec::new();
                                     for curr_bead_idx in braid_data.tips.iter() {
                                         if let Some(current_bead) = braid_data.beads.get(*curr_bead_idx) {
-                                            current_tip_hashes.push(current_bead.block_header.block_hash());
+                                            current_tip_hashes.push(current_bead.bead_hash());
                                         } else {
                                             error!(bead_idx = %curr_bead_idx, "Tip bead not found in beads list");
                                         }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,5 +1,4 @@
 use bitcoin::consensus::encode::deserialize;
-use node::cpunet::BraidpoolNetwork;
 use clap::Parser;
 use futures::lock::Mutex;
 use futures::StreamExt;
@@ -14,6 +13,7 @@ use libp2p::{
     swarm::SwarmEvent,
     PeerId,
 };
+use node::cpunet::BraidpoolNetwork;
 use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -175,7 +175,7 @@ impl RpcServer for RpcServerImpl {
         let bead = braid_data
             .beads
             .iter()
-            .find(|bead| bead.block_header.block_hash() == hash)
+            .find(|bead| bead.bead_hash() == hash)
             .cloned();
 
         match bead {
@@ -194,7 +194,7 @@ impl RpcServer for RpcServerImpl {
             ErrorObjectOwned::owned(1, format!("Invalid bead data: {}", e), None::<()>)
         })?;
         info!(
-            hash = %bead.block_header.block_hash(),
+            hash = %bead.bead_hash(),
             "Add bead request received"
         );
         let mut braid_data = self.braid_arc.write().await;
@@ -217,7 +217,7 @@ impl RpcServer for RpcServerImpl {
         let tips: Vec<BeadHash> = braid_data
             .tips
             .iter()
-            .map(|&index| braid_data.beads[index].block_header.block_hash())
+            .map(|&index| braid_data.beads[index].bead_hash())
             .collect();
         info!(tip_count = %tips.len(), "Get tips request received");
         let tips_str: Vec<String> = tips.iter().map(|h| h.to_string()).collect();
@@ -331,7 +331,7 @@ pub async fn test_extend_rpc() {
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
-    let new_bead = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let new_bead = create_test_bead(2, Some(test_bead1.bead_hash()));
     let bead_json_str = serde_json::to_string(&new_bead).expect("Failed to serialize bead");
 
     let mut params = ArrayParams::new();
@@ -373,7 +373,7 @@ pub async fn test_same_bead_extend() {
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
-    let new_bead = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let new_bead = create_test_bead(2, Some(test_bead1.bead_hash()));
 
     let bead_json_str = serde_json::to_string(&new_bead).expect("Failed to serialize bead");
 
@@ -395,9 +395,9 @@ pub async fn test_same_bead_extend() {
 #[tokio::test]
 pub async fn test_cohort_count_rpc() {
     let test_bead_1 = create_test_bead(1, None);
-    let test_bead_2 = create_test_bead(2, Some(test_bead_1.block_header.block_hash()));
-    let test_bead_3 = create_test_bead(3, Some(test_bead_2.block_header.block_hash()));
-    let test_bead_4 = create_test_bead(2, Some(test_bead_3.block_header.block_hash()));
+    let test_bead_2 = create_test_bead(2, Some(test_bead_1.bead_hash()));
+    let test_bead_3 = create_test_bead(3, Some(test_bead_2.bead_hash()));
+    let test_bead_4 = create_test_bead(2, Some(test_bead_3.bead_hash()));
 
     let genesis_beads = vec![test_bead_1.clone()];
 

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1,7 +1,7 @@
+use crate::cpunet;
 use crate::error::StratumErrors;
 use crate::template_creator::calculate_merkle_root;
 use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
-use bitcoin::block::HeaderExt;
 use bitcoin::consensus::serialize;
 use bitcoin::io::Cursor;
 use bitcoin::{absolute::Decodable, Transaction};
@@ -659,7 +659,7 @@ impl DownstreamClient {
         );
         debug!(
             connection_id = %connection_id_hex,
-            block_hash = %header.block_hash(),
+            block_hash = %cpunet::cpunet_block_hash(&header),
             "Block hash computed"
         );
 
@@ -720,12 +720,12 @@ impl DownstreamClient {
         let complete_block = bitcoin::Block::new_unchecked(header, block_transactions);
 
         //Checking with PoW of the target whether the block sent by downstream is below that or not
-        match header.validate_pow(target) {
+        match cpunet::cpunet_validate_pow(&header, target) {
             Ok(_) => {
                 debug!(
                     connection_id = %connection_id_hex,
                     target = %target.to_hex(),
-                    hash = %header.block_hash(),
+                    hash = %cpunet::cpunet_block_hash(&header),
                     "Header meets target"
                 );
 

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -405,9 +405,11 @@ pub fn build_braidpool_coinbase_from_template(
     let total_available = original_coinbase.output[0].value.to_sat();
 
     // Create the single payout output for the entire available amount.
+    // CPUNet uses regtest-format addresses (bcrt1) so we validate against
+    // the mapped bitcoin::Network.
     let payout_address = Address::from_str(&config.pool_payout_address)
         .map_err(CoinbaseError::AddressError)?
-        .require_network(config.network)
+        .require_network(config.network.bitcoin_network())
         .map_err(|_| CoinbaseError::AddressNetworkMismatch)?;
 
     let reward_payout = TxOut {

--- a/node/src/utils/test_utils.rs
+++ b/node/src/utils/test_utils.rs
@@ -65,7 +65,7 @@ pub mod test_utility_functions {
         for bead_idx in file_braid.clone().parents {
             let random_test_bead = emit_bead();
             test_braid_vector_bead_mapping.insert(
-                random_test_bead.clone().block_header.block_hash(),
+                random_test_bead.clone().bead_hash(),
                 bead_idx.0,
             );
             beads_to_idx.insert(bead_idx.0, random_test_bead.clone());
@@ -77,7 +77,7 @@ pub mod test_utility_functions {
             if let Some(current_bead_parents) = file_braid.parents.get(&idx) {
                 for parent_bead_idx in current_bead_parents {
                     let parent_bead_block_hash =
-                        beads_to_idx[parent_bead_idx].block_header.block_hash();
+                        beads_to_idx[parent_bead_idx].bead_hash();
                     current_bead
                         .committed_metadata
                         .parents

--- a/node/src/utils/test_utils.rs
+++ b/node/src/utils/test_utils.rs
@@ -64,10 +64,7 @@ pub mod test_utility_functions {
         let mut test_braid_vector_bead_mapping: HashMap<BeadHash, usize> = HashMap::new();
         for bead_idx in file_braid.clone().parents {
             let random_test_bead = emit_bead();
-            test_braid_vector_bead_mapping.insert(
-                random_test_bead.clone().bead_hash(),
-                bead_idx.0,
-            );
+            test_braid_vector_bead_mapping.insert(random_test_bead.clone().bead_hash(), bead_idx.0);
             beads_to_idx.insert(bead_idx.0, random_test_bead.clone());
         }
         let mut test_braid_parents_map: HashMap<usize, HashSet<usize>> = HashMap::new();
@@ -76,8 +73,7 @@ pub mod test_utility_functions {
             let mut parent_idx_set: HashSet<usize> = HashSet::new();
             if let Some(current_bead_parents) = file_braid.parents.get(&idx) {
                 for parent_bead_idx in current_bead_parents {
-                    let parent_bead_block_hash =
-                        beads_to_idx[parent_bead_idx].bead_hash();
+                    let parent_bead_block_hash = beads_to_idx[parent_bead_idx].bead_hash();
                     current_bead
                         .committed_metadata
                         .parents


### PR DESCRIPTION
Remove dependency on braidpool/rust-bitcoin cpunet fork and switch to the official rust-bitcoin/rust-bitcoin at the same upstream commit.
- Fixes #396 

The three customizations from the fork (cpunet block hash with "cpunet\0" suffix, Network::CPUNet variant, and tc1 address prefix) are now implemented locally in a new node/src/cpunet.rs module:

- Add BraidpoolNetwork enum wrapping bitcoin::Network with CPUNet
- Add cpunet_block_hash() and cpunet_validate_pow() functions
- Add Bead::bead_hash() as single dispatch point for bead identification
- Replace all block_header.block_hash() calls with bead_hash()
- Update config, main, ipc, stratum, and template_creator for new types
- CPUNet maps to Regtest for standard bitcoin library operations