### PR TITLE
feat: add persistent SQLite database and state snapshotting

### DIFF
--- a/node/src/audit.rs
+++ b/node/src/audit.rs
@@ -1,9 +1,14 @@
 use crate::bead::Bead;
 use crate::braid::{AddBeadStatus, Braid};
+use crate::committed_metadata::CommittedMetadata;
+use crate::db::audit_db_handlers::AuditDBHandler;
+use crate::uncommitted_metadata::UnCommittedMetadata;
+use crate::{TimeVec, TxIdVec};
 use bitcoin::consensus::serialize;
 use bitcoin::hashes::sha256d;
-use bitcoin::BlockHash;
+use bitcoin::{BlockHash, BlockHeader, CompactTarget, TxMerkleNode};
 use serde::{Deserialize, Serialize};
+use std::cmp::Ordering;
 use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::SystemTime;
@@ -19,8 +24,78 @@ pub const TOTAL_EXTRANONCE1_BYTES: usize =
 
 pub type ShareId = BlockHash;
 
-/// Compute composite hash for audit mode: hash(block_header || committed_metadata)
-/// This is ONLY used in audit mode where we cannot use OP_RETURN commitments, which
+/// Create a genesis bead for audit mode with empty parents
+fn create_genesis_bead_for_audit() -> Result<Bead, String> {
+    let genesis_time = bitcoin::absolute::Time::from_consensus(
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map_err(|e| format!("System time error: {}", e))?
+            .as_secs() as u32,
+    )
+    .map_err(|_| "Invalid genesis timestamp")?;
+
+    // Create genesis block header
+    let block_header = BlockHeader {
+        version: bitcoin::block::Version::ONE,
+        prev_blockhash: BlockHash::from_byte_array([0u8; 32]),
+        merkle_root: TxMerkleNode::from_byte_array([0u8; 32]),
+        time: bitcoin::BlockTime::from_u32(genesis_time.to_consensus_u32()),
+        bits: CompactTarget::from_consensus(0x1d00ffff),
+        nonce: 0,
+    };
+
+    let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
+        .parse::<bitcoin::PublicKey>()
+        .unwrap();
+
+    // Create committed metadata with no parents
+    let committed_metadata = CommittedMetadata {
+        transaction_ids: TxIdVec(Vec::new()),
+        parents: std::collections::HashSet::new(),
+        parent_bead_timestamps: TimeVec(Vec::new()),
+        payout_address: "bc1qgdjqv0av3q56jvd82tkdjpy7gdp9ut8tlqmgrpmv24sq90ecnvqqjwvw97"
+            .to_string(),
+        start_timestamp: genesis_time,
+        comm_pub_key: public_key,
+        min_target: CompactTarget::from_consensus(0x1d00ffff),
+        weak_target: CompactTarget::from_consensus(0x1d00ffff),
+        miner_ip: "system".to_string(),
+    };
+
+    let default_sig_hex = "3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45";
+    let default_sig_bytes =
+        hex::decode(default_sig_hex).map_err(|e| format!("Invalid signature hex: {}", e))?;
+    let default_sig = bitcoin::ecdsa::Signature {
+        signature: bitcoin::secp256k1::ecdsa::Signature::from_der(&default_sig_bytes)
+            .map_err(|e| format!("Invalid signature DER: {}", e))?,
+        sighash_type: bitcoin::sighash::EcdsaSighashType::All,
+    };
+
+    // Create uncommitted metadata
+    let uncommitted_metadata = UnCommittedMetadata {
+        extra_nonce_1: 0,
+        extra_nonce_2: 0,
+        broadcast_timestamp: genesis_time,
+        signature: default_sig,
+    };
+
+    let genesis_bead = Bead {
+        block_header,
+        committed_metadata,
+        uncommitted_metadata,
+    };
+
+    info!(
+        block_hash = %genesis_bead.block_header.block_hash(),
+        composite_hash = %compute_audit_bead_hash(&genesis_bead),
+        "Genesis bead created"
+    );
+
+    Ok(genesis_bead)
+}
+
+/// Compute composite hash for audit mode, hash(block_header || committed_metadata)
+/// This is only used in audit mode where we cannot use OP_RETURN commitments, which
 /// we will use as an extranonce commitment.
 pub fn compute_audit_bead_hash(bead: &Bead) -> BlockHash {
     let header_bytes = serialize(&bead.block_header);
@@ -29,6 +104,48 @@ pub fn compute_audit_bead_hash(bead: &Bead) -> BlockHash {
     combined.extend_from_slice(&header_bytes);
     combined.extend_from_slice(&metadata_bytes);
     BlockHash::from_byte_array(sha256d::Hash::hash(&combined).to_byte_array())
+}
+
+/// Defined rule for comparing two 32-byte hashes.
+fn compare_hash(a: &BlockHash, b: &BlockHash) -> Ordering {
+    let a_bytes = a.as_byte_array();
+    let b_bytes = b.as_byte_array();
+
+    // Compare byte-by-byte from left to right
+    for i in 0..32 {
+        if a_bytes[i] < b_bytes[i] {
+            return Ordering::Less;
+        } else if a_bytes[i] > b_bytes[i] {
+            return Ordering::Greater;
+        }
+    }
+    error!("A very rare event has occurred, the chances of this are fewer than the atoms in the observable universe.");
+    Ordering::Equal
+}
+
+/// Computes a deterministic generation hash by concatenating all current DAG tips using compare_hash function.
+/// This is used for calculating the current commitment by combining the composite hash of the current briad tips,
+/// by doing this we are commiting to the entire set of tips in a variable interval. Now future beads will
+/// point/contain this commitment.
+pub fn compute_generation_hash(
+    tips: &[(BlockHash, bitcoin::absolute::Time)],
+) -> Result<BlockHash, &'static str> {
+    if tips.is_empty() {
+        return Err("Cannot compute generation hash, tips array is empty. Genesis bead must be loaded first.");
+    }
+
+    let mut consensus_tips: Vec<BlockHash> = tips.iter().map(|(hash, _)| *hash).collect();
+    consensus_tips.sort_unstable_by(compare_hash);
+
+    // Concatenate all the sorted composite hashes together
+    let mut combined_bytes = Vec::with_capacity(consensus_tips.len() * 32);
+    for tip_hash in consensus_tips {
+        combined_bytes.extend_from_slice(tip_hash.as_byte_array());
+    }
+
+    let generation_hash = sha256d::Hash::hash(&combined_bytes);
+
+    Ok(BlockHash::from_byte_array(generation_hash.to_byte_array()))
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -280,6 +397,12 @@ pub struct AuditDAG {
     pub miner_states: HashMap<String, MinerAuditState>,
     /// Mapping from composite bead hash to share ID that created it
     bead_to_share: HashMap<BlockHash, ShareId>,
+    /// Database handler
+    db_handler: Option<Arc<AuditDBHandler>>,
+    /// The set of parents that all shares in the current job must point to.
+    pub active_parents: Vec<(BlockHash, BlockHash, bitcoin::absolute::Time)>,
+    /// The accumulating set of valid shares mined during the current job.
+    pub current_siblings: Vec<(BlockHash, BlockHash, bitcoin::absolute::Time)>,
 }
 
 impl AuditDAG {
@@ -289,7 +412,173 @@ impl AuditDAG {
             records: HashMap::new(),
             miner_states: HashMap::new(),
             bead_to_share: HashMap::new(),
+            db_handler: None,
+            active_parents: Vec::new(),
+            current_siblings: Vec::new(),
         }
+    }
+
+    pub async fn new_with_db(braid: Arc<RwLock<Braid>>) -> Result<Self, String> {
+        let db_handler = AuditDBHandler::new()
+            .await
+            .map_err(|e| format!("Failed to initialize audit database: {}", e))?;
+
+        Ok(Self {
+            braid,
+            records: HashMap::new(),
+            miner_states: HashMap::new(),
+            bead_to_share: HashMap::new(),
+            db_handler: Some(Arc::new(db_handler)),
+            active_parents: Vec::new(),
+            current_siblings: Vec::new(),
+        })
+    }
+    pub async fn load_from_db(&mut self) -> Result<Option<BlockHash>, String> {
+        if self.db_handler.is_none() {
+            info!("No database handler available, starting from genesis");
+            return Ok(None);
+        }
+
+        let db_handler = self.db_handler.as_ref().unwrap();
+
+        // Load the latest bead from the database to get its commitment
+        match db_handler.get_tips().await {
+            Ok(beads) => {
+                if beads.is_empty() {
+                    info!("No beads found in audit database, creating and persisting genesis bead");
+
+                    // Create genesis bead in memory
+                    let genesis_bead = create_genesis_bead_for_audit()?;
+                    let genesis_block_hash = genesis_bead.block_header.block_hash();
+                    let genesis_composite_hash = compute_audit_bead_hash(&genesis_bead);
+                    let genesis_timestamp = genesis_bead.committed_metadata.start_timestamp;
+
+                    info!(
+                        genesis_block_hash = %genesis_block_hash,
+                        genesis_composite_hash = %genesis_composite_hash,
+                        "Created genesis bead for audit DAG"
+                    );
+
+                    // Persist genesis bead to database
+                    if let Some(ref db_handler) = self.db_handler {
+                        match db_handler
+                            .insert_bead(
+                                &genesis_bead,
+                                genesis_composite_hash,
+                                "system".to_string(),
+                            )
+                            .await
+                        {
+                            Ok(bead_id) => {
+                                info!(
+                                    bead_id = %bead_id,
+                                    composite_hash = %genesis_composite_hash,
+                                    "Genesis bead persisted to audit database"
+                                );
+                            }
+                            Err(e) => {
+                                error!(
+                                    error = %e,
+                                    "Failed to persist genesis bead to database"
+                                );
+                                return Err(format!("Genesis bead persistence failed: {}", e));
+                            }
+                        }
+                    }
+
+                    {
+                        let mut braid = self.braid.write().await;
+                        *braid = crate::braid::Braid::new(vec![genesis_bead.clone()]);
+                    }
+
+                    self.active_parents = vec![(
+                        genesis_composite_hash,
+                        genesis_block_hash,
+                        genesis_timestamp,
+                    )];
+
+                    let generation_hash =
+                        compute_generation_hash(&[(genesis_composite_hash, genesis_timestamp)])?;
+
+                    info!(
+                        generation_hash = %generation_hash,
+                        "Initialized DAG with genesis bead"
+                    );
+
+                    Ok(Some(generation_hash))
+                } else {
+                    let sibling_count = beads.len();
+                    {
+                        // This allows us to start with the last mined bead tip retrieved from the database
+                        // instead of the genesis, this creates a valid in-memory DAG which correctly
+                        // refers to the past history (commitment), but if the database doesn't contain any
+                        // entry of a bead, possibly running the node for the first time or after flushing
+                        // the database then the in-memory bead will start from the genesis.
+                        let mut braid = self.braid.write().await;
+                        let only_beads: Vec<Bead> = beads.iter().map(|(b, _)| b.clone()).collect();
+                        *braid = crate::braid::Braid::new(only_beads);
+                    }
+
+                    self.active_parents = beads
+                        .into_iter()
+                        .map(|(bead, hash)| {
+                            (
+                                hash,
+                                bead.block_header.block_hash(),
+                                bead.committed_metadata.start_timestamp,
+                            )
+                        })
+                        .collect();
+
+                    let generation_inputs: Vec<_> = self
+                        .active_parents
+                        .iter()
+                        .map(|(comp, _, time)| (*comp, *time))
+                        .collect();
+
+                    let generation_hash = crate::audit::compute_generation_hash(&generation_inputs)
+                        .expect("No generation hash generated");
+
+                    info!(tip_count = sibling_count, "Restored DAG tips from database");
+
+                    Ok(Some(generation_hash))
+                }
+            }
+            Err(e) => {
+                error!(
+                    error = %e,
+                    "Critical database failure while loading DAG tips. Aborting startup to prevent state corruption."
+                );
+                return Err(format!(
+                    "Database read failure during state snapshotting: {}",
+                    e
+                ));
+            }
+        }
+    }
+
+    pub fn advance_generation(&mut self) -> Result<BlockHash, &'static str> {
+        // Shift siblings to become the new parents only if we found shares
+        if !self.current_siblings.is_empty() {
+            self.active_parents = self.current_siblings.clone();
+            self.current_siblings.clear();
+        }
+
+        // Compute the deterministic generation hash
+        let generation_inputs: Vec<_> = self
+            .active_parents
+            .iter()
+            .map(|(comp, _, time)| (*comp, *time))
+            .collect();
+        let generation_hash = compute_generation_hash(&generation_inputs)?;
+
+        info!(
+            parent_count = self.active_parents.len(),
+            generation_hash = %generation_hash,
+            "Advanced DAG generation on new upstream job"
+        );
+
+        Ok(generation_hash)
     }
 
     pub async fn add_and_record_bead(
@@ -351,10 +640,32 @@ impl AuditDAG {
             match status {
                 AddBeadStatus::BeadAdded => {
                     bead_added = true;
+
+                    if let Some(ref db_handler) = self.db_handler {
+                        match db_handler
+                            .insert_bead(&bead, composite_hash, miner_ip.clone())
+                            .await
+                        {
+                            Ok(_bead_id) => {}
+                            Err(e) => {
+                                error!(
+                                    composite_hash = %composite_hash,
+                                    error = %e,
+                                    "Failed to persist bead to audit database"
+                                );
+                            }
+                        }
+                    }
+                    let start_time = bead.committed_metadata.start_timestamp;
+                    let block_hash = bead.block_header.block_hash();
+                    self.current_siblings
+                        .push((composite_hash, block_hash, start_time));
+
                     info!(
                         block_hash = %bead.block_header.block_hash(),
                         composite_hash = %composite_hash,
                         parents = ?bead.committed_metadata.parents,
+                        sibling_count = self.current_siblings.len(),
                         miner = %miner_ip,
                         "Bead added to braid"
                     );
@@ -386,10 +697,7 @@ impl AuditDAG {
         }
         self.records.insert(share_id.clone(), record);
         self.bead_to_share.insert(composite_hash, share_id.clone());
-        info!(
-            composite_hash = %composite_hash,
-            block_hash = %bead.block_header.block_hash(),
-            share_id = %share_id,
+        debug!(
             miner = %miner_ip,
             total_beads = %self.records.len(),
             "Bead recorded successfully"
@@ -729,7 +1037,8 @@ mod tests {
     }
 
     #[test]
-    /// Validate the hardware buffer latency edge cases where a job uses the previous commitment.
+    /// Validate the hardware buffer latency edge cases where a job uses the previous commitment. And
+    /// verify that a share built on the previous commitment is explicitly rejected as stale.
     fn test_verify_share_with_fallback_uses_previous() {
         let prefix = vec![0xaa, 0xbb];
         let mut state = MinerAuditState::new(prefix.clone());
@@ -748,10 +1057,16 @@ mod tests {
             state.previous_commitment.as_ref(),
         );
 
-        assert!(
-            matches!(result, AuditVerificationResult::Valid { .. }),
-            "Expected Valid result with fallback"
-        );
+        match result {
+            AuditVerificationResult::Invalid { reason } => {
+                assert!(
+                    reason.contains("Stale commitment"),
+                    "Expected stale commitment rejection, got: {}",
+                    reason
+                );
+            }
+            _ => panic!("Expected Invalid result for stale commitment share"),
+        }
     }
 
     #[test]

--- a/node/src/audit.rs
+++ b/node/src/audit.rs
@@ -51,7 +51,7 @@ fn create_genesis_bead_for_audit() -> Result<Bead, String> {
     // Create committed metadata with no parents
     let committed_metadata = CommittedMetadata {
         transaction_ids: TxIdVec(Vec::new()),
-        parents: std::collections::HashSet::new(),
+        parents: Vec::new(),
         parent_bead_timestamps: TimeVec(Vec::new()),
         payout_address: "bc1qgdjqv0av3q56jvd82tkdjpy7gdp9ut8tlqmgrpmv24sq90ecnvqqjwvw97"
             .to_string(),

--- a/node/src/audit.rs
+++ b/node/src/audit.rs
@@ -339,13 +339,10 @@ impl MinerAuditState {
                     warn!(
                         old = %prev_commitment.to_hex(),
                         current = %self.current_commitment.to_hex(),
-                        "Share used previous commitment, accepting it as valid under conditions"
+                        "Share used previous commitment, rejecting and not adding to DAG"
                     );
-                    return AuditVerificationResult::Valid {
-                        commitment: prev_commitment.clone(),
-                        miner_roll: hex::decode(extranonce2_hex)
-                            .ok()
-                            .and_then(|bytes| bytes.first().copied()),
+                    return AuditVerificationResult::Invalid {
+                        reason: "Stale commitment: share used previous bead commitment".to_string(),
                     };
                 }
             }
@@ -403,6 +400,8 @@ pub struct AuditDAG {
     pub active_parents: Vec<(BlockHash, BlockHash, bitcoin::absolute::Time)>,
     /// The accumulating set of valid shares mined during the current job.
     pub current_siblings: Vec<(BlockHash, BlockHash, bitcoin::absolute::Time)>,
+    // total beads in DB
+    db_bead_count: usize,
 }
 
 impl AuditDAG {
@@ -415,6 +414,7 @@ impl AuditDAG {
             db_handler: None,
             active_parents: Vec::new(),
             current_siblings: Vec::new(),
+            db_bead_count: 0,
         }
     }
 
@@ -431,6 +431,7 @@ impl AuditDAG {
             db_handler: Some(Arc::new(db_handler)),
             active_parents: Vec::new(),
             current_siblings: Vec::new(),
+            db_bead_count: 0,
         })
     }
     pub async fn load_from_db(&mut self) -> Result<Option<BlockHash>, String> {
@@ -540,6 +541,19 @@ impl AuditDAG {
                         .expect("No generation hash generated");
 
                     info!(tip_count = sibling_count, "Restored DAG tips from database");
+
+                    if let Some(ref db_handler) = self.db_handler {
+                        match db_handler.get_bead_count().await {
+                            Ok(count) => {
+                                self.db_bead_count = count as usize;
+                                info!(
+                                    db_bead_count = self.db_bead_count,
+                                    "Loaded total bead count from database"
+                                );
+                            }
+                            Err(e) => warn!(error = %e, "Failed to get bead count from DB"),
+                        }
+                    }
 
                     Ok(Some(generation_hash))
                 }
@@ -666,6 +680,7 @@ impl AuditDAG {
                         composite_hash = %composite_hash,
                         parents = ?bead.committed_metadata.parents,
                         sibling_count = self.current_siblings.len(),
+                        total_beads = self.db_bead_count + self.records.len() + 1,
                         miner = %miner_ip,
                         "Bead added to braid"
                     );

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -29,7 +29,6 @@ use bitcoin::TxMerkleNode;
 use bitcoin::Txid;
 use futures::executor::block_on;
 use libp2p::request_response::Codec;
-use std::collections::HashSet;
 use std::io::Cursor;
 use std::str::FromStr;
 #[test]
@@ -41,7 +40,7 @@ fn test_serialized_committed_metadata() {
         .unwrap();
     let socket = String::from("127.0.0.1");
     let time_val = Time::from_consensus(1653195600).unwrap();
-    let parent_hash_set: HashSet<BlockHash> = HashSet::new();
+    let parent_hash_set: Vec<BlockHash> = Vec::new();
     let time_hash_set = TimeVec(Vec::new());
     let weak_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();
     let min_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();
@@ -109,7 +108,7 @@ fn test_serialized_bead() {
         .unwrap();
     let socket = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
-    let parent_hash_set: HashSet<BlockHash> = HashSet::new();
+    let parent_hash_set: Vec<BlockHash> = Vec::new();
     //Adding test txid
     let test_txid =
         Txid::from_str("8df401c7580ea2491d88d936ed0e16f3e6ea6c3d69eb9d9cf27652696a559e24").unwrap();
@@ -182,7 +181,7 @@ fn test_bead_response_serialization() {
         .unwrap();
     let socket = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
-    let parent_hash_set: HashSet<BlockHash> = HashSet::new();
+    let parent_hash_set: Vec<BlockHash> = Vec::new();
     let weak_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();
     let min_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();
     let time_val = Time::from_consensus(1653195600).unwrap();

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -13,7 +13,6 @@ use futures::StreamExt;
 use libp2p::floodsub::Topic;
 use libp2p::swarm::SwarmEvent;
 use libp2p::{Multiaddr, Swarm, SwarmBuilder};
-use std::collections::HashSet;
 use std::str::FromStr;
 use tokio::time::timeout;
 
@@ -25,7 +24,7 @@ fn create_test_bead() -> Bead {
         .unwrap();
     let socket = String::from("127.0.0.1");
     let time_hash_set = TimeVec(Vec::new());
-    let parent_hash_set: HashSet<BlockHash> = HashSet::new();
+    let parent_hash_set: Vec<BlockHash> = Vec::new();
     let weak_target = CompactTarget::from_consensus(486604799);
     let min_target = CompactTarget::from_consensus(486604799);
     let time_val = Time::from_consensus(1653195600).unwrap();

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -50,7 +50,7 @@ pub fn test_extend_functionality() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
 
     test_braid.extend(&test_bead_1);
     // After adding a new bead that extends the zeroth one, we should have two cohorts
@@ -64,7 +64,7 @@ pub fn test_extend_functionality() {
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_braid.extend(&test_bead_2);
 
     // After adding the second bead, we should have three cohorts
@@ -96,7 +96,7 @@ pub fn test_extend_functionality() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_braid.extend(&test_bead_3);
 
     // Create bead 4 with parent 2
@@ -104,7 +104,7 @@ pub fn test_extend_functionality() {
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_braid.extend(&test_bead_4);
 
     // Create bead 5 with parent 2
@@ -112,7 +112,7 @@ pub fn test_extend_functionality() {
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_braid.extend(&test_bead_5);
 
     assert_eq!(
@@ -131,21 +131,21 @@ pub fn test_extend_functionality() {
     test_bead_6
         .committed_metadata
         .parents
-        .insert(test_bead_4.block_header.block_hash());
+        .push(test_bead_4.block_header.block_hash());
     test_braid.extend(&test_bead_6);
 
     let mut test_bead_7 = emit_bead();
     test_bead_7
         .committed_metadata
         .parents
-        .insert(test_bead_6.block_header.block_hash());
+        .push(test_bead_6.block_header.block_hash());
     test_braid.extend(&test_bead_7);
 
     let mut test_bead_8 = emit_bead();
     test_bead_8
         .committed_metadata
         .parents
-        .insert(test_bead_7.block_header.block_hash());
+        .push(test_bead_7.block_header.block_hash());
     test_braid.extend(&test_bead_8);
 
     assert_eq!(
@@ -163,21 +163,21 @@ pub fn test_extend_functionality() {
     test_bead_9
         .committed_metadata
         .parents
-        .insert(test_bead_5.block_header.block_hash());
+        .push(test_bead_5.block_header.block_hash());
     test_braid.extend(&test_bead_9);
 
     let mut test_bead_10 = emit_bead();
     test_bead_10
         .committed_metadata
         .parents
-        .insert(test_bead_9.block_header.block_hash());
+        .push(test_bead_9.block_header.block_hash());
     test_braid.extend(&test_bead_10);
 
     let mut test_bead_11 = emit_bead();
     test_bead_11
         .committed_metadata
         .parents
-        .insert(test_bead_10.block_header.block_hash());
+        .push(test_bead_10.block_header.block_hash());
     test_braid.extend(&test_bead_11);
 
     assert_eq!(
@@ -194,15 +194,15 @@ pub fn test_extend_functionality() {
     test_bead_12
         .committed_metadata
         .parents
-        .insert(test_bead_8.block_header.block_hash());
+        .push(test_bead_8.block_header.block_hash());
     test_bead_12
         .committed_metadata
         .parents
-        .insert(test_bead_11.block_header.block_hash());
+        .push(test_bead_11.block_header.block_hash());
     test_bead_12
         .committed_metadata
         .parents
-        .insert(test_bead_3.block_header.block_hash());
+        .push(test_bead_3.block_header.block_hash());
     test_braid.extend(&test_bead_12);
 
     assert_eq!(
@@ -220,7 +220,7 @@ pub fn test_extend_functionality() {
     test_bead_13
         .committed_metadata
         .parents
-        .insert(test_bead_12.block_header.block_hash());
+        .push(test_bead_12.block_header.block_hash());
     test_braid.extend(&test_bead_13);
     assert_eq!(
         test_braid.cohorts,
@@ -263,7 +263,7 @@ pub fn test_orphan_beads_functinality() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
 
     test_braid.extend(&test_bead_1);
     assert_eq!(
@@ -275,7 +275,7 @@ pub fn test_orphan_beads_functinality() {
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_braid.extend(&test_bead_2);
 
     // After adding the second bead, we should have three cohorts
@@ -302,16 +302,16 @@ pub fn test_genesis1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -358,11 +358,11 @@ pub fn test_genesis2() {
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.prev_blockhash);
+        .push(test_bead_1.block_header.prev_blockhash);
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.prev_blockhash);
+        .push(test_bead_1.block_header.prev_blockhash);
     let test_braid = Braid {
         beads: vec![
             test_bead_0.clone(),
@@ -408,11 +408,11 @@ pub fn test_genesis3() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -492,16 +492,16 @@ pub fn test_tips1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -548,16 +548,16 @@ pub fn test_tips2() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -608,39 +608,39 @@ pub fn test_tips3() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     let test_braid = Braid {
         beads: vec![
             test_bead_0.clone(),
@@ -696,39 +696,39 @@ pub fn test_reverse() {
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_5
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     let test_braid = Braid {
         beads: vec![
             test_bead_0.clone(),
@@ -830,16 +830,16 @@ pub fn test_cohorts_parents_1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -965,16 +965,16 @@ pub fn test_highest_work_path_1() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
 
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -1024,23 +1024,23 @@ pub fn test_diamond_path_highest_work() {
     test_bead_1
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_2
         .committed_metadata
         .parents
-        .insert(test_bead_0.block_header.block_hash());
+        .push(test_bead_0.block_header.block_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_1.block_header.block_hash());
+        .push(test_bead_1.block_header.block_hash());
     test_bead_3
         .committed_metadata
         .parents
-        .insert(test_bead_2.block_header.block_hash());
+        .push(test_bead_2.block_header.block_hash());
     test_bead_4
         .committed_metadata
         .parents
-        .insert(test_bead_3.block_header.block_hash());
+        .push(test_bead_3.block_header.block_hash());
 
     let test_braid = Braid {
         beads: vec![
@@ -1377,7 +1377,7 @@ fn test_extend_function() {
         for (index, hashes) in parent_hashes {
             if let Some(bead) = index_to_bead.get_mut(&index) {
                 for hash in hashes {
-                    bead.committed_metadata.parents.insert(hash);
+                    bead.committed_metadata.parents.push(hash);
                 }
             }
         }
@@ -1482,7 +1482,7 @@ fn test_get_beads_after() {
     // Update parent hashes in committed metadata
     for (index, hashes) in parent_hashes {
         for hash in hashes {
-            beads[index].committed_metadata.parents.insert(hash);
+            beads[index].committed_metadata.parents.push(hash);
         }
     }
 
@@ -1585,7 +1585,7 @@ fn test_get_beads_after_diamond_structure() {
     // Update parent hashes in committed metadata
     for (index, hashes) in parent_hashes {
         for hash in hashes {
-            beads[index].committed_metadata.parents.insert(hash);
+            beads[index].committed_metadata.parents.push(hash);
         }
     }
 
@@ -1682,7 +1682,7 @@ fn test_get_beads_after_complex_braid() {
     // Update parent hashes in committed metadata
     for (index, hashes) in parent_hashes {
         for hash in hashes {
-            beads[index].committed_metadata.parents.insert(hash);
+            beads[index].committed_metadata.parents.push(hash);
         }
     }
 
@@ -1765,8 +1765,8 @@ fn test_get_beads_after_edge_cases() {
     // Collect parent hashes first to avoid borrowing issues
     let parent0_hash = beads[0].block_header.block_hash();
     let parent1_hash = beads[1].block_header.block_hash();
-    beads[1].committed_metadata.parents.insert(parent0_hash);
-    beads[2].committed_metadata.parents.insert(parent1_hash);
+    beads[1].committed_metadata.parents.push(parent0_hash);
+    beads[2].committed_metadata.parents.push(parent1_hash);
 
     let genesis_set = HashSet::from([0]);
     let mut bead_index_mapping = HashMap::new();
@@ -1859,7 +1859,7 @@ fn test_get_beads_after_multiple_tips() {
     // Update parent hashes in committed metadata
     for (index, hashes) in parent_hashes {
         for hash in hashes {
-            beads[index].committed_metadata.parents.insert(hash);
+            beads[index].committed_metadata.parents.push(hash);
         }
     }
 

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -72,6 +72,6 @@ pub struct Cli {
     pub upstream_password: String,
 
     /// Weak difficulty for the miner in audit mode
-    #[arg(long, default_value = "100.0")]
-    pub miner_difficulty: f64,
+    #[arg(long)]
+    pub miner_difficulty: Option<f64>,
 }

--- a/node/src/committed_metadata/mod.rs
+++ b/node/src/committed_metadata/mod.rs
@@ -1,4 +1,4 @@
-use crate::utils::{hashset_to_vec_deterministic, vec_to_hashset, BeadHash};
+use crate::utils::BeadHash;
 use bitcoin::absolute::MedianTimePast;
 use bitcoin::absolute::Time;
 use bitcoin::consensus::encode::Decodable;
@@ -10,7 +10,6 @@ use bitcoin::PublicKey;
 use bitcoin::Txid;
 use serde::Deserialize;
 use serde::Serialize;
-use std::collections::HashSet;
 use std::str::FromStr;
 
 #[derive(Clone, Debug, Serialize, Deserialize, PartialEq, Eq, Default)]
@@ -67,7 +66,7 @@ impl Decodable for TxIdVec {
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CommittedMetadata {
     pub transaction_ids: TxIdVec,
-    pub parents: HashSet<BeadHash>,
+    pub parents: Vec<BeadHash>,
     pub parent_bead_timestamps: TimeVec,
     pub payout_address: String,
     pub start_timestamp: Time,
@@ -83,7 +82,7 @@ impl Default for CommittedMetadata {
     fn default() -> Self {
         Self {
             transaction_ids: TxIdVec(Vec::new()),
-            parents: HashSet::new(),
+            parents: Vec::new(),
             parent_bead_timestamps: TimeVec(Vec::new()),
             payout_address: "bc1".to_string(),
             start_timestamp: MedianTimePast::MIN,
@@ -101,7 +100,7 @@ impl Encodable for CommittedMetadata {
     fn consensus_encode<W: Write + ?Sized>(&self, w: &mut W) -> Result<usize, io::Error> {
         let mut len = 0;
         len += self.transaction_ids.consensus_encode(w)?;
-        len += hashset_to_vec_deterministic(&self.parents).consensus_encode(w)?;
+        len += self.parents.consensus_encode(w)?;
         len += self.parent_bead_timestamps.consensus_encode(w)?;
         len += self.payout_address.consensus_encode(w)?;
         len += self
@@ -120,7 +119,7 @@ impl Encodable for CommittedMetadata {
 impl Decodable for CommittedMetadata {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let transaction_ids = TxIdVec::consensus_decode(r)?;
-        let parents = vec_to_hashset(Vec::<BeadHash>::consensus_decode(r)?);
+        let parents = Vec::<BeadHash>::consensus_decode(r)?;
         let parent_bead_timestamps = TimeVec::consensus_decode(r)?;
         let payout_address = String::consensus_decode(r)?;
         let start_timestamp = Time::from_consensus(u32::consensus_decode(r).unwrap()).unwrap();

--- a/node/src/committed_metadata/tests.rs
+++ b/node/src/committed_metadata/tests.rs
@@ -1,12 +1,10 @@
 use super::*;
-use crate::utils::hashset_to_vec_deterministic;
 use crate::utils::test_utils::test_utility_functions::TestCommittedMetadataBuilder;
 use bitcoin::absolute::MedianTimePast;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::consensus::serialize;
 use bitcoin::BlockHash;
 use serde::Deserialize;
-use std::collections::HashSet;
 use std::fs;
 use std::path::Path;
 use std::str::FromStr;
@@ -214,9 +212,8 @@ fn test_committed_metadata_roundtrip_populated() {
 
     let parent1 = parse_block_hash(&data.block_hashes.parent1);
     let parent2 = parse_block_hash(&data.block_hashes.parent2);
-    let mut parents = HashSet::new();
-    parents.insert(parent1);
-    parents.insert(parent2);
+    let mut parents = vec![parent1, parent2];
+    parents.sort();
 
     let timestamps = TimeVec(vec![
         parse_time(data.timestamps.first),
@@ -254,10 +251,8 @@ fn test_committed_metadata_deterministic_parent_encoding() {
     // because hashset_to_vec_deterministic sorts the parents.
     let mut encodings = Vec::new();
     for _ in 0..5 {
-        let mut parents = HashSet::new();
-        parents.insert(parent1);
-        parents.insert(parent2);
-        parents.insert(parent3);
+        let mut parents = vec![parent1, parent2, parent3];
+        parents.sort();
 
         let metadata = TestCommittedMetadataBuilder::new()
             .transactions(vec![])
@@ -291,9 +286,7 @@ fn test_committed_metadata_serde_json_roundtrip() {
     let txid = parse_txid(&data.txids.genesis);
 
     let parent = parse_block_hash(&data.block_hashes.parent1);
-    let mut parents = HashSet::new();
-    parents.insert(parent);
-
+    let parents = vec![parent];
     let original = TestCommittedMetadataBuilder::new()
         .transactions(vec![txid])
         .parents(parents)
@@ -320,10 +313,12 @@ fn test_committed_metadata_consensus_field_order_decode() {
         parse_txid(&data.txids.second),
     ];
 
-    let mut parents = HashSet::new();
-    parents.insert(parse_block_hash(&data.block_hashes.parent2));
-    parents.insert(parse_block_hash(&data.block_hashes.parent1));
-    parents.insert(parse_block_hash(&data.block_hashes.parent3));
+    let mut parents = vec![
+        parse_block_hash(&data.block_hashes.parent2),
+        parse_block_hash(&data.block_hashes.parent1),
+        parse_block_hash(&data.block_hashes.parent3),
+    ];
+    parents.sort();
 
     let metadata = TestCommittedMetadataBuilder::new()
         .transactions(txids.clone())
@@ -357,7 +352,7 @@ fn test_committed_metadata_consensus_field_order_decode() {
     let decoded_miner_ip = String::consensus_decode(&mut reader).unwrap();
 
     assert_eq!(decoded_txids, TxIdVec(txids));
-    assert_eq!(decoded_parents, hashset_to_vec_deterministic(&parents));
+    assert_eq!(decoded_parents, parents);
     assert_eq!(
         decoded_parent_times,
         TimeVec(vec![
@@ -387,10 +382,8 @@ fn test_committed_metadata_consensus_parents_are_canonical() {
     let parent2 = parse_block_hash(&data.block_hashes.parent2);
     let parent3 = parse_block_hash(&data.block_hashes.parent3);
 
-    let mut parents = HashSet::new();
-    parents.insert(parent3);
-    parents.insert(parent1);
-    parents.insert(parent2);
+    let mut parents = vec![parent3, parent1, parent2];
+    parents.sort();
 
     let metadata = TestCommittedMetadataBuilder::new()
         .transactions(vec![])
@@ -409,7 +402,7 @@ fn test_committed_metadata_consensus_parents_are_canonical() {
     let _ = TxIdVec::consensus_decode(&mut reader).unwrap();
     let decoded_parents = Vec::<BeadHash>::consensus_decode(&mut reader).unwrap();
 
-    assert_eq!(decoded_parents, hashset_to_vec_deterministic(&parents));
+    assert_eq!(decoded_parents, parents);
 }
 
 #[test]
@@ -419,8 +412,7 @@ fn test_committed_metadata_consensus_txid_order_is_significant() {
     let txid_a = parse_txid(&data.txids.genesis);
     let txid_b = parse_txid(&data.txids.second);
 
-    let mut parents = HashSet::new();
-    parents.insert(parse_block_hash(&data.block_hashes.parent1));
+    let parents = vec![parse_block_hash(&data.block_hashes.parent1)];
 
     let metadata_ab = TestCommittedMetadataBuilder::new()
         .transactions(vec![txid_a, txid_b])

--- a/node/src/db/audit_db_handlers.rs
+++ b/node/src/db/audit_db_handlers.rs
@@ -357,6 +357,17 @@ impl AuditDBHandler {
 
         Ok(result.unwrap_or_default())
     }
+
+    pub async fn get_bead_count(&self) -> Result<i64, DBErrors> {
+        let pool = self.db_connection_pool.lock().await;
+        let row: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM AuditBead")
+            .fetch_one(&*pool)
+            .await
+            .map_err(|e| DBErrors::TupleNotFetched {
+                error: e.to_string(),
+            })?;
+        Ok(row.0)
+    }
 }
 
 #[derive(Debug, Clone, Default)]

--- a/node/src/db/audit_db_handlers.rs
+++ b/node/src/db/audit_db_handlers.rs
@@ -249,25 +249,31 @@ impl AuditDBHandler {
             error: format!("Failed to fetch parents for bead id {}: {}", bead_id, e),
         })?;
 
-        let mut parents = std::collections::HashSet::new();
-        let mut parent_timestamps = Vec::new();
+        let mut parent_pairs: Vec<(BlockHash, bitcoin::absolute::Time)> = Vec::new();
+
         for p_row in parent_rows {
             let p_hash: Vec<u8> = p_row.get("parent_block_hash");
-            parents.insert(BlockHash::from_byte_array(p_hash.try_into().map_err(
-                |_| DBErrors::TupleAttributeParsingError {
+            let hash = BlockHash::from_byte_array(p_hash.try_into().map_err(|_| {
+                DBErrors::TupleAttributeParsingError {
                     error: "Expected 32 bytes".to_string(),
                     attribute: "parent_block_hash".to_string(),
-                },
-            )?));
-            parent_timestamps.push(
-                bitcoin::absolute::MedianTimePast::from_u32(
-                    p_row.get::<i64, _>("parent_timestamp") as u32,
-                )
-                .map_err(|e| DBErrors::TupleAttributeParsingError {
-                    error: e.to_string(),
-                    attribute: "parent_timestamp".to_string(),
-                })?,
-            );
+                }
+            })?);
+            let time = bitcoin::absolute::MedianTimePast::from_u32(
+                p_row.get::<i64, _>("parent_timestamp") as u32,
+            )
+            .map_err(|e| DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "parent_timestamp".to_string(),
+            })?;
+            parent_pairs.push((hash, time));
+        }
+        parent_pairs.sort_by_key(|(hash, _)| *hash);
+        let mut parents: Vec<BlockHash> = Vec::new();
+        let mut parent_timestamps = Vec::new();
+        for (hash, time) in parent_pairs {
+            parents.push(hash);
+            parent_timestamps.push(time);
         }
 
         let bead = Bead {

--- a/node/src/db/audit_db_handlers.rs
+++ b/node/src/db/audit_db_handlers.rs
@@ -1,0 +1,380 @@
+use crate::bead::Bead;
+use crate::error::DBErrors;
+use bitcoin::BlockHash;
+use sqlx::{Pool, Sqlite};
+use std::sync::Arc;
+use tokio::sync::Mutex;
+#[allow(unused_imports)]
+use tracing::{debug, error, info, trace, warn};
+
+const INSERT_BEAD_QUERY: &str = "
+INSERT INTO AuditBead (
+    composite_hash, block_hash,
+    version, prev_block_hash, merkle_root, timestamp, bits, nonce,
+    payout_address, start_timestamp, comm_pub_key, min_target, weak_target, miner_ip,
+    extranonce1, extranonce2, broadcast_timestamp, signature,
+    created_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+";
+
+const INSERT_PARENT_QUERY: &str = "
+INSERT INTO AuditBeadParent (child_id, parent_block_hash, parent_timestamp)
+SELECT 
+    ?, 
+    unhex(json_extract(value, '$.parent_hash')), 
+    json_extract(value, '$.timestamp')
+FROM json_each(?);
+";
+
+pub struct AuditDBHandler {
+    db_connection_pool: Arc<Mutex<Pool<Sqlite>>>,
+}
+
+impl AuditDBHandler {
+    pub async fn new() -> Result<Self, DBErrors> {
+        let connection = match crate::db::init_db::init_audit_db().await {
+            Ok(conn) => conn,
+            Err(error) => {
+                error!(error = ?error, "Failed to initialize audit database connection");
+                return Err(error);
+            }
+        };
+
+        Ok(Self {
+            db_connection_pool: Arc::new(Mutex::new(connection)),
+        })
+    }
+
+    pub async fn insert_bead(
+        &self,
+        bead: &Bead,
+        composite_hash: BlockHash,
+        miner_ip: String,
+    ) -> Result<i64, DBErrors> {
+        let pool = self.db_connection_pool.lock().await;
+
+        let mut tx = match pool.begin().await {
+            Ok(tx) => tx,
+            Err(e) => {
+                return Err(DBErrors::ConnectionToSQlitePoolFailed {
+                    error: e.to_string(),
+                })
+            }
+        };
+
+        let block_hash = bead.block_header.block_hash();
+        let created_at = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+
+        let extranonce1 = format!("{:08x}", bead.uncommitted_metadata.extra_nonce_1);
+        let extranonce2 = format!("{:08x}", bead.uncommitted_metadata.extra_nonce_2);
+
+        let result = sqlx::query(INSERT_BEAD_QUERY)
+            .bind(composite_hash.as_byte_array().as_slice())
+            .bind(block_hash.as_byte_array().as_slice())
+            .bind(bead.block_header.version.to_consensus() as i64)
+            .bind(bead.block_header.prev_blockhash.as_byte_array().as_slice())
+            .bind(bead.block_header.merkle_root.as_byte_array().as_slice())
+            .bind(bead.block_header.time.to_u32() as i64)
+            .bind(bead.block_header.bits.to_consensus() as i64)
+            .bind(bead.block_header.nonce as i64)
+            .bind(&bead.committed_metadata.payout_address)
+            .bind(bead.committed_metadata.start_timestamp.to_u32() as i64)
+            .bind(bead.committed_metadata.comm_pub_key.to_bytes())
+            .bind(bead.committed_metadata.min_target.to_consensus() as i64)
+            .bind(bead.committed_metadata.weak_target.to_consensus() as i64)
+            .bind(miner_ip)
+            .bind(extranonce1)
+            .bind(extranonce2)
+            .bind(bead.uncommitted_metadata.broadcast_timestamp.to_u32() as i64)
+            .bind(bead.uncommitted_metadata.signature.to_vec())
+            .bind(created_at)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| DBErrors::TupleNotInserted {
+                error: e.to_string(),
+            })?;
+
+        let bead_id = result.last_insert_rowid();
+
+        let mut parents_data = Vec::new();
+        for (parent_hash, parent_timestamp) in bead
+            .committed_metadata
+            .parents
+            .iter()
+            .zip(bead.committed_metadata.parent_bead_timestamps.0.iter())
+        {
+            parents_data.push(serde_json::json!({
+                "parent_hash": hex::encode(parent_hash.to_byte_array()),
+                "timestamp": parent_timestamp.to_u32()
+            }));
+        }
+        let parents_json =
+            serde_json::to_string(&parents_data).map_err(|e| DBErrors::TupleNotInserted {
+                error: format!("Failed to serialize parents: {}", e),
+            })?;
+
+        if !parents_data.is_empty() {
+            sqlx::query(INSERT_PARENT_QUERY)
+                .bind(bead_id)
+                .bind(parents_json)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| DBErrors::TupleNotInserted {
+                    error: e.to_string(),
+                })?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| DBErrors::InsertionTransactionNotCommitted {
+                error: e.to_string(),
+                query_name: "Audit Bead Insertion".to_string(),
+            })?;
+
+        Ok(bead_id)
+    }
+
+    /// Shared helper to reconstruct a Bead from a database row and fetch its parents
+    async fn parse_bead_row(
+        pool: &sqlx::Pool<sqlx::Sqlite>,
+        row: sqlx::sqlite::SqliteRow,
+    ) -> Result<(Bead, BlockHash), DBErrors> {
+        use sqlx::Row;
+
+        let composite_hash_bytes: Vec<u8> = row.get("composite_hash");
+        let composite_hash = match composite_hash_bytes.try_into() {
+            Ok(arr) => BlockHash::from_byte_array(arr),
+            Err(_) => {
+                return Err(DBErrors::TupleAttributeParsingError {
+                    error: "Invalid composite hash bytes".to_string(),
+                    attribute: "composite_hash".to_string(),
+                })
+            }
+        };
+
+        let version = bitcoin::block::Version::from_consensus(row.get::<i64, _>("version") as i32);
+        let prev_hash_bytes: Vec<u8> = row.get("prev_block_hash");
+        let prev_blockhash =
+            BlockHash::from_byte_array(prev_hash_bytes.try_into().map_err(|_| {
+                DBErrors::TupleAttributeParsingError {
+                    error: "Expected 32 bytes".to_string(),
+                    attribute: "prev_block_hash".to_string(),
+                }
+            })?);
+        let merkle_bytes: Vec<u8> = row.get("merkle_root");
+        let merkle_root =
+            bitcoin::TxMerkleNode::from_byte_array(merkle_bytes.try_into().map_err(|_| {
+                DBErrors::TupleAttributeParsingError {
+                    error: "Expected 32 bytes".to_string(),
+                    attribute: "merkle_root".to_string(),
+                }
+            })?);
+        let timestamp = bitcoin::BlockTime::from_u32(row.get::<i64, _>("timestamp") as u32);
+        let bits = bitcoin::CompactTarget::from_consensus(row.get::<i64, _>("bits") as u32);
+        let nonce = row.get::<i64, _>("nonce") as u32;
+
+        let block_header = bitcoin::BlockHeader {
+            version,
+            prev_blockhash,
+            merkle_root,
+            time: timestamp,
+            bits,
+            nonce,
+        };
+
+        // Committed metadata
+        let payout_address = row.get::<String, _>("payout_address");
+        let start_timestamp = bitcoin::absolute::MedianTimePast::from_u32(
+            row.get::<i64, _>("start_timestamp") as u32,
+        )
+        .map_err(|e| DBErrors::TupleAttributeParsingError {
+            error: e.to_string(),
+            attribute: "start_timestamp".to_string(),
+        })?;
+
+        let comm_pub_key_bytes: Vec<u8> = row.get("comm_pub_key");
+        let comm_pub_key = bitcoin::PublicKey::from_slice(&comm_pub_key_bytes).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "comm_pub_key".to_string(),
+            }
+        })?;
+        let min_target =
+            bitcoin::CompactTarget::from_consensus(row.get::<i64, _>("min_target") as u32);
+        let weak_target =
+            bitcoin::CompactTarget::from_consensus(row.get::<i64, _>("weak_target") as u32);
+        let miner_ip = row.get::<String, _>("miner_ip");
+
+        // Uncommitted metadata
+        let extranonce1 =
+            u32::from_str_radix(&row.get::<String, _>("extranonce1"), 16).map_err(|e| {
+                DBErrors::TupleAttributeParsingError {
+                    error: e.to_string(),
+                    attribute: "extranonce1".to_string(),
+                }
+            })?;
+        let extranonce2 =
+            u32::from_str_radix(&row.get::<String, _>("extranonce2"), 16).map_err(|e| {
+                DBErrors::TupleAttributeParsingError {
+                    error: e.to_string(),
+                    attribute: "extranonce2".to_string(),
+                }
+            })?;
+        let broadcast_timestamp = bitcoin::absolute::MedianTimePast::from_u32(
+            row.get::<i64, _>("broadcast_timestamp") as u32,
+        )
+        .map_err(|e| DBErrors::TupleAttributeParsingError {
+            error: e.to_string(),
+            attribute: "broadcast_timestamp".to_string(),
+        })?;
+        let signature_bytes: Vec<u8> = row.get("signature");
+        let signature = bitcoin::ecdsa::Signature::from_slice(&signature_bytes).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "signature".to_string(),
+            }
+        })?;
+        // Fetch parents for this specific bead
+        let bead_id: i64 = row.get("id");
+        let parent_rows = sqlx::query(
+            "SELECT parent_block_hash, parent_timestamp FROM AuditBeadParent WHERE child_id = ?",
+        )
+        .bind(bead_id)
+        .fetch_all(pool)
+        .await
+        .map_err(|e| DBErrors::TupleNotFetched {
+            error: format!("Failed to fetch parents for bead id {}: {}", bead_id, e),
+        })?;
+
+        let mut parents = std::collections::HashSet::new();
+        let mut parent_timestamps = Vec::new();
+        for p_row in parent_rows {
+            let p_hash: Vec<u8> = p_row.get("parent_block_hash");
+            parents.insert(BlockHash::from_byte_array(p_hash.try_into().map_err(
+                |_| DBErrors::TupleAttributeParsingError {
+                    error: "Expected 32 bytes".to_string(),
+                    attribute: "parent_block_hash".to_string(),
+                },
+            )?));
+            parent_timestamps.push(
+                bitcoin::absolute::MedianTimePast::from_u32(
+                    p_row.get::<i64, _>("parent_timestamp") as u32,
+                )
+                .map_err(|e| DBErrors::TupleAttributeParsingError {
+                    error: e.to_string(),
+                    attribute: "parent_timestamp".to_string(),
+                })?,
+            );
+        }
+
+        let bead = Bead {
+            block_header,
+            committed_metadata: crate::committed_metadata::CommittedMetadata {
+                transaction_ids: crate::TxIdVec(Vec::new()),
+                parents,
+                parent_bead_timestamps: crate::TimeVec(parent_timestamps),
+                payout_address,
+                start_timestamp,
+                comm_pub_key,
+                min_target,
+                weak_target,
+                miner_ip,
+            },
+            uncommitted_metadata: crate::uncommitted_metadata::UnCommittedMetadata {
+                extra_nonce_1: extranonce1,
+                extra_nonce_2: extranonce2,
+                broadcast_timestamp,
+                signature,
+            },
+        };
+
+        Ok((bead, composite_hash))
+    }
+
+    // Used to return the current active tips in audit braid
+    pub async fn get_tips(&self) -> Result<Vec<(Bead, BlockHash)>, DBErrors> {
+        let pool = self.db_connection_pool.lock().await;
+
+        let rows = sqlx::query(
+            r#"
+            SELECT * FROM AuditBead 
+            WHERE block_hash NOT IN (
+                SELECT parent_block_hash FROM AuditBeadParent
+            )
+            "#,
+        )
+        .fetch_all(&*pool)
+        .await
+        .map_err(|e| DBErrors::TupleNotFetched {
+            error: format!("Failed to fetch DAG tips: {}", e),
+        })?;
+
+        let mut tips = Vec::new();
+        for row in rows {
+            match Self::parse_bead_row(&pool, row).await {
+                Ok(parsed) => tips.push(parsed),
+                Err(e) => {
+                    error!(error = ?e, "Failed to parse bead row, skipping entry");
+                }
+            }
+        }
+
+        Ok(tips)
+    }
+
+    pub async fn get_bead_by_composite_hash(
+        &self,
+        composite_hash: &BlockHash,
+    ) -> Result<Option<i64>, DBErrors> {
+        let pool = self.db_connection_pool.lock().await;
+
+        let result =
+            sqlx::query_scalar::<_, i64>("SELECT id FROM AuditBead WHERE composite_hash = ?")
+                .bind(composite_hash.as_byte_array().as_slice())
+                .fetch_optional(&*pool)
+                .await
+                .map_err(|e| DBErrors::TupleNotFetched {
+                    error: e.to_string(),
+                })?;
+
+        Ok(result)
+    }
+
+    pub async fn get_miner_stats(&self, miner_ip: &str) -> Result<MinerStats, DBErrors> {
+        let pool = self.db_connection_pool.lock().await;
+
+        let result =
+            sqlx::query_as::<_, MinerStats>("SELECT * FROM MinerStatsView WHERE miner_ip = ?")
+                .bind(miner_ip)
+                .fetch_optional(&*pool)
+                .await
+                .map_err(|e| DBErrors::TupleNotFetched {
+                    error: e.to_string(),
+                })?;
+
+        Ok(result.unwrap_or_default())
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct MinerStats {
+    pub miner_ip: String,
+    pub total_valid_beads: i64,
+    pub first_bead_at: Option<i64>,
+    pub last_bead_at: Option<i64>,
+}
+
+impl sqlx::FromRow<'_, sqlx::sqlite::SqliteRow> for MinerStats {
+    fn from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Self, sqlx::Error> {
+        use sqlx::Row;
+        Ok(Self {
+            miner_ip: row.try_get("miner_ip")?,
+            total_valid_beads: row.try_get("total_valid_beads")?,
+            first_bead_at: row.try_get("first_bead_at")?,
+            last_bead_at: row.try_get("last_bead_at")?,
+        })
+    }
+}

--- a/node/src/db/audit_schema.sql
+++ b/node/src/db/audit_schema.sql
@@ -1,0 +1,64 @@
+-- Braidpool Audit Mode Database Schema                
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS AuditBead (
+    id                  INTEGER PRIMARY KEY,
+    composite_hash      BLOB NOT NULL UNIQUE,       
+    block_hash          BLOB NOT NULL UNIQUE,           
+    version             INTEGER NOT NULL CHECK (version >= 0 AND version < 0x100000000),
+    prev_block_hash     BLOB NOT NULL,
+    merkle_root         BLOB NOT NULL,
+    timestamp           INTEGER NOT NULL CHECK (timestamp >= 0 AND timestamp < 0x100000000),
+    bits                INTEGER NOT NULL CHECK (bits >= 0 AND bits < 0x100000000),
+    nonce               INTEGER NOT NULL CHECK (nonce >= 0 AND nonce < 0x100000000),    
+    payout_address      TEXT NOT NULL,
+    start_timestamp     INTEGER NOT NULL,
+    comm_pub_key        BLOB NOT NULL,
+    min_target          INTEGER NOT NULL CHECK (min_target >= 0 AND min_target < 0x100000000),
+    weak_target         INTEGER NOT NULL CHECK (weak_target >= 0 AND weak_target < 0x100000000),
+    miner_ip            TEXT NOT NULL,    
+    extranonce1         TEXT NOT NULL,
+    extranonce2         TEXT NOT NULL,
+    broadcast_timestamp INTEGER NOT NULL,
+    signature           BLOB NOT NULL,    
+    created_at          INTEGER NOT NULL,
+    UNIQUE (version, prev_block_hash, merkle_root, timestamp, bits, nonce)
+);
+
+-- Represents DAG parent relationships
+CREATE TABLE IF NOT EXISTS AuditBeadParent (
+    child_id            INTEGER NOT NULL,
+    parent_block_hash BLOB NOT NULL,            
+    parent_timestamp    INTEGER NOT NULL,           
+    
+    PRIMARY KEY (child_id, parent_block_hash),
+    FOREIGN KEY (child_id) REFERENCES AuditBead(id) ON DELETE CASCADE
+);
+
+-- Indexes
+CREATE INDEX IF NOT EXISTS idx_audit_bead_composite ON AuditBead(composite_hash);
+CREATE INDEX IF NOT EXISTS idx_audit_bead_block ON AuditBead(block_hash);
+CREATE INDEX IF NOT EXISTS idx_audit_bead_miner ON AuditBead(miner_ip);
+CREATE INDEX IF NOT EXISTS idx_audit_bead_created ON AuditBead(created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_audit_parent_child ON AuditBeadParent(child_id);
+CREATE INDEX IF NOT EXISTS idx_audit_parent_hash ON AuditBeadParent(parent_block_hash);
+
+-- Views 
+-- Real time health and performance statistics for each connected miner.
+CREATE VIEW IF NOT EXISTS MinerStatsView AS
+SELECT 
+    miner_ip,
+    COUNT(*) as total_valid_beads,
+    MIN(created_at) as first_bead_at,
+    MAX(created_at) as last_bead_at
+FROM AuditBead
+GROUP BY miner_ip;
+
+-- Audit DAG tips view
+CREATE VIEW IF NOT EXISTS AuditTips AS
+SELECT ab.*
+FROM AuditBead ab
+LEFT JOIN AuditBeadParent abp ON abp.parent_block_hash = ab.block_hash
+WHERE abp.child_id IS NULL;

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -403,6 +403,8 @@ pub async fn fetch_beads_in_batch(
                         error: e.to_string(),
                     })?;
 
+            let mut parent_pairs_batch: Vec<(BlockHash, bitcoin::absolute::MedianTimePast)> =
+                Vec::new();
             for parent in parent_rows {
                 let parent_id = parent.get::<i64, _>("parent");
                 let timestamp = parent.get::<i32, _>("timestamp");
@@ -417,9 +419,15 @@ pub async fn fetch_beads_in_batch(
 
                 match parent_hash_row.get::<Vec<u8>, _>("hash").try_into() {
                     Ok(arr) => {
-                        bead.committed_metadata
-                            .parents
-                            .insert(BlockHash::from_byte_array(arr));
+                        parent_pairs_batch.push((
+                            BlockHash::from_byte_array(arr),
+                            MedianTimePast::from_u32(timestamp as u32).map_err(|e| {
+                                DBErrors::TupleAttributeParsingError {
+                                    error: format!("Invalid timestamp {}: {}", timestamp, e),
+                                    attribute: "parent_timestamp".into(),
+                                }
+                            })?,
+                        ));
                     }
                     Err(_) => {
                         return Err(DBErrors::TupleAttributeParsingError {
@@ -428,11 +436,12 @@ pub async fn fetch_beads_in_batch(
                         });
                     }
                 };
+            }
 
-                bead.committed_metadata
-                    .parent_bead_timestamps
-                    .0
-                    .push(MedianTimePast::from_u32(timestamp as u32).unwrap());
+            parent_pairs_batch.sort_by_key(|(hash, _)| *hash);
+            for (hash, time) in parent_pairs_batch {
+                bead.committed_metadata.parents.push(hash);
+                bead.committed_metadata.parent_bead_timestamps.0.push(time);
             }
 
             fetched_beads.push(bead);
@@ -552,6 +561,8 @@ pub async fn fetch_bead_by_bead_hash(
                 });
             }
         };
+
+    let mut parent_pairs_single: Vec<(BlockHash, MedianTimePast)> = Vec::new();
     for parent_beads in parent_timestamp_rows {
         let parent_timestamp = parent_beads.get::<i32, _>("timestamp");
         let parent_bead_id = parent_beads.get::<i64, _>("parent");
@@ -578,18 +589,27 @@ pub async fn fetch_bead_by_bead_hash(
                 });
             }
         };
-        //Extending parent bead timestamp
+        parent_pairs_single.push((
+            parent_blockhash,
+            MedianTimePast::from_u32(parent_timestamp as u32).map_err(|e| {
+                DBErrors::TupleAttributeParsingError {
+                    error: format!("Invalid timestamp {}: {}", parent_timestamp, e),
+                    attribute: "parent_timestamp".into(),
+                }
+            })?,
+        ));
+    }
+
+    parent_pairs_single.sort_by_key(|(hash, _)| *hash);
+    for (hash, time) in parent_pairs_single {
+        fetched_bead.committed_metadata.parents.push(hash);
         fetched_bead
             .committed_metadata
             .parent_bead_timestamps
             .0
-            .push(MedianTimePast::from_u32(parent_timestamp as u32).unwrap());
-        //Extending parent committment by parent hash
-        fetched_bead
-            .committed_metadata
-            .parents
-            .insert(parent_blockhash);
+            .push(time);
     }
+
     for tx_row in rows {
         let _txid = tx_row.get::<Vec<u8>, _>("txid");
         let raw_tx_id = match _txid.clone().try_into() {

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -5,9 +5,18 @@ use crate::error::DBErrors;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 static SCHEMA_SQL: &str = include_str!("schema.sql");
+static AUDIT_SCHEMA_SQL: &str = include_str!("audit_schema.sql");
 
 pub async fn init_db() -> Result<SqlitePool, DBErrors> {
-    //Fetching the home directory
+    setup_sqlite_db("braidpool.db", SCHEMA_SQL).await
+}
+
+pub async fn init_audit_db() -> Result<SqlitePool, DBErrors> {
+    setup_sqlite_db("audit.db", AUDIT_SCHEMA_SQL).await
+}
+
+async fn setup_sqlite_db(db_name: &str, schema_sql: &str) -> Result<SqlitePool, DBErrors> {
+    // Fetching the home directory
     let home_dir = match env::var("HOME") {
         Ok(fetched_var) => fetched_var,
         Err(error) => {
@@ -18,27 +27,22 @@ pub async fn init_db() -> Result<SqlitePool, DBErrors> {
         }
     };
     let db_dir = Path::new(&home_dir).join(".braidpool");
-    //Final db directory path
-    let db_path = db_dir.join("braidpool.db");
-    //Creating db directory if it doesn't exist
+    let db_path = db_dir.join(db_name);
     let dir_exists = db_dir.exists();
-    match fs::create_dir_all(&db_dir) {
-        Ok(_) => {
-            if !dir_exists {
-                info!("DB directory created successfully");
-            }
-        }
-        Err(error) => {
-            return Err(DBErrors::DBDirectoryNotCreated {
-                error: error.to_string(),
-                path: db_path,
-            });
-        }
-    };
-    //sqlite db url
-    let db_url = format!("sqlite://{}", db_path.to_string_lossy());
+
+    // Create db directory if it doesn't exist
+    if let Err(error) = fs::create_dir_all(&db_dir) {
+        return Err(DBErrors::DBDirectoryNotCreated {
+            error: error.to_string(),
+            path: db_path,
+        });
+    } else if !dir_exists {
+        info!("DB directory created successfully");
+    }
+
     let db_exists = db_path.exists();
-    //SQl connection configurations
+    let db_url = format!("sqlite://{}", db_path.to_string_lossy());
+    // SQl connection configurations
     let db_config = match SqliteConnectOptions::from_str(&db_url) {
         Ok(config) => config,
         Err(error) => {
@@ -51,45 +55,41 @@ pub async fn init_db() -> Result<SqlitePool, DBErrors> {
     let sql_lite_connections = db_config
         .foreign_keys(true)
         .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
-    //Initializing connection to existing DB
-    let conn = if db_exists {
-        info!(
-            db_path = %db_path.display(),
-            "Using existing database"
-        );
-        let pool = match SqlitePool::connect_with(sql_lite_connections).await {
-            Ok(initialized_pool) => initialized_pool,
-            Err(error) => {
-                return Err(DBErrors::ConnectionToSQlitePoolFailed {
-                    error: error.to_string(),
-                });
-            }
-        };
-        pool
+
+    let pool = if db_exists {
+        info!(db_path = %db_path.display(), "Using existing database");
+        SqlitePool::connect_with(sql_lite_connections)
+            .await
+            .map_err(|error| DBErrors::ConnectionToSQlitePoolFailed {
+                error: error.to_string(),
+            })?
     } else {
-        let _file = std::fs::File::create_new(db_path.clone());
-        let pool = match SqlitePool::connect_with(sql_lite_connections).await {
-            Ok(initialized_pool) => initialized_pool,
-            Err(error) => {
-                return Err(DBErrors::ConnectionToSQlitePoolFailed {
-                    error: error.to_string(),
-                });
-            }
-        };
-        let _query_result = match pool.execute(SCHEMA_SQL).await {
-            Ok(_res) => {
-                info!(
-                    db_path = %db_path.display(),
-                    "Database schema initialized"
-                );
-            }
-            Err(error) => {
-                return Err(DBErrors::SchemaNotInitialized {
-                    error: error.to_string(),
-                    db_path: db_path,
-                })
-            }
-        };
+        info!(db_path = %db_path.display(), "Creating new database");
+        if let Err(e) = std::fs::File::create_new(&db_path) {
+            error!(
+                db_path = %db_path.display(),
+                error = %e,
+                "Failed to create database file"
+            );
+            return Err(DBErrors::DBDirectoryNotCreated {
+                error: e.to_string(),
+                path: db_path.clone(),
+            });
+        }
+
+        let pool = SqlitePool::connect_with(sql_lite_connections)
+            .await
+            .map_err(|error| DBErrors::ConnectionToSQlitePoolFailed {
+                error: error.to_string(),
+            })?;
+
+        pool.execute(schema_sql)
+            .await
+            .map_err(|error| DBErrors::SchemaNotInitialized {
+                error: error.to_string(),
+                db_path: db_path.clone(),
+            })?;
+        info!(db_path = %db_path.display(), "Database schema initialized");
 
         // Force WAL checkpoint to flush schema changes to disk
         match sqlx::query("PRAGMA wal_checkpoint(FULL)")
@@ -106,5 +106,5 @@ pub async fn init_db() -> Result<SqlitePool, DBErrors> {
         pool
     };
 
-    Ok(conn)
+    Ok(pool)
 }

--- a/node/src/db/mod.rs
+++ b/node/src/db/mod.rs
@@ -1,5 +1,6 @@
 #![allow(non_snake_case)]
 use crate::bead::Bead;
+pub mod audit_db_handlers;
 pub mod db_handlers;
 pub mod init_db;
 

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -5,12 +5,7 @@ use bitcoin::{
     CompactTarget, EcdsaSighashType, Txid,
 };
 use num::ToPrimitive;
-use std::{
-    collections::{HashMap, HashSet},
-    str::FromStr,
-    sync::Arc,
-    time::UNIX_EPOCH,
-};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::UNIX_EPOCH};
 
 use futures::lock::Mutex;
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -324,19 +319,27 @@ impl SwarmHandler {
         let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
             .parse::<bitcoin::PublicKey>()
             .unwrap();
-        let mut time_hash_set = TimeVec(Vec::new());
-        let mut parent_hash_set: HashSet<BlockHash> = HashSet::new();
         let mut braid_data = self.braid_arc.write().await;
-        let tips_index = &braid_data.tips;
-        //Committing parents data in bead
-        for tip_bead in tips_index {
-            let current_tip_bead = braid_data.beads.get(*tip_bead).unwrap();
-            parent_hash_set.insert(current_tip_bead.block_header.block_hash());
-            time_hash_set
-                .0
-                .push(current_tip_bead.committed_metadata.start_timestamp);
+        let mut pairs: Vec<(BlockHash, bitcoin::absolute::Time)> = braid_data
+            .tips
+            .iter()
+            .map(|&idx| {
+                let tip = braid_data.beads.get(idx).unwrap();
+                (
+                    tip.block_header.block_hash(),
+                    tip.committed_metadata.start_timestamp,
+                )
+            })
+            .collect();
+        pairs.sort_by_key(|(hash, _)| *hash);
+
+        let mut time_hash_set = TimeVec(Vec::new());
+        let mut parent_hash_set: Vec<BlockHash> = Vec::new();
+        for (hash, time) in pairs {
+            parent_hash_set.push(hash);
+            time_hash_set.0.push(time);
         }
-        debug!(tip_indices = ?tips_index, tip_hashes = ?parent_hash_set,
+        debug!(tip_indices = ?braid_data.tips, tip_hashes = ?parent_hash_set,
             "Tips before extending the Braid");
         //TODO:This will be replaced via the allotted `WeakShareDifficulty` after Difficulty adjustment
         let weak_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -80,53 +80,66 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Initializing the braid object with read write lock
     //for supporting concurrent readers and single writer
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(Vec::from([]))));
-    //Initializing DB and db command handler
-    let (mut _db_handler, db_tx) = DBHandler::new().await.map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::Other,
-            format!("Database initialization failed: {:?}", e),
-        )
-    })?;
-    let db_connection_pool = _db_handler.db_connection_pool.clone();
-    //Reconstructing local braid upon startup
-    let db_connection_pool_ref = _db_handler.db_connection_pool.clone();
-    let braid_ref = braid.clone();
-    // FIXME instead we should look 144 blocks back from the bitcoin tip (1 day) and load beads
-    // starting from that block as genesis
-    let initial_bead_fetch_handle = tokio::spawn(async move {
-        let mut guard = braid_ref.write().await;
-        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000).await?;
-        for bead in &fetched_beads {
-            let curr_bead_status = guard.extend(&bead);
-            debug!(
-                hash = ?bead.block_header.block_hash(),
-                status = ?curr_bead_status,
-                "Bead inserted"
-            );
+    let mut optional_db_pool = None;
+    let db_tx;
+
+    if !args.audit {
+        //Initializing DB and db command handler
+        let (mut db_handler, tx) = DBHandler::new().await.map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::Other,
+                format!("Database initialization failed: {:?}", e),
+            )
+        })?;
+        db_tx = tx;
+        optional_db_pool = Some(db_handler.db_connection_pool.clone());
+        //Reconstructing local braid upon startup
+        let db_connection_pool_ref = db_handler.db_connection_pool.clone();
+
+        //Starting the `query_handler` task
+        tokio::spawn(async move {
+            let _res = db_handler.insert_query_handler().await;
+        });
+
+        let braid_ref = braid.clone();
+        // FIXME instead we should look 144 blocks back from the bitcoin tip (1 day) and load beads
+        // starting from that block as genesis
+        let initial_bead_fetch_handle = tokio::spawn(async move {
+            let mut guard = braid_ref.write().await;
+            let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 1000).await?;
+            for bead in &fetched_beads {
+                let curr_bead_status = guard.extend(&bead);
+                debug!(hash = ?bead.block_header.block_hash(), status = ?curr_bead_status, "Bead inserted");
+            }
+            info!(beads = fetched_beads.len(), "Beads loaded from DB");
+            Ok::<(), node::error::DBErrors>(())
+        });
+
+        match initial_bead_fetch_handle.await {
+            Ok(Ok(())) => info!("Initial bead fetch completed successfully"),
+            Ok(Err(e)) => {
+                error!(error = ?e, "Failed to fetch beads from DB during startup");
+                return Err(format!("Database bead fetch failed: {:?}", e).into());
+            }
+            Err(e) => {
+                return Err(format!("Initial bead fetch task failed: {}", e).into());
+            }
         }
-        info!(beads = fetched_beads.len(), "Beads loaded from DB");
-        Ok::<(), node::error::DBErrors>(())
-    });
-    match initial_bead_fetch_handle.await {
-        Ok(Ok(())) => {
-            info!("Initial bead fetch completed successfully");
-        }
-        Ok(Err(e)) => {
-            error!(error = ?e, "Failed to fetch beads from DB during startup");
-            return Err(format!("Database bead fetch failed: {:?}", e).into());
-        }
-        Err(e) => {
-            error!(error = ?e, "Initial bead fetch task panicked");
-            return Err(format!("Initial bead fetch task panicked: {}", e).into());
-        }
+    } else {
+        // Create a dummy channel for SwarmHandler so it doesn't crash when it tries to broadcast in audit mode
+        let (tx, mut rx) = mpsc::channel(1);
+        db_tx = tx;
+
+        // Keep the receiver alive in a background sink so channel sends don't fail
+        tokio::spawn(async move {
+            while let Some(msg) = rx.recv().await {
+                trace!(message = ?msg, "Audit dummy sink; Dropping standard DB message");
+            }
+        });
     }
     let latest_template_id = Arc::new(Mutex::new(TemplateId::default()));
     let latest_template_id_for_notifier = latest_template_id.clone();
     let latest_template_id_for_consumer = latest_template_id.clone();
-    //Starting the `query_handler` task
-    tokio::spawn(async move {
-        let _res = _db_handler.insert_query_handler().await;
-    });
     //latest available template to be cached for the newest connection until new job is received
     let latest_template = Arc::new(Mutex::new(BlockTemplate::default()));
     //latest available template merkle branch
@@ -215,7 +228,37 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
 
         // Initialize audit records
-        let audit_dag = Arc::new(Mutex::new(audit::AuditDAG::new(Arc::clone(&braid))));
+        let audit_dag = match audit::AuditDAG::new_with_db(Arc::clone(&braid)).await {
+            Ok(dag) => Arc::new(Mutex::new(dag)),
+            Err(e) => {
+                error!("Failed to initialize audit DAG with database: {}", e);
+                std::process::exit(1);
+            }
+        };
+
+        match audit_dag.lock().await.load_from_db().await {
+            Ok(Some(latest_composite_hash)) => {
+                let commitment_bytes = latest_composite_hash.to_byte_array()
+                    [..crate::audit::COMMITMENT_BYTES]
+                    .to_vec();
+                let mut conn_map = connection_mapping.lock().await;
+                conn_map.current_bead_commitment = commitment_bytes.clone();
+                drop(conn_map);
+
+                info!(
+                    commitment = %hex::encode(&commitment_bytes),
+                    composite_hash = %latest_composite_hash,
+                    "Restored global bead commitment from database"
+                );
+            }
+            Ok(None) => {
+                info!("No previous beads in database, starting from genesis commitment");
+            }
+            Err(e) => {
+                warn!("Failed to load bead from database: {}", e);
+            }
+        }
+
         let audit_dag_for_notifier_inner: Option<Arc<Mutex<audit::AuditDAG>>> =
             Some(audit_dag.clone());
         let audit_dag_for_stratum = audit_dag.clone();
@@ -428,7 +471,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         let connection_mapping_for_upstream = connection_mapping.clone();
         let upstream_task_token = main_task_token.clone();
         let mut upstream_ready_tx_option = Some(upstream_ready_tx);
-        let braid_for_upstream = braid.clone();
         tokio::spawn(async move {
             // Reconnection state
             let mut retry_count: u32 = 0;
@@ -529,8 +571,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
                     Some(upstream_difficulty_tx),
                     configure_rx.clone(),
                     upstream_cache_clone.clone(),
-                    Arc::clone(&braid_for_upstream),
                     audit_log_tx.clone(),
+                    audit_dag.clone(),
                 );
 
                 // Mark upstream as connected
@@ -841,35 +883,38 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     //adding the boot nodes for peer discovery
     swarm.listen_on(multi_addr.clone())?;
-    for boot_peer in BOOTNODES {
-        let peer_id = match boot_peer.parse::<PeerId>() {
-            Ok(id) => id,
-            Err(e) => {
-                error!(boot_peer = %boot_peer, error = %e, "Failed to parse boot peer ID, skipping");
-                continue;
-            }
-        };
-        let seed_addr = match SEED_DNS.parse::<Multiaddr>() {
-            Ok(addr) => addr,
-            Err(e) => {
-                error!(seed_dns = %SEED_DNS, error = %e, "Failed to parse seed DNS, skipping");
-                continue;
-            }
-        };
-        swarm
-            .behaviour_mut()
-            .kademlia
-            .add_address(&peer_id, seed_addr);
+    if !args.audit {
+        for boot_peer in BOOTNODES {
+            let peer_id = match boot_peer.parse::<PeerId>() {
+                Ok(id) => id,
+                Err(e) => {
+                    error!(boot_peer = %boot_peer, error = %e, "Failed to parse boot peer ID, skipping");
+                    continue;
+                }
+            };
+            let seed_addr = match SEED_DNS.parse::<Multiaddr>() {
+                Ok(addr) => addr,
+                Err(e) => {
+                    error!(seed_dns = %SEED_DNS, error = %e, "Failed to parse seed DNS, skipping");
+                    continue;
+                }
+            };
+            swarm
+                .behaviour_mut()
+                .kademlia
+                .add_address(&peer_id, seed_addr);
+        }
+
+        info!(boot_node_count = %BOOTNODES.len(), "Boot nodes added to DHT");
+        let boot_addr: Multiaddr = ADDR_REFRENCE.parse().map_err(|e| {
+            std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("Failed to parse boot address: {}", e),
+            )
+        })?;
+        swarm.dial(boot_addr)?;
+        info!(address = %ADDR_REFRENCE, "Dialed boot node");
     }
-    info!(boot_node_count = %BOOTNODES.len(), "Boot nodes added to DHT");
-    let boot_addr: Multiaddr = ADDR_REFRENCE.parse().map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Failed to parse boot address: {}", e),
-        )
-    })?;
-    swarm.dial(boot_addr)?;
-    info!(address = %ADDR_REFRENCE, "Dialed boot node");
     //IPC(inter process communication) based `getblocktemplate` and `notification` to send to the downstream via the `cmempoold` architecture
     info!(socket = %args.ipc_socket, "IPC socket path");
 
@@ -1042,6 +1087,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                      SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
                          floodsub::FloodsubEvent::Message(message),
                      )) => {
+                        if args.audit {
+                            trace!(source = ?message.source, "Audit mode: Ignoring gossip bead");
+                            continue;
+                        }
                          info!(
                              topics = ?message.topics,
                              source = ?message.source,
@@ -1096,40 +1145,42 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         // update the peer manager about the invalid bead
                                         peer_manager.penalize_for_invalid_bead(&message.source);
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
-                                     //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
-                                                continue;
-                                            }
-                                        };
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
+                                        if !args.audit {
+                                            //Considering the index of the beads in braid will be same as the (insertion ids-1)
+                                            let bead_id = match braid_data
+                                                .bead_index_mapping
+                                                .get(&bead.block_header.block_hash()) {
+                                                Some(id) => id,
+                                                None => {
+                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
+                                                    continue;
+                                                }
+                                            };
+                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                                &braid_data.beads,
+                                                &braid_data.bead_index_mapping,
+                                                &bead,
+                                            ){
+                                                Ok(received_tuples)=>received_tuples,
+                                                Err(error)=>{
+                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                    continue;
+                                                }
+                                            };
+                                            // update score of the peer and adding to local db store
+                                            let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
+                                            Ok(_)=>{
+                                                debug!("Insert command sent successfully to db handler after receiving bead from peer");
+                                            },
                                             Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                continue;
+                                                error!(
+                                                    source = ?message.source,
+                                                    err = ?error.0,
+                                                    "An error occurred while sending insert bead command received from peer"
+                                                );
                                             }
                                         };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                           Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
+                                    }
                                         peer_manager.update_score(&message.source, 1.0);
                                     }
                                     for (sync_peer, ibd_ts) in timestamp_map.iter() {
@@ -1203,39 +1254,41 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         // update the peer manager about the invalid bead
                                         peer_manager.penalize_for_invalid_bead(&message.source);
                                     } else if let braid::AddBeadStatus::BeadAdded = status {
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
-                                                continue;
-                                            }
-                                        };
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
+                                        if !args.audit {
+                                            let bead_id = match braid_data
+                                                .bead_index_mapping
+                                                .get(&bead.block_header.block_hash()) {
+                                                Some(id) => id,
+                                                None => {
+                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
+                                                    continue;
+                                                }
+                                            };
+                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                                &braid_data.beads,
+                                                &braid_data.bead_index_mapping,
+                                                &bead,
+                                            ){
+                                                Ok(received_tuples)=>received_tuples,
+                                                Err(error)=>{
+                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                    continue;
+                                                }
+                                            };
+                                            // update score of the peer and adding to local db store
+                                            let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
+                                                Ok(_)=>{
+                                                debug!("Insert command sent successfully to db handler after receiving bead from peer");
+                                            },
                                             Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                continue;
+                                                error!(
+                                                    source = ?message.source,
+                                                    err = ?error.0,
+                                                    "An error occurred while sending insert bead command received from peer"
+                                                );
                                             }
-                                        };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                            Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
+                                            };
+                                        }
                                         peer_manager.update_score(&message.source, 1.0);
                                     }
                                 }
@@ -1525,41 +1578,43 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             // update the peer manager about the invalid bead
                                             peer_manager.penalize_for_invalid_bead(&peer);
                                         } else if let braid::AddBeadStatus::BeadAdded = status {
-                                            let bead_id = match braid_data
-                                                .bead_index_mapping
-                                                .get(&bead.block_header.block_hash()) {
-                                                Some(id) => id,
-                                                None => {
-                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
-                                                    continue;
-                                                }
-                                            };
-                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                                &braid_data.beads,
-                                                &braid_data.bead_index_mapping,
-                                                &bead,
-                                            ){
-                                                Ok(received_tuples)=>received_tuples,
-                                                Err(error)=>{
-                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
-                                                    continue;
-                                                }
-                                            };
-                                            // update score of the peer
-                                            peer_manager.update_score(&peer, 1.0);
-                                            //persisting the received beads from peer onto DB(disk)
-                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
-                                                Ok(_)=>{
-                                                    debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
-                                                },
-                                                Err(error)=>{
-                                                    tracing::error!(
-                                                        peer = %peer,
-                                                        err = ?error.0,
-                                                        "An error occurred while persisting received bead from peer"
-                                                    );
-                                                }
-                                            };
+                                            if !args.audit {
+                                                let bead_id = match braid_data
+                                                    .bead_index_mapping
+                                                    .get(&bead.block_header.block_hash()) {
+                                                    Some(id) => id,
+                                                    None => {
+                                                        error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
+                                                        continue;
+                                                    }
+                                                };
+                                                let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                                    &braid_data.beads,
+                                                    &braid_data.bead_index_mapping,
+                                                    &bead,
+                                                ){
+                                                    Ok(received_tuples)=>received_tuples,
+                                                    Err(error)=>{
+                                                        error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
+                                                        continue;
+                                                    }
+                                                };
+                                                // update score of the peer
+                                                peer_manager.update_score(&peer, 1.0);
+                                                //persisting the received beads from peer onto DB(disk)
+                                                match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
+                                                    Ok(_)=>{
+                                                        debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
+                                                    },
+                                                    Err(error)=>{
+                                                        tracing::error!(
+                                                            peer = %peer,
+                                                            err = ?error.0,
+                                                            "An error occurred while persisting received bead from peer"
+                                                        );
+                                                    }
+                                                };
+                                            }
                                         }
                                     }
                                     //Preparing next batch request to be sent to the sync node
@@ -1993,11 +2048,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
             main_task_token.cancel();
 
             info!(component = "database", "Closing connection pool");
-            let pool = db_connection_pool.lock().await;
-            //Closing all the existing connections to pool and committing from .db-wal to .db
-            pool.close().await;
-            info!(component = "database", "Connections closed");
-
+            if let Some(pool_arc) = optional_db_pool {
+                let pool = pool_arc.lock().await;
+                // Closing all the existing connections to pool and committing from .db-wal to .db
+                pool.close().await;
+                info!(component = "database", "Connections closed");
+            }
             // Give tasks time to drain
             tokio::time::sleep(Duration::from_millis(100)).await;
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -442,6 +442,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                         Some(job) => {
                             info!("Received job from upstream pool: {}", job.job_id);
 
+                            // Marking each job as clean_jobs=true to make the DAG consistent and consensus correct, without
+                            // that a miner can produce shares which use the previous commitment on lower difficulties
+                            // or in general.
+                            let mut job = job;
+                            job.clean_jobs = true;
+
                             if let Err(e) = notification_tx_for_upstream_jobs
                                 .send(NotifyCmd::SendUpstreamJob {
                                     job_notification: job,
@@ -881,9 +887,9 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //setting the server mode for the kademlia apart from the server
     swarm.behaviour_mut().kademlia.set_mode(Some(Mode::Server));
 
-    //adding the boot nodes for peer discovery
-    swarm.listen_on(multi_addr.clone())?;
     if !args.audit {
+        //adding the boot nodes for peer discovery
+        swarm.listen_on(multi_addr.clone())?;
         for boot_peer in BOOTNODES {
             let peer_id = match boot_peer.parse::<PeerId>() {
                 Ok(id) => id,
@@ -1024,1006 +1030,1008 @@ async fn main() -> Result<(), Box<dyn Error>> {
         info!("Skipping IPC connection, audit mode enabled using upstream pool jobs");
         None
     };
-
-    if let Some(addnode) = args.addnode {
-        for node in addnode.iter() {
-            let node_multiaddr: Multiaddr = match node.parse() {
-                Ok(addr) => addr,
-                Err(e) => {
-                    error!(node = %node, error = %e, "Failed to parse multiaddr, skipping");
+    if !args.audit {
+        if let Some(addnode) = args.addnode {
+            for node in addnode.iter() {
+                let node_multiaddr: Multiaddr = match node.parse() {
+                    Ok(addr) => addr,
+                    Err(e) => {
+                        error!(node = %node, error = %e, "Failed to parse multiaddr, skipping");
+                        continue;
+                    }
+                };
+                let dial_result = swarm.dial(node_multiaddr.clone());
+                if let Some(err) = dial_result.err() {
+                    error!(address = %node_multiaddr, error = %err, "Failed to dial peer node");
                     continue;
                 }
-            };
-            let dial_result = swarm.dial(node_multiaddr.clone());
-            if let Some(err) = dial_result.err() {
-                error!(address = %node_multiaddr, error = %err, "Failed to dial peer node");
-                continue;
+                info!(address = %node_multiaddr, "Dialed peer node");
             }
-            info!(address = %node_multiaddr, "Dialed peer node");
-        }
-    };
-    let swarm_handle = tokio::spawn(async move {
-        let braid = std::sync::Arc::clone(&braid);
-        loop {
-            tokio::select! {
-             swarm_event = swarm.select_next_some()=>{
-                 match swarm_event{
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
-                         kad::Event::RoutingUpdated {
+        };
+    }
+    let swarm_handle = if !args.audit {
+        tokio::spawn(async move {
+            let braid = std::sync::Arc::clone(&braid);
+            loop {
+                tokio::select! {
+                  swarm_event = swarm.select_next_some()=>{
+                      match swarm_event{
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
+                              kad::Event::RoutingUpdated {
+                                  peer,
+                                  is_new_peer,
+                                  addresses,
+                                  bucket_range,
+                                  old_peer,
+                              },
+                          )) => {
+                              info!(
+                                  peer = %peer,
+                                  is_new = %is_new_peer,
+                                  addresses = ?addresses,
+                                  bucket = ?bucket_range,
+                                  old_peer = ?old_peer,
+                                  "DHT routing updated"
+                              );
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
+                              floodsub::FloodsubEvent::Subscribed { peer_id, topic },
+                          )) => {
+                              info!(
+                                  peer = ?peer_id,
+                                  topic = ?topic,
+                                  "Peer subscribed to topic"
+                              );
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
+                              floodsub::FloodsubEvent::Unsubscribed { peer_id, topic },
+                          )) => {
+                              info!(
+                                  peer = ?peer_id,
+                                  topic = ?topic,
+                                  "Peer unsubscribed from topic"
+                              );
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
+                              floodsub::FloodsubEvent::Message(message),
+                          )) => {
+                             if args.audit {
+                                 trace!(source = ?message.source, "Audit mode: Ignoring gossip bead");
+                                 continue;
+                             }
+                              info!(
+                                  topics = ?message.topics,
+                                  source = ?message.source,
+                                  size_bytes = %message.data.len(),
+                                  "Floodsub message received"
+                              );
+                              let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&message.data);
+                              match result_bead {
+                                  Ok(bead) => {
+                                     info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
+                                     // Handle the received bead here
+                                     let mut braid_data = braid.write().await;
+                                     let status = {
+                                          braid_data.extend(&bead)
+                                      };
+                                      if ibd_spinlock.load(Ordering::SeqCst){
+                                         let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
+                                         let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
+                                         if let Err(e) = ibd_command_tx
+                                             .send(IBDCommands::FetchAllTimestamps { sender: ts_tx })
+                                             .await {
+                                             tracing::warn!("Failed to request timestamp map: {:?}", e);
+                                         }
+                                         let timestamp_map = match ts_rx.await {
+                                             Ok(map) => map,
+                                             Err(_) => {
+                                                 tracing::error!("Failed to receive timestamp map");
+                                                 continue;
+                                             }
+                                         };
+                                           //If the received  bead exceeds the timestamp of ibd completion wrt to a sync node
+                                           if let braid::AddBeadStatus::ParentsNotYetReceived = status {
+                                             //request the parents using request response protocol
+                                             let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
+                                             if let Some(peer) = peer_id.first() {
+                                                 swarm.behaviour_mut().bead_sync.send_request(
+                                                     &peer,
+                                                     BeadRequest::GetBeads(
+                                                         BeadHashes(
+                                                             bead.committed_metadata
+                                                                 .parents
+                                                                 .clone()
+                                                                 .into_iter()
+                                                                 .collect(),
+                                                         )
+                                                     ),
+                                                 );
+                                             } else {
+                                                 warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
+                                             }
+                                         } else if let braid::AddBeadStatus::InvalidBead = status {
+                                             // update the peer manager about the invalid bead
+                                             peer_manager.penalize_for_invalid_bead(&message.source);
+                                         } else if let braid::AddBeadStatus::BeadAdded = status {
+                                             if !args.audit {
+                                                 //Considering the index of the beads in braid will be same as the (insertion ids-1)
+                                                 let bead_id = match braid_data
+                                                     .bead_index_mapping
+                                                     .get(&bead.block_header.block_hash()) {
+                                                     Some(id) => id,
+                                                     None => {
+                                                         error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
+                                                         continue;
+                                                     }
+                                                 };
+                                                 let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                                     &braid_data.beads,
+                                                     &braid_data.bead_index_mapping,
+                                                     &bead,
+                                                 ){
+                                                     Ok(received_tuples)=>received_tuples,
+                                                     Err(error)=>{
+                                                         error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                         continue;
+                                                     }
+                                                 };
+                                                 // update score of the peer and adding to local db store
+                                                 let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
+                                                 Ok(_)=>{
+                                                     debug!("Insert command sent successfully to db handler after receiving bead from peer");
+                                                 },
+                                                 Err(error)=>{
+                                                     error!(
+                                                         source = ?message.source,
+                                                         err = ?error.0,
+                                                         "An error occurred while sending insert bead command received from peer"
+                                                     );
+                                                 }
+                                             };
+                                         }
+                                             peer_manager.update_score(&message.source, 1.0);
+                                         }
+                                         for (sync_peer, ibd_ts) in timestamp_map.iter() {
+                                             let threshold = *ibd_ts + LATENCY_ALPHA * 10;
+                                             let sync_peer_id = match sync_peer.parse::<PeerId>() {
+                                                 Ok(id) => id,
+                                                 Err(e) => {
+                                                     error!(sync_peer = %sync_peer, error = %e, "Failed to parse sync peer ID");
+                                                     continue;
+                                                 }
+                                             };
+                                             // broadcast_timestamp < timestamp + alpha * 10
+                                             if broadcast_ts  < threshold as u32 {
+                                                 info!("Incoming BEAD received during IBD within threshold limit with broadcast timestamp - {:?} and threshold is - {:?}",broadcast_ts,threshold);
+                                                match status{
+                                                 braid::AddBeadStatus::InvalidBead | braid::AddBeadStatus::ParentsNotYetReceived=>{
+                                                     //Aborting/evicting the wait_ibd handler corresponding to the sync peer
+                                                     match ibd_command_tx.send(IBDCommands::AbortWaitHandle { peer_id:sync_peer_id }).await{
+                                                         Ok(_)=>{
+                                                             warn!("Abort handle and evicting handler corresponding to sync peer sent successfully");
+                                                         },
+                                                         Err(error)=>{
+                                                             error!(error=?error,"An error occurred while sending abort handler wrt sync peer due to -");
+                                                         }
+                                                     };
+                                                     // If result is invalid then reinitiate IBD
+                                                     match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                         Ok(_)=>{
+                                                             warn!("Reinitiating IBD command sent to swarm handler");
+                                                         },
+                                                         Err(error)=>{
+                                                             error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                         }
+                                                     }
+                                                     continue;
+                                                 },
+                                                 braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
+                                                     ibd_spinlock.store(false,Ordering::SeqCst);
+                                                     continue;
+                                                 },
+                                                }
+
+                                             }
+                                             else{
+                                                 ibd_spinlock.store(false,Ordering::SeqCst);
+                                                 continue;
+                                             }
+                                         }
+                                     }
+                                     else{
+                                         if let braid::AddBeadStatus::ParentsNotYetReceived = status {
+                                             //request the parents using request response protocol
+                                             let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
+                                             if let Some(peer) = peer_id.first() {
+                                                 swarm.behaviour_mut().bead_sync.send_request(
+                                                     &peer,
+                                                     BeadRequest::GetBeads(
+                                                         BeadHashes(
+                                                             bead.committed_metadata
+                                                                 .parents
+                                                                 .clone()
+                                                                 .into_iter()
+                                                                 .collect(),
+                                                         )
+                                                     ),
+                                                 );
+                                             } else {
+                                                 warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
+                                             }
+                                         } else if let braid::AddBeadStatus::InvalidBead = status {
+                                             // update the peer manager about the invalid bead
+                                             peer_manager.penalize_for_invalid_bead(&message.source);
+                                         } else if let braid::AddBeadStatus::BeadAdded = status {
+                                             if !args.audit {
+                                                 let bead_id = match braid_data
+                                                     .bead_index_mapping
+                                                     .get(&bead.block_header.block_hash()) {
+                                                     Some(id) => id,
+                                                     None => {
+                                                         error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
+                                                         continue;
+                                                     }
+                                                 };
+                                                 let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                                     &braid_data.beads,
+                                                     &braid_data.bead_index_mapping,
+                                                     &bead,
+                                                 ){
+                                                     Ok(received_tuples)=>received_tuples,
+                                                     Err(error)=>{
+                                                         error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
+                                                         continue;
+                                                     }
+                                                 };
+                                                 // update score of the peer and adding to local db store
+                                                 let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
+                                                     Ok(_)=>{
+                                                     debug!("Insert command sent successfully to db handler after receiving bead from peer");
+                                                 },
+                                                 Err(error)=>{
+                                                     error!(
+                                                         source = ?message.source,
+                                                         err = ?error.0,
+                                                         "An error occurred while sending insert bead command received from peer"
+                                                     );
+                                                 }
+                                                 };
+                                             }
+                                             peer_manager.update_score(&message.source, 1.0);
+                                         }
+                                     }
+
+                                  }
+                                  Err(e) => {
+                                      error!(error = %e, "Failed to deserialize bead");
+                                  }
+                              }
+                          }
+                          SwarmEvent::NewListenAddr { address, .. } => {
+                              info!(address = ?address, "P2P listening on address")
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
+                              identify::Event::Sent { peer_id, .. },
+                          )) => {
+                              debug!(peer = ?peer_id, "Sent identify info");
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
+                              identify::Event::Received { peer_id, info,  .. },
+                          )) => {
+                              let info_reference = info.clone();
+                              info!(
+                                  peer = ?peer_id,
+                                  address_count = %info_reference.listen_addrs.len(),
+                                  "Received listen addresses"
+                              );
+                              if info.protocols.iter().any(|p| *p == KADPROTOCOLNAME) {
+                                  for addr in info.listen_addrs {
+                                      info!(address = %addr, "Received address via identify");
+                                  }
+                              } else {
+                                  info!(peer = ?peer_id, "Peer does not support Kademlia");
+                              }
+                              if info_reference
+                                  .clone()
+                                  .protocols
+                                  .iter()
+                                  .any(|p| *p != BEAD_ANNOUNCE_PROTOCOL)
+                              {
+
+                                  info!(
+                                      peer_address = ?info_reference.observed_addr,
+                                      "Peer does not support floodsub"
+                                  );
+                              }
+                              debug!(info = ?info_reference, "Received peer info");
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
+                              kad::Event::OutboundQueryProgressed { result, .. },
+                          )) => match result {
+                              QueryResult::GetClosestPeers(Ok(ok)) => {
+                                  info!(peers = ?ok.peers, peer_count = %ok.peers.len(), "Got closest peers");
+                              }
+                              QueryResult::GetClosestPeers(Err(err)) => {
+                                  error!(error = %err, "Failed to get closest peers");
+                              }
+                             QueryResult::Bootstrap(Ok(BootstrapOk {
+                                 peer, ..
+                             }))=>{
+                                 info!(peer = ?peer, "New peer");
+                             }
+                              _ => info!(result = ?result, "Other DHT query result"),
+                          },
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
+                              identify::Event::Error {
+                                  peer_id,
+                                  error,
+                                  connection_id: _,
+                              },
+                          )) => {
+                              error!(peer = %peer_id, error = ?error, "Identify event error");
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Ping(ping::Event {
+                              peer,
+                              result,
+                              ..
+                          })) => {
+                              match result {
+                                  Ok(latency) => {
+                                      info!(
+                                          peer = %peer,
+                                          latency_ms = %latency.as_millis(),
+                                          "Ping"
+                                      );
+                                     peer_manager.update_latency(&peer,latency);
+                                  }
+                                  Err(err) => {
+                                      warn!(
+                                          peer = %peer,
+                                          error = %err,
+                                          "Ping failed"
+                                      );
+                                  }
+                              }
+                          }
+                          SwarmEvent::ConnectionEstablished {
+                              peer_id, endpoint, ..
+                          } => {
+
+                              // Add the peer to the peer manager
+                              let remote_addr = endpoint.get_remote_address();
+                              swarm.behaviour_mut().kademlia.add_address(&peer_id,remote_addr.clone());
+                              info!(address = ?remote_addr, "DHT updated with peer address");
+                              swarm.behaviour_mut()
+                              .bead_announce
+                              .add_node_to_partial_view(peer_id);
+
+                              info!(peer = %peer_id, "Peer added to floodsub mesh");
+                              let ip = remote_addr.iter().find_map(|p| match p {
+                                  libp2p::core::multiaddr::Protocol::Ip4(ip) => {
+                                      Some(std::net::IpAddr::V4(ip))
+                                  }
+                                  libp2p::core::multiaddr::Protocol::Ip6(ip) => {
+                                      Some(std::net::IpAddr::V6(ip))
+                                  }
+                                  _ => None,
+                              });
+                              peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
+                              info!(
+                                 peer_id = ?peer_id,
+                                 remote_addr = ?remote_addr,
+                                 "Connection established to peer"
+                             );
+
+                          }
+                          SwarmEvent::ConnectionClosed {
+                              peer_id,
+                              connection_id,
+                              endpoint,
+                              num_established,
+                              cause,
+                          } => {
+                              info!(peer = %peer_id, connection_id = %connection_id, address = %endpoint.get_remote_address(), established = %num_established, cause = ?cause, "Connection closed");
+                              // Remove the peer from the peer manager
+                              peer_manager.remove_peer(&peer_id);
+                              swarm
+                                  .behaviour_mut()
+                                  .kademlia
+                                  .remove_address(&peer_id, endpoint.get_remote_address());
+                          }
+                          SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadSync(
+                         request_response::Event::Message {
                              peer,
-                             is_new_peer,
-                             addresses,
-                             bucket_range,
-                             old_peer,
+                             message,
+                             connection_id,
                          },
                      )) => {
                          info!(
                              peer = %peer,
-                             is_new = %is_new_peer,
-                             addresses = ?addresses,
-                             bucket = ?bucket_range,
-                             old_peer = ?old_peer,
-                             "DHT routing updated"
+                             message = ?message,
+                             connection = ?connection_id,
+                             "Bead sync message received"
                          );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Subscribed { peer_id, topic },
-                     )) => {
-                         info!(
-                             peer = ?peer_id,
-                             topic = ?topic,
-                             "Peer subscribed to topic"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Unsubscribed { peer_id, topic },
-                     )) => {
-                         info!(
-                             peer = ?peer_id,
-                             topic = ?topic,
-                             "Peer unsubscribed from topic"
-                         );
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadAnnounce(
-                         floodsub::FloodsubEvent::Message(message),
-                     )) => {
-                        if args.audit {
-                            trace!(source = ?message.source, "Audit mode: Ignoring gossip bead");
-                            continue;
-                        }
-                         info!(
-                             topics = ?message.topics,
-                             source = ?message.source,
-                             size_bytes = %message.data.len(),
-                             "Floodsub message received"
-                         );
-                         let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&message.data);
-                         match result_bead {
-                             Ok(bead) => {
-                                info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
-                                // Handle the received bead here
-                                let mut braid_data = braid.write().await;
-                                let status = {
-                                     braid_data.extend(&bead)
+                         match message {
+                             request_response::Message::Request {
+                                 request,
+                                 request_id: _,
+                                 channel,
+                             } => {
+                                 // Handle the bead sync request here
+                                 match request {
+                                     BeadRequest::GetBeads(hashes) => {
+                                             let mut beads = Vec::new();
+                                             {
+                                                 let braid_lock = braid.read().await;
+                                                 for hash in hashes.iter() {
+                                                     if let Some(index) =
+                                                         braid_lock.bead_index_mapping.get(hash)
+                                                     {
+                                                         if let Some(bead) = braid_lock.beads.get(*index) {
+                                                             beads.push(bead.clone());
+                                                         }
+                                                     }
+                                                 }
+                                             }
+                                             //Sending all the beads requested in the hashes supplied during `GetData` request
+                                             swarm.behaviour_mut().respond_with_beads(channel, beads);
+                                     }
+                                     BeadRequest::GetTips => {
+                                             let tips;
+                                             {
+                                                 let braid_lock = braid.read().await;
+                                                 tips = braid_lock
+                                                     .tips
+                                                     .iter()
+                                                     .filter_map(|index| braid_lock.beads.get(*index))
+                                                     .cloned()
+                                                     .map(|bead| bead.block_header.block_hash())
+                                                     .collect();
+                                             }
+                                             swarm.behaviour_mut().respond_with_tips(channel, tips);
+                                     }
+                                     BeadRequest::GetGenesis => {
+                                             let genesis;
+                                             {
+                                                 let braid_lock = braid.read().await;
+                                                 genesis = braid_lock
+                                                     .genesis_beads
+                                                     .iter()
+                                                     .filter_map(|index| braid_lock.beads.get(*index))
+                                                     .cloned()
+                                                     .map(|bead| bead.block_header.block_hash())
+                                                     .collect();
+                                             }
+                                             swarm.behaviour_mut().respond_with_genesis(channel, genesis);
+                                     }
+                                     BeadRequest::GetAllBeads => {
+
+                                             let all_beads;
+                                             {
+                                                 let braid_lock = braid.read().await;
+                                                 all_beads = braid_lock.beads.iter().cloned().collect();
+                                             }
+                                             swarm.behaviour_mut().respond_with_beads(channel, all_beads);
+                                     }
+                                     BeadRequest::GetBeadsAfter(hashes) => {
+                                             let beads = braid.read().await.get_beads_after(hashes.into());
+                                             if let Some(response_beads) = beads {
+                                                 let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
+                                                 for bead in response_beads.into_iter(){
+                                                     computed_beads_hashes.push(bead.block_header.block_hash());
+                                                 }
+                                                 //Sending the corresponding bead hashes requested by the new peer for IBD that will
+                                                 //be after the new peer's `Tips`.
+                                                 swarm
+                                                     .behaviour_mut()
+                                                     .respond_with_beadhashes(channel, computed_beads_hashes);
+                                             } else {
+                                                 swarm.behaviour_mut().respond_with_error(
+                                                     channel,
+                                                     BeadSyncError::BeadHashNotFound,
+                                                 );
+                                             }
+                                     }
+                                 }
+                             }
+                             request_response::Message::Response {
+                                 request_id: _,
+                                 response,
+                             } => {
+                                 match response {
+                                     BeadResponse::Beads(beads)
+                                     | BeadResponse::GetAllBeads(beads) => {
+                                         let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
+                                         //Fetching the pruned bead-hashes received during `GetBeadAfter` request
+                                         match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
+                                             Ok(_)=>{
+                                                 debug!("IBD command sent to handler successfully !");
+                                             },
+                                             Err(error)=>{
+                                                 //Re-initiating IBD
+                                                 error!("An error occurred while sending ibd command to ibd_handler - {:?}, re-trying IBD",error.0);
+                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                     Ok(_)=>{
+                                                         warn!("Reinitiating IBD command sent to swarm handler");
+                                                     },
+                                                     Err(error)=>{
+                                                         error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                     }
+                                                 }
+                                                 continue;
+                                             }
+                                         };
+                                         let pruned_beads = match beads_rx.await{
+                                             Ok(received_beads)=>{
+                                                 received_beads
+                                             },
+                                             Err(error)=>{
+                                                 error!(error=?error.to_string(),"An error occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
+                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                     Ok(_)=>{
+                                                         warn!("Reinitiating IBD command sent to swarm handler");
+                                                     },
+                                                     Err(error)=>{
+                                                         error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                     }
+                                                 }
+                                                 continue;
+                                             }
+                                         };
+                                         for bead in beads.into_iter() {
+                                             let mut braid_data = braid.write().await;
+                                             let status = braid_data.extend(&bead);
+                                             let curr_beadhash = bead.block_header.block_hash().to_string();
+                                             if let braid::AddBeadStatus::InvalidBead = status {
+                                                 // update the peer manager about the invalid bead
+                                                 peer_manager.penalize_for_invalid_bead(&peer);
+                                             } else if let braid::AddBeadStatus::BeadAdded = status {
+                                                 if !args.audit {
+                                                     let bead_id = match braid_data
+                                                         .bead_index_mapping
+                                                         .get(&bead.block_header.block_hash()) {
+                                                         Some(id) => id,
+                                                         None => {
+                                                             error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
+                                                             continue;
+                                                         }
+                                                     };
+                                                     let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
+                                                         &braid_data.beads,
+                                                         &braid_data.bead_index_mapping,
+                                                         &bead,
+                                                     ){
+                                                         Ok(received_tuples)=>received_tuples,
+                                                         Err(error)=>{
+                                                             error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
+                                                             continue;
+                                                         }
+                                                     };
+                                                     // update score of the peer
+                                                     peer_manager.update_score(&peer, 1.0);
+                                                     //persisting the received beads from peer onto DB(disk)
+                                                     match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
+                                                         Ok(_)=>{
+                                                             debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
+                                                         },
+                                                         Err(error)=>{
+                                                             tracing::error!(
+                                                                 peer = %peer,
+                                                                 err = ?error.0,
+                                                                 "An error occurred while persisting received bead from peer"
+                                                             );
+                                                         }
+                                                     };
+                                                 }
+                                             }
+                                         }
+                                         //Preparing next batch request to be sent to the sync node
+                                         let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
+                                         match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await{
+                                                 Ok(_)=>{
+                                                     debug!("Offset Updated");
+                                                 },
+                                                 Err(error)=>{
+                                                     error!(error=?error,"An error occurred while sending the offset update command, re-trying IBD");
+                                                     match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                         Ok(_)=>{
+                                                             warn!("Reinitiating IBD command sent to swarm handler");
+                                                         },
+                                                         Err(error)=>{
+                                                             error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                         }
+                                                     }
+                                                     continue;
+                                                 }
+                                         };
+                                         let next_batch_offset = match batch_rx.await{
+                                             Ok(next_offset)=>{
+                                                 debug!(next_offset=?next_offset,"Newer offset for batch request received successfully ");
+                                                 next_offset
+                                             },
+                                             Err(error)=>{
+                                                 error!(error=?error,"An error occurred while receiving the offset, re-trying IBD");
+                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                     Ok(_)=>{
+                                                         warn!("Reinitiating IBD command sent to swarm handler");
+                                                     },
+                                                     Err(error)=>{
+                                                         error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
+                                                     }
+                                                 }
+                                                 continue;
+                                             }
+                                         };
+                                         if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)< pruned_beads.len()){
+                                             info!("Received beads within batch range");
+                                             swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..(next_batch_offset+IBD_BATCH_SIZE)].to_vec());
+                                         }
+                                         else if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)>=pruned_beads.len()){
+                                             info!("Received beads within batch range");
+                                             swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..].to_vec());
+
+                                         }
+                                         else{
+                                             //IBD completed
+                                             info!(
+                                                 peer = %peer,
+                                                 "Initial IBD has been completed with respect to peer"
+                                             );
+                                             // Get current time and create recent timestamps (within last hour)
+                                             let current_time = SystemTime::now()
+                                                 .duration_since(UNIX_EPOCH)
+                                                 .map(|d| d.as_secs())
+                                                 .unwrap_or_else(|e| {
+                                                     error!(error = %e, "System time before UNIX epoch");
+                                                     0
+                                                 });
+                                             match ibd_command_tx.send(IBDCommands::UpdateTimestampMapping { peer_id: peer.to_string(), end_timestamp: current_time }).await{
+                                                 Ok(_)=>{
+                                                     debug!("Timestamp updated command sent successfully");
+                                                     //Scheduling a corresponding watcher task that will check after a latency period
+                                                     //if no incoming is received during the instance of [initial_headers_fetched,(initial_headers_fetched+(alpha*10))]
+                                                     let ibd_spinlock_ref = ibd_spinlock.clone();
+                                                     let ibd_incoming_handler = tokio::spawn(async move{
+                                                         //Sleeping for a fixed duration to be set according to statistical estimates
+                                                         tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
+                                                         //We will check if no bead is `incoming` after the duration of 600 seconds then we will reset/set ibd_flag accordingly
+                                                         if ibd_spinlock_ref.load(Ordering::SeqCst){
+                                                             //If no incoming is received during the period then we can say
+                                                             //that ibd wrt the given sync node is successfully completed
+                                                             ibd_spinlock_ref.store(false,Ordering::SeqCst);
+                                                             warn!("Maximum threshold wrt IBD incoming exceeded thus ibd_flag being set to false");
+                                                         }
+
+                                                     });
+                                                     //At retry we will have to abort and evict the corresponding sync-peers's wait handle
+                                                     match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:peer,retry_or_not:false,handle:Some(ibd_incoming_handler)}).await{
+                                                         Ok(_)=>{
+                                                             debug!("Incoming bead command sent successfully");
+                                                         },
+                                                         Err(error)=>{
+                                                             error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                                         }
+                                                     };
+                                                 },
+                                                 Err(error)=>{
+                                                     error!(error=?error,"An error occurred while sending timestamp update command for the given sync node");
+                                                 }
+                                             };
+                                         }
+                                     }
+                                      BeadResponse::GetBeadsAfter(bead_hashes)=>{
+                                         //Getting all the beadhashes after the common oldest in both the peers
+                                         let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
+                                         match ibd_command_tx.send(IBDCommands::FetchTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
+                                             Ok(_)=>{
+                                                 debug!("Sync peer Tips received successfully.");
+                                             },
+                                             Err(error)=>{
+                                                 error!(error=?error,"Error occurred while receiving tips, re-trying IBD");
+                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                     Ok(_)=>{
+                                                         warn!("Reinitiating IBD command sent to swarm handler");
+                                                     },
+                                                     Err(error)=>{
+                                                         error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
+                                                     }
+                                                 }
+                                                 continue;
+                                             }
+                                         };
+                                         let received_tips = match tips_rx.await{
+                                             Ok(received_tips)=>{
+                                                 received_tips
+                                             },
+                                             Err(error)=>{
+                                                 error!(error=?error,"An error occurred while receiving the Tips, re-trying IBD");
+                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                     Ok(_)=>{
+                                                         warn!("Reinitiating IBD command sent to swarm handler");
+                                                     },
+                                                     Err(error)=>{
+                                                         error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
+                                                     }
+                                                 }
+                                                 continue;
+                                             }
+                                         };
+                                         //Pruning the hashes wrt cached `Tips`
+                                         let mut found_tips = HashSet::new();
+                                         let mut pruned = Vec::new();
+                                         let tips_set: HashSet<_> = received_tips.into_iter().collect();
+                                         for hash in bead_hashes {
+                                             if tips_set.contains(&hash) {
+                                                 found_tips.insert(hash.clone());
+                                             }
+                                             pruned.push(hash);
+                                             // Stop once all tips have been matched
+                                             if found_tips.len() == tips_set.len() {
+                                                 break;
+                                             }
+                                         }
+                                         let pruned_ref = pruned.clone();
+                                         // Storing them in cache
+                                         match ibd_command_tx.send(IBDCommands::UpdateIncoming { get_bead_response: pruned, peer_id: peer.to_string() }).await{
+                                             Ok(_)=>{
+                                                 debug!("Received beads to be fetched in GetBeads saved successfully");
+                                             },
+                                             Err(error)=>{
+                                                 error!(error=?error,"An error occurred while Caching pruned beadhashes to be fetched in GetBeads");
+                                                 match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
+                                                     Ok(_)=>{
+                                                         warn!("Reinitiating IBD command sent to swarm handler");
+                                                     },
+                                                     Err(error)=>{
+                                                         error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
+                                                     }
+                                                 }
+                                                 continue;
+                                             }
+                                         };
+                                         // Initiating `GetBead` request cycle
+                                         if pruned_ref.len() <= IBD_BATCH_SIZE{
+                                             swarm.behaviour_mut().request_beads(peer, &pruned_ref);
+                                         }
+                                         else{
+                                             swarm.behaviour_mut().request_beads(peer, &pruned_ref[0..IBD_BATCH_SIZE].to_vec());
+                                         }
+
+                                     }
+                                     BeadResponse::Tips(tips) => {
+                                         info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
+                                         //If received tips are already present in the local braid arc then we can stop
+                                         //IBD and continue with mining
+                                         //Initializing the batch offset for the corresponding sync peer
+                                         let (ibd_bridge_tx, _ibd_bridge_rx) = tokio::sync::oneshot::channel::<usize>();
+                                         match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await{
+                                             Ok(_)=>{
+                                                 debug!("Offset Initialized successfully");
+                                             },
+                                             Err(_error)=>{
+                                                 error!("An error occurred while sending offset initalization command to ibd_handler");
+                                                 continue;
+                                             }
+                                         };
+                                         let _val = match _ibd_bridge_rx.await {
+                                             Ok(v) => v,
+                                             Err(e) => {
+                                                 error!(error = %e, "Failed to receive IBD batch offset");
+                                                 continue;
+                                             }
+                                         };
+                                         let braid_data = braid.read().await;
+
+                                         let bead_hash_set: HashSet<BeadHash> = braid_data
+                                         .beads
+                                         .iter()
+                                         .map(|b| b.block_header.block_hash())
+                                         .collect();
+
+                                         let flag = tips.iter().all(|tip_hash| bead_hash_set.contains(tip_hash));
+
+                                         if flag{
+                                             //No need to proceed further and continue to next event
+                                             info!("Peer already synced to tip");
+                                             //IBD flag can be set  as the current bead is already synced//
+                                             ibd_spinlock.store(false, Ordering::SeqCst);
+                                             continue;
+                                         }
+                                       let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips.0, peer_id: peer.to_string() }).await{
+                                         Ok(_)=>{
+                                             debug!("Sync peers Tip mapping update successfully");
+                                         },
+                                         Err(error)=>{
+                                             tracing::error!(
+                                                 err = ?error,
+                                                 "Error while sending update cache command"
+                                             );
+                                             continue;
+                                         }
+                                       };
+                                         // After storing tips we will issue `GetBeads` command that will find the oldest
+                                         // common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
+                                         // the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
+                                         let mut current_tip_hashes = Vec::new();
+                                         for curr_bead_idx in braid_data.tips.iter() {
+                                             if let Some(current_bead) = braid_data.beads.get(*curr_bead_idx) {
+                                                 current_tip_hashes.push(current_bead.block_header.block_hash());
+                                             } else {
+                                                 error!(bead_idx = %curr_bead_idx, "Tip bead not found in beads list");
+                                             }
+                                         }
+                                         // Sending the current bead hashes for the receiving of beads to start in batches
+                                         let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
+                                         swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
+
+                                     }
+                                     BeadResponse::Genesis(genesis) => {
+                                         info!(genesis=?genesis,"Received genesis beads: ");
+                                         let status = {
+                                             let braid_lock = braid.read().await;
+                                             braid_lock.check_genesis_beads(&genesis.0)
+                                         };
+                                         match status {
+                                             braid::GenesisCheckStatus::GenesisBeadsValid => {
+                                                 info!("Genesis beads are valid");
+                                             }
+                                             braid::GenesisCheckStatus::MissingGenesisBead => {
+                                                 warn!(peer = %peer, "Missing genesis bead");
+                                                 swarm
+                                                     .behaviour_mut()
+                                                     .request_beads(peer, &genesis.0);
+                                             }
+                                             braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
+                                                 warn!(
+                                                     received = %genesis.0.len(),
+                                                     peer = %peer,
+                                                     "Genesis bead count mismatch"
+                                                 );
+                                             }
+                                         }
+                                     }
+                                     BeadResponse::Error(error) => match error {
+                                         BeadSyncError::GenesisMismatch => {
+                                             warn!("Genesis mismatch error received");
+                                             swarm.behaviour_mut().request_genesis(peer.clone());
+                                         }
+                                         BeadSyncError::BeadHashNotFound => {
+                                             warn!("Peer requested bead hashes not found in local store");
+                                         }
+                                     },
                                  };
-                                 if ibd_spinlock.load(Ordering::SeqCst){
-                                    let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
-                                    let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
-                                    if let Err(e) = ibd_command_tx
-                                        .send(IBDCommands::FetchAllTimestamps { sender: ts_tx })
-                                        .await {
-                                        tracing::warn!("Failed to request timestamp map: {:?}", e);
-                                    }
-                                    let timestamp_map = match ts_rx.await {
-                                        Ok(map) => map,
-                                        Err(_) => {
-                                            tracing::error!("Failed to receive timestamp map");
-                                            continue;
-                                        }
-                                    };
-                                      //If the received  bead exceeds the timestamp of ibd completion wrt to a sync node
-                                      if let braid::AddBeadStatus::ParentsNotYetReceived = status {
-                                        //request the parents using request response protocol
-                                        let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
-                                        if let Some(peer) = peer_id.first() {
-                                            swarm.behaviour_mut().bead_sync.send_request(
-                                                &peer,
-                                                BeadRequest::GetBeads(
-                                                    BeadHashes(
-                                                        bead.committed_metadata
-                                                            .parents
-                                                            .clone()
-                                                            .into_iter()
-                                                            .collect(),
-                                                    )
-                                                ),
-                                            );
-                                        } else {
-                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
-                                        }
-                                    } else if let braid::AddBeadStatus::InvalidBead = status {
-                                        // update the peer manager about the invalid bead
-                                        peer_manager.penalize_for_invalid_bead(&message.source);
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
-                                        if !args.audit {
-                                            //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                                            let bead_id = match braid_data
-                                                .bead_index_mapping
-                                                .get(&bead.block_header.block_hash()) {
-                                                Some(id) => id,
-                                                None => {
-                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
-                                                    continue;
-                                                }
-                                            };
-                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                                &braid_data.beads,
-                                                &braid_data.bead_index_mapping,
-                                                &bead,
-                                            ){
-                                                Ok(received_tuples)=>received_tuples,
-                                                Err(error)=>{
-                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                    continue;
-                                                }
-                                            };
-                                            // update score of the peer and adding to local db store
-                                            let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                            Ok(_)=>{
-                                                debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                            },
-                                            Err(error)=>{
-                                                error!(
-                                                    source = ?message.source,
-                                                    err = ?error.0,
-                                                    "An error occurred while sending insert bead command received from peer"
-                                                );
-                                            }
-                                        };
-                                    }
-                                        peer_manager.update_score(&message.source, 1.0);
-                                    }
-                                    for (sync_peer, ibd_ts) in timestamp_map.iter() {
-                                        let threshold = *ibd_ts + LATENCY_ALPHA * 10;
-                                        let sync_peer_id = match sync_peer.parse::<PeerId>() {
-                                            Ok(id) => id,
-                                            Err(e) => {
-                                                error!(sync_peer = %sync_peer, error = %e, "Failed to parse sync peer ID");
-                                                continue;
-                                            }
-                                        };
-                                        // broadcast_timestamp < timestamp + alpha * 10
-                                        if broadcast_ts  < threshold as u32 {
-                                            info!("Incoming BEAD received during IBD within threshold limit with broadcast timestamp - {:?} and threshold is - {:?}",broadcast_ts,threshold);
-                                           match status{
-                                            braid::AddBeadStatus::InvalidBead | braid::AddBeadStatus::ParentsNotYetReceived=>{
-                                                //Aborting/evicting the wait_ibd handler corresponding to the sync peer
-                                                match ibd_command_tx.send(IBDCommands::AbortWaitHandle { peer_id:sync_peer_id }).await{
-                                                    Ok(_)=>{
-                                                        warn!("Abort handle and evicting handler corresponding to sync peer sent successfully");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"An error occurred while sending abort handler wrt sync peer due to -");
-                                                    }
-                                                };
-                                                // If result is invalid then reinitiate IBD
-                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                    Ok(_)=>{
-                                                        warn!("Reinitiating IBD command sent to swarm handler");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                    }
-                                                }
-                                                continue;
-                                            },
-                                            braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
-                                                ibd_spinlock.store(false,Ordering::SeqCst);
-                                                continue;
-                                            },
-                                           }
-
-                                        }
-                                        else{
-                                            ibd_spinlock.store(false,Ordering::SeqCst);
-                                            continue;
-                                        }
-                                    }
-                                }
-                                else{
-                                    if let braid::AddBeadStatus::ParentsNotYetReceived = status {
-                                        //request the parents using request response protocol
-                                        let peer_id = peer_manager.get_top_k_peers_for_propagation(1);
-                                        if let Some(peer) = peer_id.first() {
-                                            swarm.behaviour_mut().bead_sync.send_request(
-                                                &peer,
-                                                BeadRequest::GetBeads(
-                                                    BeadHashes(
-                                                        bead.committed_metadata
-                                                            .parents
-                                                            .clone()
-                                                            .into_iter()
-                                                            .collect(),
-                                                    )
-                                                ),
-                                            );
-                                        } else {
-                                            warn!(parent_count = %bead.committed_metadata.parents.len(), "Insufficient peers for bead sync");
-                                        }
-                                    } else if let braid::AddBeadStatus::InvalidBead = status {
-                                        // update the peer manager about the invalid bead
-                                        peer_manager.penalize_for_invalid_bead(&message.source);
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
-                                        if !args.audit {
-                                            let bead_id = match braid_data
-                                                .bead_index_mapping
-                                                .get(&bead.block_header.block_hash()) {
-                                                Some(id) => id,
-                                                None => {
-                                                    error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
-                                                    continue;
-                                                }
-                                            };
-                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                                &braid_data.beads,
-                                                &braid_data.bead_index_mapping,
-                                                &bead,
-                                            ){
-                                                Ok(received_tuples)=>received_tuples,
-                                                Err(error)=>{
-                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                    continue;
-                                                }
-                                            };
-                                            // update score of the peer and adding to local db store
-                                            let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
-                                                Ok(_)=>{
-                                                debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                            },
-                                            Err(error)=>{
-                                                error!(
-                                                    source = ?message.source,
-                                                    err = ?error.0,
-                                                    "An error occurred while sending insert bead command received from peer"
-                                                );
-                                            }
-                                            };
-                                        }
-                                        peer_manager.update_score(&message.source, 1.0);
-                                    }
-                                }
-
-                             }
-                             Err(e) => {
-                                 error!(error = %e, "Failed to deserialize bead");
                              }
                          }
                      }
-                     SwarmEvent::NewListenAddr { address, .. } => {
-                         info!(address = ?address, "P2P listening on address")
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Sent { peer_id, .. },
-                     )) => {
-                         debug!(peer = ?peer_id, "Sent identify info");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Received { peer_id, info,  .. },
-                     )) => {
-                         let info_reference = info.clone();
-                         info!(
-                             peer = ?peer_id,
-                             address_count = %info_reference.listen_addrs.len(),
-                             "Received listen addresses"
-                         );
-                         if info.protocols.iter().any(|p| *p == KADPROTOCOLNAME) {
-                             for addr in info.listen_addrs {
-                                 info!(address = %addr, "Received address via identify");
+                          other_event=>{
+                                  debug!(event = ?other_event, "Other swarm event");
+                          }
+                      }
+
+                  }
+                  Some(swarm_command) = swarm_command_receiver.recv()=>{
+                      match swarm_command{
+                          SwarmCommand::PropagateValidBead {
+                              bead_bytes,
+                          } => {
+                              swarm
+                                  .behaviour_mut()
+                                  .bead_announce
+                                  .publish(current_broadcast_topic.clone(), bead_bytes);
+                             info!(topic = ?current_broadcast_topic, "Published bead to floodsub topic");
+                          },
+                          SwarmCommand::InitiateIBD=>{
+                             info!("Initiating IBD after peer discovery and selecting peer with lowest latency score");
+                             //Evicting lowest latency peer id
+                             let peer_ids = peer_manager.get_top_k_peers_for_propagation(1);
+                             if peer_ids.len() == 0 {
+                                 warn!("No peer available for syncing to take place");
+                                     tokio::spawn({
+                                         let swarm_command_sender = swarm_command_sender.clone();
+                                         //Retrying at fixed interval in case of no sync peers being available
+                                         async move {
+                                             tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
+                                                 Ok(_) => {
+                                                     info!("Retrying IBD when no sync peers are available");
+                                                 }
+                                                 Err(error) => {
+                                                     error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
+                                                 }
+                                             }
+                                         }
+                                     });
                              }
-                         } else {
-                             info!(peer = ?peer_id, "Peer does not support Kademlia");
-                         }
-                         if info_reference
-                             .clone()
-                             .protocols
-                             .iter()
-                             .any(|p| *p != BEAD_ANNOUNCE_PROTOCOL)
-                         {
+                             else{
+                                 let mut sync_request_sent = false;
+                                 for lowest_latency_peer in peer_ids.into_iter(){
+                                     let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
+                                     match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:lowest_latency_peer,retry_sender:retry_count_tx}).await{
+                                         Ok(_)=>{
+                                             info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
+                                         },
+                                         Err(error)=>{
+                                             error!(error=?error,"An error occurred while sending retry count to IBDHandler");
+                                         }
+                                     }
+                                     let retry_cnt = match retry_count_rx.await {
+                                         Ok(cnt) => cnt,
+                                         Err(e) => {
+                                             error!(error=?e, "Failed to receive retry count from IBDHandler, channel closed or sender dropped");
+                                             continue;
+                                         }
+                                     };
+                                     if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
+                                         warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
+                                         continue;
+                                     }
+                                     else if retry_cnt == u64::MAX{
+                                         //First time syncing is being done wrt the provided peer
+                                         match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:false,handle:None}).await{
+                                             Ok(_)=>{
+                                                 info!("Incoming bead command sent successfully");
+                                                 let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                                                 swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                                             },
+                                             Err(error)=>{
+                                                 error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                             }
+                                         };
+                                         sync_request_sent = true;
+                                         break;
+                                     }
+                                     else{
+                                         //Case of retry is there
+                                         match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:true,handle:None}).await{
+                                             Ok(_)=>{
+                                                 info!("Incoming bead command sent successfully");
+                                             },
+                                             Err(error)=>{
+                                                 error!(error=?error,"An error occurred while sending Update Incoming due to ");
+                                             }
+                                         };
+                                         //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
+                                         let sync_start_request:BeadRequest = BeadRequest::GetTips;
+                                         swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
+                                         sync_request_sent = true;
+                                         break;
+                                     }
 
-                             info!(
-                                 peer_address = ?info_reference.observed_addr,
-                                 "Peer does not support floodsub"
-                             );
-                         }
-                         debug!(info = ?info_reference, "Received peer info");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
-                         kad::Event::OutboundQueryProgressed { result, .. },
-                     )) => match result {
-                         QueryResult::GetClosestPeers(Ok(ok)) => {
-                             info!(peers = ?ok.peers, peer_count = %ok.peers.len(), "Got closest peers");
-                         }
-                         QueryResult::GetClosestPeers(Err(err)) => {
-                             error!(error = %err, "Failed to get closest peers");
-                         }
-                        QueryResult::Bootstrap(Ok(BootstrapOk {
-                            peer, ..
-                        }))=>{
-                            info!(peer = ?peer, "New peer");
-                        }
-                         _ => info!(result = ?result, "Other DHT query result"),
-                     },
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
-                         identify::Event::Error {
-                             peer_id,
-                             error,
-                             connection_id: _,
-                         },
-                     )) => {
-                         error!(peer = %peer_id, error = ?error, "Identify event error");
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Ping(ping::Event {
-                         peer,
-                         result,
-                         ..
-                     })) => {
-                         match result {
-                             Ok(latency) => {
-                                 info!(
-                                     peer = %peer,
-                                     latency_ms = %latency.as_millis(),
-                                     "Ping"
-                                 );
-                                peer_manager.update_latency(&peer,latency);
+                                 }
+                                 if sync_request_sent{
+                                     //The lowest latency avaialble sync peer whose retry count is not exceeded has been selected and requested to initiate IBD
+                                     continue;
+                                 }
+                                 else{
+                                     warn!("Retry count for all the available sync peers exceeded waiting for new peer connections");
+                                     tokio::spawn({
+                                         let swarm_command_sender = swarm_command_sender.clone();
+                                         //Retrying at fixed interval in case of all available sync peer retry count has exceeded
+                                         //Probe at fixed interval for any new peer
+                                         async move {
+                                             tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
+                                             match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
+                                                 Ok(_) => {
+                                                     info!("Retrying IBD when no sync peers are available");
+                                                 }
+                                                 Err(error) => {
+                                                     error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
+                                                 }
+                                             }
+                                         }
+                                     });
+                                 }
                              }
-                             Err(err) => {
-                                 warn!(
-                                     peer = %peer,
-                                     error = %err,
-                                     "Ping failed"
-                                 );
-                             }
-                         }
-                     }
-                     SwarmEvent::ConnectionEstablished {
-                         peer_id, endpoint, ..
-                     } => {
-
-                         // Add the peer to the peer manager
-                         let remote_addr = endpoint.get_remote_address();
-                         swarm.behaviour_mut().kademlia.add_address(&peer_id,remote_addr.clone());
-                         info!(address = ?remote_addr, "DHT updated with peer address");
-                         swarm.behaviour_mut()
-                         .bead_announce
-                         .add_node_to_partial_view(peer_id);
-
-                         info!(peer = %peer_id, "Peer added to floodsub mesh");
-                         let ip = remote_addr.iter().find_map(|p| match p {
-                             libp2p::core::multiaddr::Protocol::Ip4(ip) => {
-                                 Some(std::net::IpAddr::V4(ip))
-                             }
-                             libp2p::core::multiaddr::Protocol::Ip6(ip) => {
-                                 Some(std::net::IpAddr::V6(ip))
-                             }
-                             _ => None,
-                         });
-                         peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
-                         info!(
-                            peer_id = ?peer_id,
-                            remote_addr = ?remote_addr,
-                            "Connection established to peer"
-                        );
-
-                     }
-                     SwarmEvent::ConnectionClosed {
-                         peer_id,
-                         connection_id,
-                         endpoint,
-                         num_established,
-                         cause,
-                     } => {
-                         info!(peer = %peer_id, connection_id = %connection_id, address = %endpoint.get_remote_address(), established = %num_established, cause = ?cause, "Connection closed");
-                         // Remove the peer from the peer manager
-                         peer_manager.remove_peer(&peer_id);
-                         swarm
-                             .behaviour_mut()
-                             .kademlia
-                             .remove_address(&peer_id, endpoint.get_remote_address());
-                     }
-                     SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadSync(
-                    request_response::Event::Message {
-                        peer,
-                        message,
-                        connection_id,
-                    },
-                )) => {
-                    info!(
-                        peer = %peer,
-                        message = ?message,
-                        connection = ?connection_id,
-                        "Bead sync message received"
-                    );
-                    match message {
-                        request_response::Message::Request {
-                            request,
-                            request_id: _,
-                            channel,
-                        } => {
-                            // Handle the bead sync request here
-                            match request {
-                                BeadRequest::GetBeads(hashes) => {
-                                        let mut beads = Vec::new();
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            for hash in hashes.iter() {
-                                                if let Some(index) =
-                                                    braid_lock.bead_index_mapping.get(hash)
-                                                {
-                                                    if let Some(bead) = braid_lock.beads.get(*index) {
-                                                        beads.push(bead.clone());
-                                                    }
-                                                }
-                                            }
-                                        }
-                                        //Sending all the beads requested in the hashes supplied during `GetData` request
-                                        swarm.behaviour_mut().respond_with_beads(channel, beads);
-                                }
-                                BeadRequest::GetTips => {
-                                        let tips;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            tips = braid_lock
-                                                .tips
-                                                .iter()
-                                                .filter_map(|index| braid_lock.beads.get(*index))
-                                                .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
-                                                .collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_tips(channel, tips);
-                                }
-                                BeadRequest::GetGenesis => {
-                                        let genesis;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            genesis = braid_lock
-                                                .genesis_beads
-                                                .iter()
-                                                .filter_map(|index| braid_lock.beads.get(*index))
-                                                .cloned()
-                                                .map(|bead| bead.block_header.block_hash())
-                                                .collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_genesis(channel, genesis);
-                                }
-                                BeadRequest::GetAllBeads => {
-
-                                        let all_beads;
-                                        {
-                                            let braid_lock = braid.read().await;
-                                            all_beads = braid_lock.beads.iter().cloned().collect();
-                                        }
-                                        swarm.behaviour_mut().respond_with_beads(channel, all_beads);
-                                }
-                                BeadRequest::GetBeadsAfter(hashes) => {
-                                        let beads = braid.read().await.get_beads_after(hashes.into());
-                                        if let Some(response_beads) = beads {
-                                            let mut computed_beads_hashes:Vec<BeadHash> = Vec::new();
-                                            for bead in response_beads.into_iter(){
-                                                computed_beads_hashes.push(bead.block_header.block_hash());
-                                            }
-                                            //Sending the corresponding bead hashes requested by the new peer for IBD that will
-                                            //be after the new peer's `Tips`.
-                                            swarm
-                                                .behaviour_mut()
-                                                .respond_with_beadhashes(channel, computed_beads_hashes);
-                                        } else {
-                                            swarm.behaviour_mut().respond_with_error(
-                                                channel,
-                                                BeadSyncError::BeadHashNotFound,
-                                            );
-                                        }
-                                }
-                            }
-                        }
-                        request_response::Message::Response {
-                            request_id: _,
-                            response,
-                        } => {
-                            match response {
-                                BeadResponse::Beads(beads)
-                                | BeadResponse::GetAllBeads(beads) => {
-                                    let (beads_tx, beads_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    //Fetching the pruned bead-hashes received during `GetBeadAfter` request
-                                    match ibd_command_tx.send(IBDCommands::FetchGetBeadMapping { peer_id: peer.to_string(), beadhash_sender: beads_tx }).await{
-                                        Ok(_)=>{
-                                            debug!("IBD command sent to handler successfully !");
-                                        },
-                                        Err(error)=>{
-                                            //Re-initiating IBD
-                                            error!("An error occurred while sending ibd command to ibd_handler - {:?}, re-trying IBD",error.0);
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    let pruned_beads = match beads_rx.await{
-                                        Ok(received_beads)=>{
-                                            received_beads
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error.to_string(),"An error occurred while receiving cached beads from ibd_handler due to , re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    for bead in beads.into_iter() {
-                                        let mut braid_data = braid.write().await;
-                                        let status = braid_data.extend(&bead);
-                                        let curr_beadhash = bead.block_header.block_hash().to_string();
-                                        if let braid::AddBeadStatus::InvalidBead = status {
-                                            // update the peer manager about the invalid bead
-                                            peer_manager.penalize_for_invalid_bead(&peer);
-                                        } else if let braid::AddBeadStatus::BeadAdded = status {
-                                            if !args.audit {
-                                                let bead_id = match braid_data
-                                                    .bead_index_mapping
-                                                    .get(&bead.block_header.block_hash()) {
-                                                    Some(id) => id,
-                                                    None => {
-                                                        error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetBeadsAfter)");
-                                                        continue;
-                                                    }
-                                                };
-                                                let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                                    &braid_data.beads,
-                                                    &braid_data.bead_index_mapping,
-                                                    &bead,
-                                                ){
-                                                    Ok(received_tuples)=>received_tuples,
-                                                    Err(error)=>{
-                                                        error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
-                                                        continue;
-                                                    }
-                                                };
-                                                // update score of the peer
-                                                peer_manager.update_score(&peer, 1.0);
-                                                //persisting the received beads from peer onto DB(disk)
-                                                match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
-                                                    Ok(_)=>{
-                                                        debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
-                                                    },
-                                                    Err(error)=>{
-                                                        tracing::error!(
-                                                            peer = %peer,
-                                                            err = ?error.0,
-                                                            "An error occurred while persisting received bead from peer"
-                                                        );
-                                                    }
-                                                };
-                                            }
-                                        }
-                                    }
-                                    //Preparing next batch request to be sent to the sync node
-                                    let (batch_tx, batch_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: batch_tx, batch_size:IBD_BATCH_SIZE  }).await{
-                                            Ok(_)=>{
-                                                debug!("Offset Updated");
-                                            },
-                                            Err(error)=>{
-                                                error!(error=?error,"An error occurred while sending the offset update command, re-trying IBD");
-                                                match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                    Ok(_)=>{
-                                                        warn!("Reinitiating IBD command sent to swarm handler");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                    }
-                                                }
-                                                continue;
-                                            }
-                                    };
-                                    let next_batch_offset = match batch_rx.await{
-                                        Ok(next_offset)=>{
-                                            debug!(next_offset=?next_offset,"Newer offset for batch request received successfully ");
-                                            next_offset
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while receiving the offset, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetAllBeads Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)< pruned_beads.len()){
-                                        info!("Received beads within batch range");
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..(next_batch_offset+IBD_BATCH_SIZE)].to_vec());
-                                    }
-                                    else if next_batch_offset < pruned_beads.len() && ((next_batch_offset+IBD_BATCH_SIZE)>=pruned_beads.len()){
-                                        info!("Received beads within batch range");
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_beads[next_batch_offset..].to_vec());
-
-                                    }
-                                    else{
-                                        //IBD completed
-                                        info!(
-                                            peer = %peer,
-                                            "Initial IBD has been completed with respect to peer"
-                                        );
-                                        // Get current time and create recent timestamps (within last hour)
-                                        let current_time = SystemTime::now()
-                                            .duration_since(UNIX_EPOCH)
-                                            .map(|d| d.as_secs())
-                                            .unwrap_or_else(|e| {
-                                                error!(error = %e, "System time before UNIX epoch");
-                                                0
-                                            });
-                                        match ibd_command_tx.send(IBDCommands::UpdateTimestampMapping { peer_id: peer.to_string(), end_timestamp: current_time }).await{
-                                            Ok(_)=>{
-                                                debug!("Timestamp updated command sent successfully");
-                                                //Scheduling a corresponding watcher task that will check after a latency period
-                                                //if no incoming is received during the instance of [initial_headers_fetched,(initial_headers_fetched+(alpha*10))]
-                                                let ibd_spinlock_ref = ibd_spinlock.clone();
-                                                let ibd_incoming_handler = tokio::spawn(async move{
-                                                    //Sleeping for a fixed duration to be set according to statistical estimates
-                                                    tokio::time::sleep(Duration::from_secs(MAX_IBD_INCOMING_THRESHOLD)).await;
-                                                    //We will check if no bead is `incoming` after the duration of 600 seconds then we will reset/set ibd_flag accordingly
-                                                    if ibd_spinlock_ref.load(Ordering::SeqCst){
-                                                        //If no incoming is received during the period then we can say
-                                                        //that ibd wrt the given sync node is successfully completed
-                                                        ibd_spinlock_ref.store(false,Ordering::SeqCst);
-                                                        warn!("Maximum threshold wrt IBD incoming exceeded thus ibd_flag being set to false");
-                                                    }
-
-                                                });
-                                                //At retry we will have to abort and evict the corresponding sync-peers's wait handle
-                                                match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:peer,retry_or_not:false,handle:Some(ibd_incoming_handler)}).await{
-                                                    Ok(_)=>{
-                                                        debug!("Incoming bead command sent successfully");
-                                                    },
-                                                    Err(error)=>{
-                                                        error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                                    }
-                                                };
-                                            },
-                                            Err(error)=>{
-                                                error!(error=?error,"An error occurred while sending timestamp update command for the given sync node");
-                                            }
-                                        };
-                                    }
-                                }
-                                 BeadResponse::GetBeadsAfter(bead_hashes)=>{
-                                    //Getting all the beadhashes after the common oldest in both the peers
-                                    let (tips_tx, tips_rx) = tokio::sync::oneshot::channel::<Vec<BeadHash>>();
-                                    match ibd_command_tx.send(IBDCommands::FetchTips { peer_id: peer.to_string(), tips_sender: tips_tx }).await{
-                                        Ok(_)=>{
-                                            debug!("Sync peer Tips received successfully.");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"Error occurred while receiving tips, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    let received_tips = match tips_rx.await{
-                                        Ok(received_tips)=>{
-                                            received_tips
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while receiving the Tips, re-trying IBD");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    //Pruning the hashes wrt cached `Tips`
-                                    let mut found_tips = HashSet::new();
-                                    let mut pruned = Vec::new();
-                                    let tips_set: HashSet<_> = received_tips.into_iter().collect();
-                                    for hash in bead_hashes {
-                                        if tips_set.contains(&hash) {
-                                            found_tips.insert(hash.clone());
-                                        }
-                                        pruned.push(hash);
-                                        // Stop once all tips have been matched
-                                        if found_tips.len() == tips_set.len() {
-                                            break;
-                                        }
-                                    }
-                                    let pruned_ref = pruned.clone();
-                                    // Storing them in cache
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncoming { get_bead_response: pruned, peer_id: peer.to_string() }).await{
-                                        Ok(_)=>{
-                                            debug!("Received beads to be fetched in GetBeads saved successfully");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while Caching pruned beadhashes to be fetched in GetBeads");
-                                            match swarm_command_sender.send(SwarmCommand::InitiateIBD).await{
-                                                Ok(_)=>{
-                                                    warn!("Reinitiating IBD command sent to swarm handler");
-                                                },
-                                                Err(error)=>{
-                                                    error!(error=?error,"Reinitiating IBD failed in GetBeadsAfter Response - ");
-                                                }
-                                            }
-                                            continue;
-                                        }
-                                    };
-                                    // Initiating `GetBead` request cycle
-                                    if pruned_ref.len() <= IBD_BATCH_SIZE{
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref);
-                                    }
-                                    else{
-                                        swarm.behaviour_mut().request_beads(peer, &pruned_ref[0..IBD_BATCH_SIZE].to_vec());
-                                    }
-
-                                }
-                                BeadResponse::Tips(tips) => {
-                                    info!(tips = ?tips, tip_count = %tips.len(), "Received braid tips");
-                                    //If received tips are already present in the local braid arc then we can stop
-                                    //IBD and continue with mining
-                                    //Initializing the batch offset for the corresponding sync peer
-                                    let (ibd_bridge_tx, _ibd_bridge_rx) = tokio::sync::oneshot::channel::<usize>();
-                                    match ibd_command_tx.send(IBDCommands::UpdateAndFetchBatchOffset { peer_id: peer.to_string(), offset_sender: ibd_bridge_tx, batch_size: IBD_BATCH_SIZE }).await{
-                                        Ok(_)=>{
-                                            debug!("Offset Initialized successfully");
-                                        },
-                                        Err(_error)=>{
-                                            error!("An error occurred while sending offset initalization command to ibd_handler");
-                                            continue;
-                                        }
-                                    };
-                                    let _val = match _ibd_bridge_rx.await {
-                                        Ok(v) => v,
-                                        Err(e) => {
-                                            error!(error = %e, "Failed to receive IBD batch offset");
-                                            continue;
-                                        }
-                                    };
-                                    let braid_data = braid.read().await;
-
-                                    let bead_hash_set: HashSet<BeadHash> = braid_data
-                                    .beads
-                                    .iter()
-                                    .map(|b| b.block_header.block_hash())
-                                    .collect();
-
-                                    let flag = tips.iter().all(|tip_hash| bead_hash_set.contains(tip_hash));
-
-                                    if flag{
-                                        //No need to proceed further and continue to next event
-                                        info!("Peer already synced to tip");
-                                        //IBD flag can be set  as the current bead is already synced//
-                                        ibd_spinlock.store(false, Ordering::SeqCst);
-                                        continue;
-                                    }
-                                  let _update_tip_cache_ack = match  ibd_command_tx.send(IBDCommands::UpdateIBDTipsMapping { received_tips: tips.0, peer_id: peer.to_string() }).await{
-                                    Ok(_)=>{
-                                        debug!("Sync peers Tip mapping update successfully");
-                                    },
-                                    Err(error)=>{
-                                        tracing::error!(
-                                            err = ?error,
-                                            "Error while sending update cache command"
-                                        );
-                                        continue;
-                                    }
-                                  };
-                                    // After storing tips we will issue `GetBeads` command that will find the oldest
-                                    // common bead if any and will send the beadhashes of all the next beads this will either be the current tips or
-                                    // the current genesis in all the cases in case of new braid-node this will be genesis otherwise it will always be tips
-                                    let mut current_tip_hashes = Vec::new();
-                                    for curr_bead_idx in braid_data.tips.iter() {
-                                        if let Some(current_bead) = braid_data.beads.get(*curr_bead_idx) {
-                                            current_tip_hashes.push(current_bead.block_header.block_hash());
-                                        } else {
-                                            error!(bead_idx = %curr_bead_idx, "Tip bead not found in beads list");
-                                        }
-                                    }
-                                    // Sending the current bead hashes for the receiving of beads to start in batches
-                                    let get_bead_start_request:BeadRequest = BeadRequest::GetBeadsAfter(BeadHashes(current_tip_hashes));
-                                    swarm.behaviour_mut().bead_sync.send_request(&peer,get_bead_start_request);
-
-                                }
-                                BeadResponse::Genesis(genesis) => {
-                                    info!(genesis=?genesis,"Received genesis beads: ");
-                                    let status = {
-                                        let braid_lock = braid.read().await;
-                                        braid_lock.check_genesis_beads(&genesis.0)
-                                    };
-                                    match status {
-                                        braid::GenesisCheckStatus::GenesisBeadsValid => {
-                                            info!("Genesis beads are valid");
-                                        }
-                                        braid::GenesisCheckStatus::MissingGenesisBead => {
-                                            warn!(peer = %peer, "Missing genesis bead");
-                                            swarm
-                                                .behaviour_mut()
-                                                .request_beads(peer, &genesis.0);
-                                        }
-                                        braid::GenesisCheckStatus::GenesisBeadsCountMismatch => {
-                                            warn!(
-                                                received = %genesis.0.len(),
-                                                peer = %peer,
-                                                "Genesis bead count mismatch"
-                                            );
-                                        }
-                                    }
-                                }
-                                BeadResponse::Error(error) => match error {
-                                    BeadSyncError::GenesisMismatch => {
-                                        warn!("Genesis mismatch error received");
-                                        swarm.behaviour_mut().request_genesis(peer.clone());
-                                    }
-                                    BeadSyncError::BeadHashNotFound => {
-                                        warn!("Peer requested bead hashes not found in local store");
-                                    }
-                                },
-                            };
-                        }
-                    }
+                          }
+                      }
+                  }
                 }
-                     other_event=>{
-                             debug!(event = ?other_event, "Other swarm event");
-                     }
-                 }
-
-             }
-             Some(swarm_command) = swarm_command_receiver.recv()=>{
-                 match swarm_command{
-                     SwarmCommand::PropagateValidBead {
-                         bead_bytes,
-                     } => {
-                         swarm
-                             .behaviour_mut()
-                             .bead_announce
-                             .publish(current_broadcast_topic.clone(), bead_bytes);
-                        info!(topic = ?current_broadcast_topic, "Published bead to floodsub topic");
-                     },
-                     SwarmCommand::InitiateIBD=>{
-                        info!("Initiating IBD after peer discovery and selecting peer with lowest latency score");
-                        //Evicting lowest latency peer id
-                        let peer_ids = peer_manager.get_top_k_peers_for_propagation(1);
-                        if peer_ids.len() == 0 {
-                            warn!("No peer available for syncing to take place");
-                                tokio::spawn({
-                                    let swarm_command_sender = swarm_command_sender.clone();
-                                    //Retrying at fixed interval in case of no sync peers being available
-                                    async move {
-                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
-                                            Ok(_) => {
-                                                info!("Retrying IBD when no sync peers are available");
-                                            }
-                                            Err(error) => {
-                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
-                                            }
-                                        }
-                                    }
-                                });
-                        }
-                        else{
-                            let mut sync_request_sent = false;
-                            for lowest_latency_peer in peer_ids.into_iter(){
-                                let (retry_count_tx,retry_count_rx) = tokio::sync::oneshot::channel();
-                                match ibd_command_tx.send(IBDCommands::GetIncomingBeadRetryCount{peer_id:lowest_latency_peer,retry_sender:retry_count_tx}).await{
-                                    Ok(_)=>{
-                                        info!(peer=?lowest_latency_peer,"Retry count corresponding to peer received successfully");
-                                    },
-                                    Err(error)=>{
-                                        error!(error=?error,"An error occurred while sending retry count to IBDHandler");
-                                    }
-                                }
-                                let retry_cnt = match retry_count_rx.await {
-                                    Ok(cnt) => cnt,
-                                    Err(e) => {
-                                        error!(error=?e, "Failed to receive retry count from IBDHandler, channel closed or sender dropped");
-                                        continue;
-                                    }
-                                };
-                                if retry_cnt >= MAX_IBD_RETRIES && retry_cnt != u64::MAX{
-                                    warn!("Corresponding peer {:?} retries for IBD exceeded selecting next lowest latent peer",lowest_latency_peer);
-                                    continue;
-                                }
-                                else if retry_cnt == u64::MAX{
-                                    //First time syncing is being done wrt the provided peer
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:false,handle:None}).await{
-                                        Ok(_)=>{
-                                            info!("Incoming bead command sent successfully");
-                                            let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                            swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                        }
-                                    };
-                                    sync_request_sent = true;
-                                    break;
-                                }
-                                else{
-                                    //Case of retry is there
-                                    match ibd_command_tx.send(IBDCommands::UpdateIncomingBeadMapping{peer_id:lowest_latency_peer,retry_or_not:true,handle:None}).await{
-                                        Ok(_)=>{
-                                            info!("Incoming bead command sent successfully");
-                                        },
-                                        Err(error)=>{
-                                            error!(error=?error,"An error occurred while sending Update Incoming due to ");
-                                        }
-                                    };
-                                    //Initiating IBD and sending the request to fetch tips and store them in a centralized mapping owned by main_thread .
-                                    let sync_start_request:BeadRequest = BeadRequest::GetTips;
-                                    swarm.behaviour_mut().bead_sync.send_request(&lowest_latency_peer, sync_start_request);
-                                    sync_request_sent = true;
-                                    break;
-                                }
-
-                            }
-                            if sync_request_sent{
-                                //The lowest latency avaialble sync peer whose retry count is not exceeded has been selected and requested to initiate IBD
-                                continue;
-                            }
-                            else{
-                                warn!("Retry count for all the available sync peers exceeded waiting for new peer connections");
-                                tokio::spawn({
-                                    let swarm_command_sender = swarm_command_sender.clone();
-                                    //Retrying at fixed interval in case of all available sync peer retry count has exceeded
-                                    //Probe at fixed interval for any new peer
-                                    async move {
-                                        tokio::time::sleep(Duration::from_secs(IBD_TRIGGER_AFTER)).await;
-                                        match swarm_command_sender.send(SwarmCommand::InitiateIBD).await {
-                                            Ok(_) => {
-                                                info!("Retrying IBD when no sync peers are available");
-                                            }
-                                            Err(error) => {
-                                                error!(error=?error, "Failed to reinitiate IBD when no sync peer was available");
-                                            }
-                                        }
-                                    }
-                                });
-                            }
-                        }
-                     }
-                 }
-             }
-
-
-
-
             }
-        }
-    });
+        })
+    } else {
+        info!("Skipping P2P swarm, audit mode enabled");
+        tokio::spawn(async {}) // dummy handler for the shutdown abort() call
+    };
 
     //graceful shutdown via `Cancellation token`
     let shutdown_signal = tokio::signal::ctrl_c().await;

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -697,7 +697,6 @@ impl DownstreamClient {
                     audit_dag,
                     upstream_share_tx,
                     upstream_difficulty,
-                    swarm_handler,
                 )
                 .await;
         }
@@ -1065,7 +1064,6 @@ impl DownstreamClient {
         audit_dag: Option<Arc<Mutex<crate::audit::AuditDAG>>>,
         upstream_share_tx: Option<mpsc::Sender<crate::upstream_pool::UpstreamShare>>,
         upstream_difficulty: Option<f64>,
-        swarm_handler: Arc<Mutex<SwarmHandler>>,
     ) -> Result<StratumResponses, StratumErrors> {
         let ntime_u32 =
             u32::from_str_radix(ntime, 16).map_err(|e| StratumErrors::InvalidMethodParams {
@@ -1193,7 +1191,6 @@ impl DownstreamClient {
             let share_id = block_hash;
 
             let bead = {
-                let swarm = swarm_handler.lock().await;
                 let payout_address = self
                     .payout_address
                     .as_ref()
@@ -1225,16 +1222,14 @@ impl DownstreamClient {
                     .to_string();
 
                 let (parent_hash_set, time_hash_set) = {
-                    let braid = swarm.braid_arc.read().await;
                     let mut parents = std::collections::HashSet::new();
                     let mut timestamps = crate::committed_metadata::TimeVec(Vec::new());
-                    for &tip_idx in braid.tips.iter() {
-                        if let Some(tip_bead) = braid.beads.get(tip_idx) {
-                            let standard_hash = tip_bead.block_header.block_hash();
-                            parents.insert(crate::utils::BeadHash::from(standard_hash));
-                            timestamps
-                                .0
-                                .push(tip_bead.committed_metadata.start_timestamp);
+
+                    if let Some(ref dag_mutex) = audit_dag {
+                        let dag = dag_mutex.lock().await;
+                        for &(_comp_hash, block_hash, parent_time) in &dag.active_parents {
+                            parents.insert(crate::utils::BeadHash::from(block_hash));
+                            timestamps.0.push(parent_time);
                         }
                     }
                     if parents.is_empty() {

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -126,7 +126,7 @@ pub struct StratumServerConfig {
     /// Indicates audit mode.
     pub audit_mode: bool,
     /// Audit mode miner weak difficulty
-    pub audit_miner_difficulty: f64,
+    pub audit_miner_difficulty: Option<f64>,
 }
 
 impl Default for StratumServerConfig {
@@ -140,7 +140,7 @@ impl Default for StratumServerConfig {
             maximum_difficulty: None,
             solo_address: None,
             audit_mode: false,
-            audit_miner_difficulty: 100.0,
+            audit_miner_difficulty: None,
         }
     }
 }
@@ -245,7 +245,7 @@ pub struct DownstreamClient {
     // Payout address used in the audit mode
     pub payout_address: Option<String>,
     // Refers to the miner difficulty in audit mode
-    pub audit_miner_difficulty: f64,
+    pub audit_miner_difficulty: Option<f64>,
 }
 impl DownstreamClient {
     /// A helper function to keep connection_id immutable after assignment
@@ -415,7 +415,7 @@ impl DownstreamClient {
                     };
                     if let Some(diff) = upstream_diff {
                         let miner_difficulty: f64 = if self.is_proxy_mode {
-                            self.audit_miner_difficulty
+                            self.audit_miner_difficulty.unwrap_or(diff)
                         } else {
                             diff
                         };
@@ -1109,10 +1109,11 @@ impl DownstreamClient {
         let mut candidates = vec![self.extranonce1.clone()];
         candidates.extend(self.extranonce_history.iter().cloned());
         let miner_difficulty = if self.is_proxy_mode {
-            self.audit_miner_difficulty
+            self.audit_miner_difficulty.or(upstream_difficulty)
         } else {
-            100.0
-        };
+            None
+        }
+        .unwrap_or(100.0);
         let miner_target = Self::target_from_difficulty(miner_difficulty);
         let upstream_target = upstream_difficulty
             .map(|d| Self::target_from_difficulty(d))
@@ -1940,7 +1941,7 @@ impl Default for DownstreamClient {
             block_submission_tx: None,
             is_proxy_mode: false,
             payout_address: None,
-            audit_miner_difficulty: 100.0,
+            audit_miner_difficulty: None,
         }
     }
 }

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1223,14 +1223,22 @@ impl DownstreamClient {
                     .to_string();
 
                 let (parent_hash_set, time_hash_set) = {
-                    let mut parents = std::collections::HashSet::new();
+                    let mut parents: Vec<crate::utils::BeadHash> = Vec::new();
                     let mut timestamps = crate::committed_metadata::TimeVec(Vec::new());
 
                     if let Some(ref dag_mutex) = audit_dag {
                         let dag = dag_mutex.lock().await;
-                        for &(_comp_hash, block_hash, parent_time) in &dag.active_parents {
-                            parents.insert(crate::utils::BeadHash::from(block_hash));
-                            timestamps.0.push(parent_time);
+                        let mut pairs: Vec<(crate::utils::BeadHash, bitcoin::absolute::Time)> = dag
+                            .active_parents
+                            .iter()
+                            .map(|&(_, block_hash, parent_time)| {
+                                (crate::utils::BeadHash::from(block_hash), parent_time)
+                            })
+                            .collect();
+                        pairs.sort_by_key(|(hash, _)| *hash);
+                        for (hash, time) in pairs {
+                            parents.push(hash);
+                            timestamps.0.push(time);
                         }
                     }
                     if parents.is_empty() {

--- a/node/src/upstream_pool.rs
+++ b/node/src/upstream_pool.rs
@@ -173,7 +173,7 @@ impl UpstreamCache {
 
         self.latest_job = Some(CachedItem::new(job.clone(), 3600)); // 1 hour
 
-        info!(
+        debug!(
             job_id = %job.job_id,
             clean_jobs = %job.clean_jobs,
             "Cached upstream job"

--- a/node/src/upstream_pool.rs
+++ b/node/src/upstream_pool.rs
@@ -22,13 +22,10 @@ const WRITE_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct UpstreamCache {
     /// Cached mining.configure response (version rolling mask, etc.)
     pub configure_response: Option<CachedItem<Value>>,
-
     /// Cached mining.subscribe response (extranonce1, extranonce2_size)
     pub subscribe_response: Option<CachedItem<UpstreamSubscribeResponse>>,
-
     /// Current difficulty from upstream
     pub current_difficulty: Option<CachedItem<f64>>,
-
     /// Most recent job notification
     pub latest_job: Option<CachedItem<JobNotification>>,
 }
@@ -38,10 +35,8 @@ pub struct UpstreamCache {
 pub struct CachedItem<T> {
     /// The cached value
     pub value: T,
-
     /// When this item was cached
     pub cached_at: std::time::SystemTime,
-
     /// TTL in seconds, how long this item stays valid
     pub ttl_seconds: u64,
 }
@@ -306,14 +301,14 @@ pub struct UpstreamPoolClient {
     configure_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>>>,
     /// Shared cache for upstream responses and state
     upstream_cache: Arc<RwLock<UpstreamCache>>,
-    /// Shared reference to the Braid structure for bead/audit operations
-    braid_arc: Arc<tokio::sync::RwLock<crate::braid::Braid>>,
     /// Channel for sending upstream share responses and events with ShareId to the audit log
     audit_log_tx: mpsc::Sender<(crate::audit::ShareId, Value)>,
     // Track subscribe handshake request ID
     subscribe_req_id: Option<u64>,
     // Track authorize handshake requet ID
     authorize_req_id: Option<u64>,
+    /// Audit DAG for tracking commitment chain in audit mode
+    pub audit_dag_arc: Arc<futures::lock::Mutex<crate::audit::AuditDAG>>,
 }
 
 impl UpstreamPoolClient {
@@ -327,8 +322,8 @@ impl UpstreamPoolClient {
         difficulty_tx: Option<mpsc::Sender<f64>>,
         configure_rx: Arc<tokio::sync::Mutex<mpsc::Receiver<(Value, u64, mpsc::Sender<Value>)>>>,
         upstream_cache: Arc<RwLock<UpstreamCache>>,
-        braid_arc: Arc<tokio::sync::RwLock<crate::braid::Braid>>,
         audit_log_tx: mpsc::Sender<(crate::audit::ShareId, Value)>,
+        audit_dag_arc: Arc<futures::lock::Mutex<crate::audit::AuditDAG>>,
     ) -> Self {
         Self {
             config,
@@ -346,10 +341,10 @@ impl UpstreamPoolClient {
             difficulty_tx,
             configure_rx,
             upstream_cache,
-            braid_arc,
             audit_log_tx,
             subscribe_req_id: None,
             authorize_req_id: None,
+            audit_dag_arc,
         }
     }
 
@@ -1033,34 +1028,43 @@ impl UpstreamPoolClient {
                     );
                     debug!("Upstream parsed job: {:?}", job);
 
-                    let bead_hash = {
-                        let braid = self.braid_arc.read().await;
-
-                        if let Some(&latest_tip_idx) = braid.tips.iter().next() {
-                            if let Some(bead) = braid.beads.get(latest_tip_idx) {
-                                crate::audit::compute_audit_bead_hash(bead)
-                            } else {
-                                bitcoin::BlockHash::from_byte_array([0u8; 32])
+                    let commitment_hash = {
+                        let mut dag = self.audit_dag_arc.lock().await;
+                        match dag.advance_generation() {
+                            Ok(hash) => {
+                                info!(
+                                    job_id = %job.job_id,
+                                    generation_hash = %hash,
+                                    "Upstream job received, DAG generation shifted"
+                                );
+                                hash
                             }
-                        } else {
-                            bitcoin::BlockHash::from_byte_array([0u8; 32])
+                            Err(e) => {
+                                error!("Critical failure advancing DAG generation: {}", e);
+                                return Err(StratumErrors::InvalidMethodParams {
+                                    method: format!(
+                                        "mining.notify: DAG generation shift failed - {}",
+                                        e
+                                    ),
+                                });
+                            }
                         }
                     };
                     if let Err(e) = self
                         .notification_tx
                         .send(NotifyCmd::UpdateExtranonce {
-                            new_bead_hash: bead_hash,
+                            new_bead_hash: commitment_hash,
                         })
                         .await
                     {
                         error!(
-                            bead_hash = %bead_hash,
+                            bead_hash = %commitment_hash,
                             error = %e,
                             "Failed to send extranonce update command to notifier"
                         );
                     } else {
                         debug!(
-                            bead_hash = %bead_hash,
+                            bead_hash = %commitment_hash,
                             "Sent extranonce update command to notifier"
                         );
                     }
@@ -1518,7 +1522,10 @@ mod tests {
         let (response_tx, _response_rx) = mpsc::channel(10);
         let (_configure_tx, configure_rx) = mpsc::channel(10);
         let (audit_log_tx, _audit_log_rx) = mpsc::channel(10);
-
+        let braid_arc = Arc::new(tokio::sync::RwLock::new(Braid::new(vec![])));
+        let audit_dag_arc = Arc::new(futures::lock::Mutex::new(crate::audit::AuditDAG::new(
+            braid_arc,
+        )));
         let client = UpstreamPoolClient::new(
             config,
             Arc::new(tokio::sync::Mutex::new(share_rx)),
@@ -1529,8 +1536,8 @@ mod tests {
             None,
             Arc::new(tokio::sync::Mutex::new(configure_rx)),
             UpstreamCache::new(),
-            Arc::new(tokio::sync::RwLock::new(Braid::new(vec![]))),
             audit_log_tx,
+            audit_dag_arc,
         );
 
         (client, job_rx, notification_rx)

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -27,16 +27,6 @@ pub(crate) type Relatives = HashSet<BeadHash>;
 // Error Definitions
 use std::{collections::HashSet, net::IpAddr, str::FromStr};
 
-pub(crate) fn hashset_to_vec_deterministic(hashset: &HashSet<BeadHash>) -> Vec<BeadHash> {
-    let mut vec: Vec<BeadHash> = hashset.iter().cloned().collect();
-    vec.sort();
-    vec
-}
-
-pub(crate) fn vec_to_hashset(vec: Vec<BeadHash>) -> HashSet<BeadHash> {
-    vec.iter().cloned().collect()
-}
-
 /// Get list of actual local IPv4 addresses for servers binding to 0.0.0.0
 ///
 /// Returns all IPv4 addresses found on network interfaces.
@@ -86,9 +76,9 @@ pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
         .parse::<bitcoin::PublicKey>()
         .unwrap();
     let time_hash_set = TimeVec(Vec::new());
-    let mut parent_hash_set: HashSet<BlockHash> = HashSet::new();
+    let mut parent_hash_set: Vec<BlockHash> = Vec::new();
     if let Some(hash) = prev_hash {
-        parent_hash_set.insert(hash);
+        parent_hash_set.push(hash);
     }
     let weak_target = CompactTarget::from_consensus(486604799);
     let min_target = CompactTarget::from_consensus(486604799);

--- a/node/src/utils/test_utils.rs
+++ b/node/src/utils/test_utils.rs
@@ -81,7 +81,7 @@ pub mod test_utility_functions {
                     current_bead
                         .committed_metadata
                         .parents
-                        .insert(parent_bead_block_hash);
+                        .push(parent_bead_block_hash);
 
                     parent_idx_set.insert(*parent_bead_idx);
                 }
@@ -174,7 +174,7 @@ pub mod test_utility_functions {
     #[cfg(test)]
     pub struct TestCommittedMetadataBuilder {
         transaction_ids: Vec<Txid>,
-        parents: std::collections::HashSet<BeadHash>,
+        parents: Vec<BeadHash>,
         parent_bead_timestamps: Option<TimeVec>,
         payout_address: Option<String>,
         start_timestamp: Option<Time>,
@@ -189,7 +189,7 @@ pub mod test_utility_functions {
         pub fn new() -> Self {
             Self {
                 transaction_ids: Vec::new(),
-                parents: HashSet::new(),
+                parents: Vec::new(),
                 parent_bead_timestamps: None,
                 payout_address: None,
                 start_timestamp: None,
@@ -205,7 +205,7 @@ pub mod test_utility_functions {
             self
         }
 
-        pub fn parents(mut self, parents: HashSet<BeadHash>) -> Self {
+        pub fn parents(mut self, parents: Vec<BeadHash>) -> Self {
             self.parents = parents;
             self
         }
@@ -331,7 +331,7 @@ pub mod test_utility_functions {
         let public_key = random_public_key;
         let socket: String = String::from("127.0.0.1");
         let time_hash_set = TimeVec(Vec::new());
-        let parent_hash_set: HashSet<BlockHash> = HashSet::new();
+        let parent_hash_set: Vec<BlockHash> = Vec::new();
         let weak_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();
         let min_target = CompactTarget::from_unprefixed_hex("1d00ffff").unwrap();
         let time_val = current_time;


### PR DESCRIPTION
This PR adds the functionality of having a persistent database into the audit mode; you can treat this PR as a follow-up of [PR#305](https://github.com/braidpool/braidpool/pull/305). With this you can mine shares on an upstream pool while auditing all the things related to each miner's work (hashrate) statistics etc and save them safely on your local persistence storage. The saved records can we used to verify the active involvement of a miner mining shares or producing some hashrate on some period X. 

This also supports restarts and stopping and starting the mining work for some interval; for example, if someone wants to mine on some particular hours of a day or on some intervals, then he can stop the node and restart later whenever he wants, and the DAG chain will completely restart and recover itself from the last mining info and will start mining on top of previous DAG tips, leading to no breakage of DAG and creating a valid, consistent chain of records. For this the node uses a feature called _State Snapshotting_ or _Pruned Initialization_ in which we restart a node using the valid last snapshot of data without feeding or initializing with the entire data. In our case a node can create a valid in-memory bead as a starting point by fetching the last valid snapshot from the database..