### PR TITLE
removing forked dependency for updated version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,15 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base58ck"
-version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,11 +408,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
-source = "git+https://github.com/braidpool/rust-bech32.git?branch=cpunet#34d8ea70211b4178b6b5c540e17981719faccdd2"
-
-[[package]]
-name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
@@ -437,38 +423,19 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.7-pre-cpunet"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "base58ck 0.2.0",
- "base64 0.22.1",
- "bech32 0.11.0",
- "bitcoin-internals 0.4.0",
- "bitcoin-io 0.2.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "bitcoin-primitives",
- "bitcoin-units 0.2.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "bitcoinconsensus",
- "hex-conservative 0.3.1",
- "secp256k1 0.30.0",
- "serde",
-]
-
-[[package]]
-name = "bitcoin"
 version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
- "base58ck 0.1.0",
- "bech32 0.11.1",
+ "base58ck",
+ "bech32",
  "bitcoin-internals 0.3.0",
  "bitcoin-io 0.1.4",
- "bitcoin-units 0.1.2",
+ "bitcoin-units",
  "bitcoin_hashes 0.14.1",
  "hex-conservative 0.2.2",
  "hex_lit",
- "secp256k1 0.29.1",
+ "secp256k1",
  "serde",
 ]
 
@@ -478,15 +445,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.4.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "hex-conservative 0.3.1",
  "serde",
 ]
 
@@ -518,43 +476,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
-]
-
-[[package]]
-name = "bitcoin-primitives"
-version = "0.101.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "arrayvec",
- "bitcoin-internals 0.4.0",
- "bitcoin-units 0.2.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "hex-conservative 0.3.1",
- "serde",
-]
-
-[[package]]
 name = "bitcoin-units"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
 dependencies = [
  "bitcoin-internals 0.3.0",
- "serde",
-]
-
-[[package]]
-name = "bitcoin-units"
-version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
  "serde",
 ]
 
@@ -575,27 +502,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5d09f16329cd545d7e6008b2c6b2af3a90bc678cf41ac3d2f6755943301b16"
 dependencies = [
- "bitcoin-io 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin-io 0.2.0",
  "hex-conservative 0.3.1",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.16.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
- "hex-conservative 0.3.1",
- "serde",
-]
-
-[[package]]
-name = "bitcoinconsensus"
-version = "0.106.0+26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12cba9cce5043cdda968e07b9df6d05ec6b0b38aa27a9a40bb575cf3e521ae9"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -617,7 +525,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.8",
+ "bitcoin",
  "serde",
  "serde_json",
 ]
@@ -628,7 +536,7 @@ version = "1.5.4"
 source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#7a523bd0578db2294403d663cc7e7c84aad3aae9"
 dependencies = [
  "async_zmq",
- "bitcoin 0.32.8",
+ "bitcoin",
  "futures-util",
  "zmq",
  "zmq-sys",
@@ -1753,7 +1661,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2b9348ee0d8d4e3a894946c1ab104d08a2e44ca13656613afada8905ea609b6"
 dependencies = [
  "arrayvec",
- "serde",
 ]
 
 [[package]]
@@ -3251,9 +3158,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bitcoin 0.32.7-pre-cpunet",
+ "bitcoin",
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.16.0",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "bitcoincore-zmq",
@@ -3270,7 +3177,7 @@ dependencies = [
  "num",
  "rand 0.8.5",
  "reqwest",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_json",
  "shellexpand",
@@ -4291,18 +4198,6 @@ name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "bitcoin_hashes 0.14.1",
- "rand 0.8.5",
- "secp256k1-sys",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes 0.14.1",
  "rand 0.8.5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -28,9 +28,9 @@ dependencies = [
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -43,15 +43,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -78,9 +78,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.100"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arrayref"
@@ -158,13 +158,13 @@ dependencies = [
 
 [[package]]
 name = "async-executor"
-version = "1.13.3"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "497c00e0fd83a72a79a39fcbd8e3e2f055d6f6c7e025f3b3d91f4f8e76527fb8"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "futures-lite 2.6.1",
  "pin-project-lite",
  "slab",
@@ -218,7 +218,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "parking",
  "polling 3.11.0",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -503,7 +503,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5d09f16329cd545d7e6008b2c6b2af3a90bc678cf41ac3d2f6755943301b16"
 dependencies = [
  "bitcoin-io 0.2.0",
- "hex-conservative 0.3.1",
+ "hex-conservative 0.3.2",
 ]
 
 [[package]]
@@ -533,7 +533,7 @@ dependencies = [
 [[package]]
 name = "bitcoincore-zmq"
 version = "1.5.4"
-source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#7a523bd0578db2294403d663cc7e7c84aad3aae9"
+source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#9946d0fe5b4e5b04bef63e5db4a33d044687dd8f"
 dependencies = [
  "async_zmq",
  "bitcoin",
@@ -550,9 +550,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -601,9 +601,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -659,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -705,9 +705,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
  "num-traits",
@@ -716,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -726,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -738,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -750,15 +750,15 @@ dependencies = [
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "combine"
@@ -1013,9 +1013,9 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.5"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ececcb659e7ba858fb4f10388c250a7252eb0a27373f1a72b8748afdd248e587"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
 ]
@@ -1034,9 +1034,9 @@ dependencies = [
 
 [[package]]
 name = "dircpy"
-version = "0.3.19"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a88521b0517f5f9d51d11925d8ab4523497dcf947073fa3231a311b63941131c"
+checksum = "ebcbec2b9a580ddee352ac38523d2ecd4dcaad53532957034394556909e27f4b"
 dependencies = [
  "jwalk",
  "log",
@@ -1212,9 +1212,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "fiat-crypto"
@@ -1293,9 +1293,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 
 [[package]]
 name = "futures"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1318,9 +1318,9 @@ dependencies = [
 
 [[package]]
 name = "futures-channel"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
  "futures-sink",
@@ -1328,20 +1328,19 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
- "num_cpus",
 ]
 
 [[package]]
@@ -1357,9 +1356,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
 name = "futures-lite"
@@ -1382,7 +1381,7 @@ version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -1391,9 +1390,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1413,15 +1412,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
 name = "futures-timer"
@@ -1435,9 +1434,9 @@ dependencies = [
 
 [[package]]
 name = "futures-util"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
  "futures-core",
@@ -1447,7 +1446,6 @@ dependencies = [
  "futures-task",
  "memchr",
  "pin-project-lite",
- "pin-utils",
  "slab",
 ]
 
@@ -1494,9 +1492,22 @@ dependencies = [
  "cfg-if 1.0.4",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1608,9 +1619,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
 name = "hashlink"
@@ -1656,9 +1667,9 @@ dependencies = [
 
 [[package]]
 name = "hex-conservative"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2b9348ee0d8d4e3a894946c1ab104d08a2e44ca13656613afada8905ea609b6"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
 ]
@@ -1686,7 +1697,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.2",
+ "rand 0.9.3",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1708,7 +1719,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.2",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -1836,9 +1847,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -1851,7 +1862,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -1864,7 +1874,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
  "http 1.4.0",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "rustls",
@@ -1898,10 +1908,10 @@ dependencies = [
  "futures-util",
  "http 1.4.0",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "libc",
  "pin-project-lite",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1919,7 +1929,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1933,12 +1943,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1946,9 +1957,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1959,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1973,15 +1984,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1993,15 +2004,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -2011,6 +2022,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "idna"
@@ -2035,16 +2052,6 @@ dependencies = [
 
 [[package]]
 name = "if-addrs"
-version = "0.10.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cabb0019d51a643781ff15c9c8a3e5dedc365c47211270f4e8f82812fedd8f0a"
-dependencies = [
- "libc",
- "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "if-addrs"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
@@ -2054,16 +2061,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "if-watch"
-version = "3.2.1"
+name = "if-addrs"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cdf9d64cfcf380606e64f9a0bcf493616b65331199f984151a6fa11a7b3cde38"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "if-watch"
+version = "3.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io 2.6.0",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
- "if-addrs 0.10.2",
+ "if-addrs 0.15.0",
  "ipnet",
  "log",
  "netlink-packet-core",
@@ -2071,7 +2088,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.6.1",
+ "system-configuration 0.7.0",
  "tokio",
  "windows",
 ]
@@ -2088,7 +2105,7 @@ dependencies = [
  "futures",
  "http 1.4.0",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "rand 0.8.5",
@@ -2099,12 +2116,14 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -2138,21 +2157,22 @@ dependencies = [
 
 [[package]]
 name = "ipconfig"
-version = "0.3.2"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b58db92f96b720de98181bbbe63c831e87005ab460c1bf306eb2622b4707997f"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "widestring",
- "windows-sys 0.48.0",
- "winreg",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "ipnet"
-version = "2.11.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "469fb0b9cefa57e3ef31275ee7cacb78f2fdca44e4765491884a2b119d4eb130"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
 name = "is_terminal_polyfill"
@@ -2162,9 +2182,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jni"
@@ -2175,7 +2195,7 @@ dependencies = [
  "cesu8",
  "cfg-if 1.0.4",
  "combine",
- "jni-sys",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2184,9 +2204,31 @@ dependencies = [
 
 [[package]]
 name = "jni-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "jobserver"
@@ -2200,10 +2242,12 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if 1.0.4",
+ "futures-util",
  "once_cell",
  "wasm-bindgen",
 ]
@@ -2279,7 +2323,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.2",
+ "rand 0.9.3",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2299,7 +2343,7 @@ checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
 dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
  "jsonrpsee-core",
@@ -2337,7 +2381,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.9.0",
  "hyper-util",
  "jsonrpsee-core",
  "jsonrpsee-types",
@@ -2431,10 +2475,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "libc"
-version = "0.2.180"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bcc35a38544a891a5f7c865aca548a982ccb3b8650a5b06d0fd33a10283c56fc"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -2805,13 +2855,14 @@ dependencies = [
 
 [[package]]
 name = "libredox"
-version = "0.1.12"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d0b95e02c851351f877147b7deea7b1afb1df71b63aa5f8270716e0c5720616"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "libc",
- "redox_syscall 0.7.0",
+ "plain",
+ "redox_syscall 0.7.4",
 ]
 
 [[package]]
@@ -2833,15 +2884,15 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.11.0"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -2908,9 +2959,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.7.6"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f52b00d39961fc5b2736ea853c9cc86238e165017a493d1d5c8eac6bdc4cc273"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "mime"
@@ -2955,9 +3006,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
@@ -2978,9 +3029,9 @@ dependencies = [
 
 [[package]]
 name = "moka"
-version = "0.12.13"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac832c50ced444ef6be0767a008b02c106a909ba79d1d830501e94b96f6b7e"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-epoch",
@@ -3078,46 +3129,30 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-core"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72724faf704479d67b388da142b186f916188505e7e0b26719019c525882eda4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "anyhow",
- "byteorder",
- "netlink-packet-utils",
+ "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "anyhow",
- "bitflags 1.3.2",
- "byteorder",
+ "bitflags 2.11.0",
  "libc",
+ "log",
  "netlink-packet-core",
- "netlink-packet-utils",
-]
-
-[[package]]
-name = "netlink-packet-utils"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ede8a08c71ad5a95cdd0e4e52facd37190977039a4704eb82a283f713747d34"
-dependencies = [
- "anyhow",
- "byteorder",
- "paste",
- "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "netlink-proto"
-version = "0.11.5"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72452e012c2f8d612410d89eea01e2d9b56205274abb35d53f60200b2ec41d60"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
  "futures",
@@ -3142,12 +3177,13 @@ dependencies = [
 
 [[package]]
 name = "nix"
-version = "0.26.4"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.11.0",
  "cfg-if 1.0.4",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -3265,9 +3301,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
 name = "num-integer"
@@ -3312,16 +3348,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "num_cpus"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
-dependencies = [
- "hermit-abi 0.5.2",
- "libc",
-]
-
-[[package]]
 name = "oid-registry"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3332,9 +3358,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "once_cell_polyfill"
@@ -3344,11 +3370,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.75"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08838db121398ad17ab8531ce9de97b244589089e290a384c900cb9ff7434328"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
@@ -3376,9 +3402,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.111"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82cab2d520aa75e3c58898289429321eb788c3106963d0dc886ec7a5f4adc321"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -3454,18 +3480,18 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3474,9 +3500,9 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pin-utils"
@@ -3486,12 +3512,12 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "piper"
-version = "0.2.4"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96c8c490f422ef9a4efd2cb5b42b76c8613d7e7dfc1caf667b8a3350a5acc066"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.3.0",
+ "fastrand 2.4.1",
  "futures-io",
 ]
 
@@ -3523,6 +3549,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
+
+[[package]]
 name = "polling"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3548,7 +3580,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.5.2",
  "pin-project-lite",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3560,9 +3592,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -3583,12 +3615,22 @@ dependencies = [
 ]
 
 [[package]]
-name = "proc-macro-crate"
-version = "3.4.0"
+name = "prettyplease"
+version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "219cb19e96be00ab2e37d6e299658a0cfa83e52429179969b0f0121b4ac46983"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
- "toml_edit 0.23.10+spec-1.0.0",
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
 ]
 
 [[package]]
@@ -3659,7 +3701,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3668,14 +3710,14 @@ dependencies = [
 
 [[package]]
 name = "quinn-proto"
-version = "0.11.13"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3696,16 +3738,16 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -3715,6 +3757,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -3742,9 +3790,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3855,16 +3903,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
-version = "0.7.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49f3fe0889e69e2ae9e41f4d6c4c0181701d00e4697b356fb1f74173a5e0ee27"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3903,9 +3951,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
@@ -3995,15 +4043,15 @@ dependencies = [
 
 [[package]]
 name = "rtnetlink"
-version = "0.13.1"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a552eb82d19f38c3beed3f786bd23aa434ceb9ac43ab44419ca6d67a7e186c0"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
- "futures",
+ "futures-channel",
+ "futures-util",
  "log",
  "netlink-packet-core",
  "netlink-packet-route",
- "netlink-packet-utils",
  "netlink-proto",
  "netlink-sys",
  "nix",
@@ -4013,9 +4061,9 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -4051,22 +4099,22 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "1.1.3"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.36"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c665f33d38cea657d9614f766881e4d510e0eda4239891eea56b4cadcf01801b"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -4137,9 +4185,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.9"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4165,9 +4213,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.22"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a50f4cf475b65d88e057964e0e9bb1f0aa9bbb2036dc65c64596b42932536984"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -4180,9 +4228,9 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
 ]
@@ -4216,11 +4264,11 @@ dependencies = [
 
 [[package]]
 name = "security-framework"
-version = "3.5.1"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4229,9 +4277,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.15.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4239,9 +4287,9 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "send_wrapper"
@@ -4346,9 +4394,9 @@ dependencies = [
 
 [[package]]
 name = "shellexpand"
-version = "3.1.1"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b1fdf65dd6331831494dd616b30351c38e96e45921a27745cf98490458b90bb"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
 ]
@@ -4416,12 +4464,12 @@ dependencies = [
 
 [[package]]
 name = "socket2"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4557,7 +4605,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -4601,7 +4649,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -4718,9 +4766,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4763,11 +4811,11 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.6.1"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -4819,14 +4867,14 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
- "fastrand 2.3.0",
- "getrandom 0.3.4",
+ "fastrand 2.4.1",
+ "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.3",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -4881,9 +4929,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.46"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9da98b7d9b7dad93488a84b8248efc35352b0b2657397d4167e7ad67e5d535e5"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -4902,9 +4950,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.26"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78cc610bac2dcee56805c99642447d4c5dbde4d01f752ffea0199aee1f601dc4"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4912,9 +4960,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -4922,9 +4970,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -4937,16 +4985,16 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.49.0"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
- "mio 1.1.1",
+ "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.2",
+ "socket2 0.6.3",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -4954,9 +5002,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-macros"
-version = "2.6.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5035,9 +5083,9 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
 ]
@@ -5053,28 +5101,28 @@ dependencies = [
  "serde_spanned",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.23.10+spec-1.0.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84c8b9f757e028cee9fa244aea147aab2a9ec09d5325a9b01e0a49730c2b5269"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
- "toml_datetime 0.7.5+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
-version = "1.0.6+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3198b4b0a8e11f09dd03e133c0280504d0801269e9afa46362ffde1cbeebf44"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5155,9 +5203,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
  "nu-ansi-term",
@@ -5202,9 +5250,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -5220,6 +5268,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unsigned-varint"
@@ -5265,11 +5319,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -5351,6 +5405,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "wasite"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5358,9 +5421,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -5371,23 +5434,19 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
- "cfg-if 1.0.4",
- "futures-util",
  "js-sys",
- "once_cell",
  "wasm-bindgen",
- "web-sys",
 ]
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5395,9 +5454,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5408,18 +5467,52 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "web-sys"
-version = "0.3.85"
+name = "wasm-encoder"
+version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags 2.11.0",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.95"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5441,14 +5534,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.5",
+ "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.5"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36a29fc0408b113f68cf32637857ab740edfafdf460c326cd2afaa2d84cc05dc"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5514,22 +5607,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.53.0"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "efc5cf48f83140dcaab716eeaea345f9e93d0018fb81162753a3f76c3397b538"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-core 0.53.0",
- "windows-targets 0.52.6",
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
 ]
 
 [[package]]
-name = "windows-core"
-version = "0.53.0"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dcc5b895a6377f1ab9fa55acedab1fd5ac0db66ad1e6c7f47e28a22e446a5dd"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-result 0.1.2",
- "windows-targets 0.52.6",
+ "windows-core",
 ]
 
 [[package]]
@@ -5541,8 +5635,19 @@ dependencies = [
  "windows-implement",
  "windows-interface",
  "windows-link",
- "windows-result 0.4.1",
+ "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5574,12 +5679,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
-name = "windows-result"
-version = "0.1.2"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-targets 0.52.6",
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5715,6 +5832,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -5899,9 +6025,18 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -5921,12 +6056,94 @@ name = "wit-bindgen"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags 2.11.0",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "ws2_32-sys"
@@ -5981,9 +6198,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -5992,9 +6209,9 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6004,18 +6221,18 @@ dependencies = [
 
 [[package]]
 name = "zerocopy"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57cf3aa6855b23711ee9852dfc97dfaa51c45feaba5b645d0c777414d494a961"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.38"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a616990af1a287837c4fe6596ad77ef57948f787e46ce28e166facc0cc1cb75"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6024,18 +6241,18 @@ dependencies = [
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6061,9 +6278,9 @@ dependencies = [
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -6072,9 +6289,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -6083,9 +6300,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6094,9 +6311,9 @@ dependencies = [
 
 [[package]]
 name = "zmij"
-version = "1.0.19"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ff05f8caa9038894637571ae6b9e29466c1f4f829d26c9b28f869a29cbe3445"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]
 name = "zmq"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,15 +383,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "base58ck"
-version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
-]
-
-[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -417,11 +408,6 @@ checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "bech32"
-version = "0.11.0"
-source = "git+https://github.com/braidpool/rust-bech32.git?branch=cpunet#34d8ea70211b4178b6b5c540e17981719faccdd2"
-
-[[package]]
-name = "bech32"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32637268377fc7b10a8c6d51de3e7fba1ce5dd371a96e342b34e6078db558e7f"
@@ -437,38 +423,19 @@ dependencies = [
 
 [[package]]
 name = "bitcoin"
-version = "0.32.7-pre-cpunet"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "base58ck 0.2.0",
- "base64 0.22.1",
- "bech32 0.11.0",
- "bitcoin-internals 0.4.0",
- "bitcoin-io 0.2.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "bitcoin-primitives",
- "bitcoin-units 0.2.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "bitcoinconsensus",
- "hex-conservative 0.3.2",
- "secp256k1 0.30.0",
- "serde",
-]
-
-[[package]]
-name = "bitcoin"
 version = "0.32.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e499f9fc0407f50fe98af744ab44fa67d409f76b6772e1689ec8485eb0c0f66"
 dependencies = [
- "base58ck 0.1.0",
- "bech32 0.11.1",
+ "base58ck",
+ "bech32",
  "bitcoin-internals 0.3.0",
  "bitcoin-io 0.1.4",
- "bitcoin-units 0.1.3",
+ "bitcoin-units",
  "bitcoin_hashes 0.14.1",
  "hex-conservative 0.2.2",
  "hex_lit",
- "secp256k1 0.29.1",
+ "secp256k1",
  "serde",
 ]
 
@@ -478,15 +445,6 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
 dependencies = [
- "serde",
-]
-
-[[package]]
-name = "bitcoin-internals"
-version = "0.4.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "hex-conservative 0.3.2",
  "serde",
 ]
 
@@ -518,43 +476,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "bitcoin-io"
-version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
-]
-
-[[package]]
-name = "bitcoin-primitives"
-version = "0.101.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "arrayvec",
- "bitcoin-internals 0.4.0",
- "bitcoin-units 0.2.0",
- "bitcoin_hashes 0.16.0 (git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet)",
- "hex-conservative 0.3.2",
- "serde",
-]
-
-[[package]]
 name = "bitcoin-units"
 version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "346568ebaab2918487cea76dd55dae13c27bb618cdb737c952e69eb2017c4118"
 dependencies = [
  "bitcoin-internals 0.3.0",
- "serde",
-]
-
-[[package]]
-name = "bitcoin-units"
-version = "0.2.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
  "serde",
 ]
 
@@ -575,27 +502,8 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5d09f16329cd545d7e6008b2c6b2af3a90bc678cf41ac3d2f6755943301b16"
 dependencies = [
- "bitcoin-io 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "hex-conservative 0.3.2",
-]
-
-[[package]]
-name = "bitcoin_hashes"
-version = "0.16.0"
-source = "git+https://github.com/braidpool/rust-bitcoin.git?branch=cpunet#156f317b6a90d2ddfb9c7b74ac8ff36b705c52b8"
-dependencies = [
- "bitcoin-internals 0.4.0",
- "hex-conservative 0.3.2",
- "serde",
-]
-
-[[package]]
-name = "bitcoinconsensus"
-version = "0.106.0+26.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12cba9cce5043cdda968e07b9df6d05ec6b0b38aa27a9a40bb575cf3e521ae9"
-dependencies = [
- "cc",
+ "bitcoin-io 0.2.0",
+ "hex-conservative 0.3.1",
 ]
 
 [[package]]
@@ -617,7 +525,7 @@ version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8909583c5fab98508e80ef73e5592a651c954993dc6b7739963257d19f0e71a"
 dependencies = [
- "bitcoin 0.32.8",
+ "bitcoin",
  "serde",
  "serde_json",
 ]
@@ -628,7 +536,7 @@ version = "1.5.4"
 source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#9946d0fe5b4e5b04bef63e5db4a33d044687dd8f"
 dependencies = [
  "async_zmq",
- "bitcoin 0.32.8",
+ "bitcoin",
  "futures-util",
  "zmq",
  "zmq-sys",
@@ -1755,7 +1663,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
- "serde",
 ]
 
 [[package]]
@@ -3286,9 +3193,9 @@ dependencies = [
  "anyhow",
  "async-trait",
  "bincode",
- "bitcoin 0.32.7-pre-cpunet",
+ "bitcoin",
  "bitcoin-internals 0.5.0",
- "bitcoin_hashes 0.16.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "bitcoin_hashes 0.16.0",
  "bitcoincore-rpc",
  "bitcoincore-rpc-json",
  "bitcoincore-zmq",
@@ -3305,7 +3212,7 @@ dependencies = [
  "num",
  "rand 0.8.6",
  "reqwest",
- "secp256k1 0.30.0",
+ "secp256k1",
  "serde",
  "serde_json",
  "shellexpand",
@@ -4338,18 +4245,6 @@ name = "secp256k1"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
-dependencies = [
- "bitcoin_hashes 0.14.1",
- "rand 0.8.6",
- "secp256k1-sys",
- "serde",
-]
-
-[[package]]
-name = "secp256k1"
-version = "0.30.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50c5943d326858130af85e049f2661ba3c78b26589b8ab98e65e80ae44a1252"
 dependencies = [
  "bitcoin_hashes 0.14.1",
  "rand 0.8.6",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,9 +29,7 @@ dependencies = [
 [[package]]
 name = "anstream"
 version = "1.0.0"
-version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
@@ -46,17 +44,13 @@ dependencies = [
 [[package]]
 name = "anstyle"
 version = "1.0.14"
-version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "1.0.0"
-version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
@@ -85,9 +79,7 @@ dependencies = [
 [[package]]
 name = "anyhow"
 version = "1.0.102"
-version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
@@ -167,14 +159,11 @@ dependencies = [
 [[package]]
 name = "async-executor"
 version = "1.14.0"
-version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
- "fastrand 2.4.1",
  "fastrand 2.4.1",
  "futures-lite 2.6.1",
  "pin-project-lite",
@@ -229,7 +218,6 @@ dependencies = [
  "futures-lite 2.6.1",
  "parking",
  "polling 3.11.0",
- "rustix 1.1.4",
  "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
@@ -546,7 +534,6 @@ dependencies = [
 name = "bitcoincore-zmq"
 version = "1.5.4"
 source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#9946d0fe5b4e5b04bef63e5db4a33d044687dd8f"
-source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#9946d0fe5b4e5b04bef63e5db4a33d044687dd8f"
 dependencies = [
  "async_zmq",
  "bitcoin",
@@ -563,9 +550,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 dependencies = [
  "serde_core",
 ]
@@ -615,9 +602,7 @@ dependencies = [
 [[package]]
 name = "bumpalo"
 version = "3.20.2"
-version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
@@ -674,9 +659,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -721,9 +706,7 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "chrono"
 version = "0.4.44"
-version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
@@ -733,9 +716,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -744,9 +727,7 @@ dependencies = [
 [[package]]
 name = "clap_builder"
 version = "4.6.0"
-version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
@@ -757,9 +738,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.0"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -770,17 +751,13 @@ dependencies = [
 [[package]]
 name = "clap_lex"
 version = "1.1.0"
-version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
 version = "1.0.5"
-version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
@@ -1028,9 +1005,7 @@ dependencies = [
 [[package]]
 name = "deranged"
 version = "0.5.8"
-version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
@@ -1051,9 +1026,7 @@ dependencies = [
 [[package]]
 name = "dircpy"
 version = "0.3.20"
-version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebcbec2b9a580ddee352ac38523d2ecd4dcaad53532957034394556909e27f4b"
 checksum = "ebcbec2b9a580ddee352ac38523d2ecd4dcaad53532957034394556909e27f4b"
 dependencies = [
  "jwalk",
@@ -1231,9 +1204,7 @@ dependencies = [
 [[package]]
 name = "fastrand"
 version = "2.4.1"
-version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
@@ -1314,9 +1285,7 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 [[package]]
 name = "futures"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
@@ -1341,9 +1310,7 @@ dependencies = [
 [[package]]
 name = "futures-channel"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
@@ -1353,17 +1320,13 @@ dependencies = [
 [[package]]
 name = "futures-core"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
@@ -1385,9 +1348,7 @@ dependencies = [
 [[package]]
 name = "futures-io"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
@@ -1412,7 +1373,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand 2.4.1",
- "fastrand 2.4.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -1422,9 +1382,7 @@ dependencies = [
 [[package]]
 name = "futures-macro"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
@@ -1446,17 +1404,13 @@ dependencies = [
 [[package]]
 name = "futures-sink"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
@@ -1472,9 +1426,7 @@ dependencies = [
 [[package]]
 name = "futures-util"
 version = "0.3.32"
-version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
@@ -1532,22 +1484,8 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 5.3.0",
- "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
-dependencies = [
- "cfg-if 1.0.4",
- "libc",
- "r-efi 6.0.0",
- "wasip2",
- "wasip3",
 ]
 
 [[package]]
@@ -1673,9 +1611,7 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.17.0"
-version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
@@ -1723,9 +1659,7 @@ dependencies = [
 [[package]]
 name = "hex-conservative"
 version = "0.3.2"
-version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
@@ -1754,7 +1688,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.3",
+ "rand 0.9.4",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1776,7 +1710,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.3",
+ "rand 0.9.4",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -1905,9 +1839,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "1.9.0"
-version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
@@ -1933,7 +1865,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
- "hyper 1.9.0",
  "hyper 1.9.0",
  "hyper-util",
  "log",
@@ -1968,10 +1899,8 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.9.0",
- "hyper 1.9.0",
  "libc",
  "pin-project-lite",
- "socket2 0.6.3",
  "socket2 0.6.3",
  "tokio",
  "tower-service",
@@ -1991,7 +1920,6 @@ dependencies = [
  "log",
  "wasm-bindgen",
  "windows-core",
- "windows-core",
 ]
 
 [[package]]
@@ -2006,14 +1934,11 @@ dependencies = [
 [[package]]
 name = "icu_collections"
 version = "2.2.0"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
- "utf8_iter",
  "utf8_iter",
  "yoke",
  "zerofrom",
@@ -2023,9 +1948,7 @@ dependencies = [
 [[package]]
 name = "icu_locale_core"
 version = "2.2.0"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
@@ -2038,9 +1961,7 @@ dependencies = [
 [[package]]
 name = "icu_normalizer"
 version = "2.2.0"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
@@ -2054,17 +1975,13 @@ dependencies = [
 [[package]]
 name = "icu_normalizer_data"
 version = "2.2.0"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
 version = "2.2.0"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
@@ -2078,17 +1995,13 @@ dependencies = [
 [[package]]
 name = "icu_properties_data"
 version = "2.2.0"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
 version = "2.2.0"
-version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
@@ -2099,12 +2012,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "id-arena"
@@ -2125,9 +2032,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2136,42 +2043,33 @@ dependencies = [
 [[package]]
 name = "if-addrs"
 version = "0.13.4"
-version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
 checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "if-addrs"
 version = "0.15.0"
-version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "if-watch"
 version = "3.2.2"
-version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io 2.6.0",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
- "if-addrs 0.15.0",
  "if-addrs 0.15.0",
  "ipnet",
  "log",
@@ -2180,7 +2078,6 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
- "system-configuration 0.7.0",
  "system-configuration 0.7.0",
  "tokio",
  "windows",
@@ -2199,7 +2096,6 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "hyper 1.9.0",
- "hyper 1.9.0",
  "hyper-util",
  "log",
  "rand 0.8.6",
@@ -2211,15 +2107,10 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.14.0"
-version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
- "serde",
- "serde_core",
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
@@ -2257,17 +2148,11 @@ dependencies = [
 [[package]]
 name = "ipconfig"
 version = "0.3.4"
-version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
  "socket2 0.6.3",
- "socket2 0.6.3",
  "widestring",
- "windows-registry",
- "windows-result",
- "windows-sys 0.61.2",
  "windows-registry",
  "windows-result",
  "windows-sys 0.61.2",
@@ -2276,9 +2161,7 @@ dependencies = [
 [[package]]
 name = "ipnet"
 version = "2.12.0"
-version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
@@ -2290,9 +2173,7 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 [[package]]
 name = "itoa"
 version = "1.0.18"
-version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
@@ -2305,7 +2186,6 @@ dependencies = [
  "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.1",
- "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2315,31 +2195,7 @@ dependencies = [
 [[package]]
 name = "jni-sys"
 version = "0.3.1"
-version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
-dependencies = [
- "jni-sys 0.4.1",
-]
-
-[[package]]
-name = "jni-sys"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
-dependencies = [
- "jni-sys-macros",
-]
-
-[[package]]
-name = "jni-sys-macros"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
-dependencies = [
- "quote",
- "syn",
-]
 checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
 dependencies = [
  "jni-sys 0.4.1",
@@ -2376,14 +2232,10 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "a1840c94c045fbcf8ba2812c95db44499f7c64910a912551aaaa541decebcacf"
 dependencies = [
- "cfg-if 1.0.4",
- "futures-util",
  "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
@@ -2461,7 +2313,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.3",
+ "rand 0.9.4",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2481,7 +2333,6 @@ checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
 dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
- "hyper 1.9.0",
  "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
@@ -2520,7 +2371,6 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
- "hyper 1.9.0",
  "hyper 1.9.0",
  "hyper-util",
  "jsonrpsee-core",
@@ -2621,16 +2471,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libm"
@@ -3002,15 +2846,11 @@ dependencies = [
 [[package]]
 name = "libredox"
 version = "0.1.16"
-version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
-checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
- "plain",
- "redox_syscall 0.7.4",
  "plain",
  "redox_syscall 0.7.4",
 ]
@@ -3035,17 +2875,13 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
-version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.8.2"
-version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
@@ -3114,9 +2950,7 @@ dependencies = [
 [[package]]
 name = "memchr"
 version = "2.8.0"
-version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
@@ -3163,9 +2997,7 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "1.2.0"
-version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
@@ -3188,9 +3020,7 @@ dependencies = [
 [[package]]
 name = "moka"
 version = "0.12.15"
-version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
@@ -3237,11 +3067,10 @@ dependencies = [
 
 [[package]]
 name = "multihash"
-version = "0.19.4"
+version = "0.19.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ace881e3f514092ce9efbcb8f413d0ad9763860b828981c2de51ddc666936c"
+checksum = "577c63b00ad74d57e8c9aa870b5fccebf2fd64a308a5aee9f1bb88e4aea19447"
 dependencies = [
- "no_std_io2",
  "unsigned-varint 0.8.0",
 ]
 
@@ -3290,26 +3119,20 @@ dependencies = [
 [[package]]
 name = "netlink-packet-core"
 version = "0.8.1"
-version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
-checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
- "paste",
  "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
 version = "0.28.0"
-version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
-checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "libc",
- "log",
  "log",
  "netlink-packet-core",
 ]
@@ -3317,9 +3140,7 @@ dependencies = [
 [[package]]
 name = "netlink-proto"
 version = "0.12.0"
-version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
@@ -3346,25 +3167,13 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.30.1"
-version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
-checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if 1.0.4",
  "cfg_aliases",
- "cfg_aliases",
  "libc",
-]
-
-[[package]]
-name = "no_std_io2"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a3564ce7035b1e4778d8cb6cacebb5d766b5e8fe5a75b9e441e33fb61a872c6"
-dependencies = [
- "memchr",
 ]
 
 [[package]]
@@ -3482,9 +3291,7 @@ dependencies = [
 [[package]]
 name = "num-conv"
 version = "0.2.1"
-version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
@@ -3541,9 +3348,7 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.21.4"
-version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
@@ -3554,11 +3359,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.76"
+version = "0.10.78"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
+checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
@@ -3586,9 +3391,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.112"
+version = "0.9.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
+checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
 dependencies = [
  "cc",
  "libc",
@@ -3665,9 +3470,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pin-project"
 version = "1.1.11"
-version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
@@ -3676,9 +3479,7 @@ dependencies = [
 [[package]]
 name = "pin-project-internal"
 version = "1.1.11"
-version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
@@ -3689,9 +3490,7 @@ dependencies = [
 [[package]]
 name = "pin-project-lite"
 version = "0.2.17"
-version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
@@ -3703,13 +3502,10 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "piper"
 version = "0.2.5"
-version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
- "fastrand 2.4.1",
  "fastrand 2.4.1",
  "futures-io",
 ]
@@ -3739,7 +3535,7 @@ dependencies = [
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plain"
@@ -3774,7 +3570,6 @@ dependencies = [
  "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.4",
- "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3787,9 +3582,7 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 [[package]]
 name = "potential_utf"
 version = "0.1.5"
-version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
@@ -3821,24 +3614,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "prettyplease"
-version = "0.2.37"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
-dependencies = [
- "proc-macro2",
- "syn",
-]
-
-[[package]]
 name = "proc-macro-crate"
 version = "3.5.0"
-version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
-checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
- "toml_edit 0.25.11+spec-1.1.0",
  "toml_edit 0.25.11+spec-1.1.0",
 ]
 
@@ -3911,7 +3691,6 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.3",
- "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3921,15 +3700,13 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.14"
-version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.3",
+ "rand 0.9.4",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3951,7 +3728,6 @@ dependencies = [
  "libc",
  "once_cell",
  "socket2 0.6.3",
- "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3959,9 +3735,7 @@ dependencies = [
 [[package]]
 name = "quote"
 version = "1.0.45"
-version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
@@ -3972,12 +3746,6 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
-version = "6.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-efi"
@@ -4011,9 +3779,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -4124,18 +3892,16 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.7.4"
-version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
-checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
@@ -4175,9 +3941,7 @@ dependencies = [
 [[package]]
 name = "regex-syntax"
 version = "0.8.10"
-version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
@@ -4269,13 +4033,9 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.20.0"
-version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
-checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
- "futures-channel",
- "futures-util",
  "futures-channel",
  "futures-util",
  "log",
@@ -4291,9 +4051,7 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "2.1.2"
-version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
@@ -4331,24 +4089,21 @@ dependencies = [
 [[package]]
 name = "rustix"
 version = "1.1.4"
-version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
-checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.37"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "log",
  "once_cell",
@@ -4419,9 +4174,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4448,9 +4203,7 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.23"
-version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
@@ -4465,9 +4218,7 @@ dependencies = [
 [[package]]
 name = "schannel"
 version = "0.1.29"
-version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
@@ -4503,12 +4254,10 @@ dependencies = [
 [[package]]
 name = "security-framework"
 version = "3.7.0"
-version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
-checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4518,9 +4267,7 @@ dependencies = [
 [[package]]
 name = "security-framework-sys"
 version = "2.17.0"
-version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
@@ -4530,9 +4277,7 @@ dependencies = [
 [[package]]
 name = "semver"
 version = "1.0.28"
-version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
@@ -4639,9 +4384,7 @@ dependencies = [
 [[package]]
 name = "shellexpand"
 version = "3.1.2"
-version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
@@ -4711,13 +4454,10 @@ dependencies = [
 [[package]]
 name = "socket2"
 version = "0.6.3"
-version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
  "windows-sys 0.61.2",
 ]
 
@@ -4854,7 +4594,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "bytes",
  "chrono",
@@ -4898,7 +4638,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "byteorder",
  "chrono",
  "crc",
@@ -5016,9 +4756,7 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "syn"
 version = "2.0.117"
-version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
@@ -5063,12 +4801,10 @@ dependencies = [
 [[package]]
 name = "system-configuration"
 version = "0.7.0"
-version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
-checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -5121,17 +4857,12 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "tempfile"
 version = "3.27.0"
-version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
  "getrandom 0.4.2",
- "fastrand 2.4.1",
- "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
@@ -5188,9 +4919,7 @@ dependencies = [
 [[package]]
 name = "time"
 version = "0.3.47"
-version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
@@ -5211,9 +4940,7 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 [[package]]
 name = "time-macros"
 version = "0.2.27"
-version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
@@ -5223,9 +4950,7 @@ dependencies = [
 [[package]]
 name = "tinystr"
 version = "0.8.3"
-version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
@@ -5235,9 +4960,7 @@ dependencies = [
 [[package]]
 name = "tinyvec"
 version = "1.11.0"
-version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
@@ -5251,17 +4974,15 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
  "mio 1.2.0",
- "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
  "socket2 0.6.3",
  "tokio-macros",
  "tracing",
@@ -5271,9 +4992,7 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "2.7.0"
-version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
@@ -5354,9 +5073,7 @@ dependencies = [
 [[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
-version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
@@ -5374,33 +5091,27 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
-version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
- "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
-version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.1",
+ "winnow 1.0.2",
 ]
 
 [[package]]
@@ -5482,9 +5193,7 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
-version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
@@ -5531,9 +5240,7 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
-version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
@@ -5550,12 +5257,6 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode-xid"
@@ -5607,11 +5308,10 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
 dependencies = [
- "getrandom 0.4.2",
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
@@ -5688,16 +5388,7 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -5719,11 +5410,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "df52b6d9b87e0c74c9edfa1eb2d9bf85e5d63515474513aa50fa181b3c4f5db1"
 dependencies = [
  "cfg-if 1.0.4",
  "once_cell",
@@ -5734,11 +5423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
-version = "0.4.68"
+version = "0.4.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "af934872acec734c2d80e6617bbb5ff4f12b052dd8e6332b0817bce889516084"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5746,11 +5433,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "78b1041f495fb322e64aca85f5756b2172e35cd459376e67f2a6c9dffcedb103"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -5758,11 +5443,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "9dcd0ff20416988a18ac686d4d4d0f6aae9ebf08a389ff5d29012b05af2a1b41"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -5773,11 +5456,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
-version = "0.2.118"
+version = "0.2.120"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "49757b3c82ebf16c57d69365a142940b384176c24df52a087fb748e2085359ea"
 dependencies = [
  "unicode-ident",
 ]
@@ -5810,7 +5491,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5818,11 +5499,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
-version = "0.3.95"
+version = "0.3.97"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "2eadbac71025cd7b0834f20d1fe8472e8495821b4e9801eb0a60bd1f19827602"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -5844,14 +5523,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.6",
+ "webpki-root-certs 1.0.7",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5918,15 +5597,9 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "windows"
 version = "0.62.2"
-version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
-checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
- "windows-collections",
- "windows-core",
- "windows-future",
- "windows-numerics",
  "windows-collections",
  "windows-core",
  "windows-future",
@@ -5936,13 +5609,9 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
-name = "windows-collections"
-version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
-checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core",
  "windows-core",
 ]
 
@@ -5956,19 +5625,7 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
- "windows-result",
  "windows-strings",
-]
-
-[[package]]
-name = "windows-future"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
-dependencies = [
- "windows-core",
- "windows-link",
- "windows-threading",
 ]
 
 [[package]]
@@ -6013,25 +5670,9 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 [[package]]
 name = "windows-numerics"
 version = "0.3.1"
-name = "windows-numerics"
-version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
-checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core",
- "windows-link",
-]
-
-[[package]]
-name = "windows-registry"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
-dependencies = [
- "windows-link",
- "windows-result",
- "windows-strings",
  "windows-core",
  "windows-link",
 ]
@@ -6180,15 +5821,6 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
-]
-
-[[package]]
-name = "windows-threading"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
-dependencies = [
- "windows-link",
 ]
 
 [[package]]
@@ -6383,7 +6015,6 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winnow"
 version = "0.7.15"
-version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
@@ -6392,9 +6023,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.1"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
 dependencies = [
  "memchr",
 ]
@@ -6417,6 +6048,12 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
+
+[[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -6467,7 +6104,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -6500,9 +6137,7 @@ dependencies = [
 [[package]]
 name = "writeable"
 version = "0.6.3"
-version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
@@ -6559,9 +6194,7 @@ dependencies = [
 [[package]]
 name = "yoke"
 version = "0.8.2"
-version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
@@ -6572,9 +6205,7 @@ dependencies = [
 [[package]]
 name = "yoke-derive"
 version = "0.8.2"
-version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
@@ -6586,9 +6217,7 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.48"
-version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
@@ -6597,9 +6226,7 @@ dependencies = [
 [[package]]
 name = "zerocopy-derive"
 version = "0.8.48"
-version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
@@ -6610,9 +6237,7 @@ dependencies = [
 [[package]]
 name = "zerofrom"
 version = "0.1.7"
-version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
@@ -6621,9 +6246,7 @@ dependencies = [
 [[package]]
 name = "zerofrom-derive"
 version = "0.1.7"
-version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
@@ -6651,9 +6274,7 @@ dependencies = [
 [[package]]
 name = "zerotrie"
 version = "0.2.4"
-version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
@@ -6664,9 +6285,7 @@ dependencies = [
 [[package]]
 name = "zerovec"
 version = "0.11.6"
-version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
@@ -6677,9 +6296,7 @@ dependencies = [
 [[package]]
 name = "zerovec-derive"
 version = "0.11.3"
-version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
@@ -6690,9 +6307,7 @@ dependencies = [
 [[package]]
 name = "zmij"
 version = "1.0.21"
-version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,7 +29,9 @@ dependencies = [
 [[package]]
 name = "anstream"
 version = "1.0.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
@@ -44,13 +46,17 @@ dependencies = [
 [[package]]
 name = "anstyle"
 version = "1.0.14"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
 version = "1.0.0"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
@@ -79,7 +85,9 @@ dependencies = [
 [[package]]
 name = "anyhow"
 version = "1.0.102"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
@@ -159,11 +167,14 @@ dependencies = [
 [[package]]
 name = "async-executor"
 version = "1.14.0"
+version = "1.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
 dependencies = [
  "async-task",
  "concurrent-queue",
+ "fastrand 2.4.1",
  "fastrand 2.4.1",
  "futures-lite 2.6.1",
  "pin-project-lite",
@@ -218,6 +229,7 @@ dependencies = [
  "futures-lite 2.6.1",
  "parking",
  "polling 3.11.0",
+ "rustix 1.1.4",
  "rustix 1.1.4",
  "slab",
  "windows-sys 0.61.2",
@@ -503,7 +515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e5d09f16329cd545d7e6008b2c6b2af3a90bc678cf41ac3d2f6755943301b16"
 dependencies = [
  "bitcoin-io 0.2.0",
- "hex-conservative 0.3.1",
+ "hex-conservative 0.3.2",
 ]
 
 [[package]]
@@ -534,6 +546,7 @@ dependencies = [
 name = "bitcoincore-zmq"
 version = "1.5.4"
 source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#9946d0fe5b4e5b04bef63e5db4a33d044687dd8f"
+source = "git+https://github.com/antonilol/rust-bitcoincore-zmq.git#9946d0fe5b4e5b04bef63e5db4a33d044687dd8f"
 dependencies = [
  "async_zmq",
  "bitcoin",
@@ -550,9 +563,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.1"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 dependencies = [
  "serde_core",
 ]
@@ -602,7 +615,9 @@ dependencies = [
 [[package]]
 name = "bumpalo"
 version = "3.20.2"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
@@ -659,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -706,7 +721,9 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 [[package]]
 name = "chrono"
 version = "0.4.44"
+version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
@@ -716,9 +733,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
+checksum = "b193af5b67834b676abd72466a96c1024e6a6ad978a1f484bd90b85c94041351"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -727,7 +744,9 @@ dependencies = [
 [[package]]
 name = "clap_builder"
 version = "4.6.0"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
@@ -738,9 +757,9 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.6.1"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
+checksum = "1110bd8a634a1ab8cb04345d8d878267d57c3cf1b38d91b71af6686408bbca6a"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -751,13 +770,17 @@ dependencies = [
 [[package]]
 name = "clap_lex"
 version = "1.1.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "colorchoice"
 version = "1.0.5"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
@@ -1005,7 +1028,9 @@ dependencies = [
 [[package]]
 name = "deranged"
 version = "0.5.8"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
@@ -1026,7 +1051,9 @@ dependencies = [
 [[package]]
 name = "dircpy"
 version = "0.3.20"
+version = "0.3.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebcbec2b9a580ddee352ac38523d2ecd4dcaad53532957034394556909e27f4b"
 checksum = "ebcbec2b9a580ddee352ac38523d2ecd4dcaad53532957034394556909e27f4b"
 dependencies = [
  "jwalk",
@@ -1204,7 +1231,9 @@ dependencies = [
 [[package]]
 name = "fastrand"
 version = "2.4.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
@@ -1285,7 +1314,9 @@ checksum = "3dcaa9ae7725d12cdb85b3ad99a434db70b468c09ded17e012d86b5c1010f7a7"
 [[package]]
 name = "futures"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
@@ -1310,7 +1341,9 @@ dependencies = [
 [[package]]
 name = "futures-channel"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
@@ -1320,13 +1353,17 @@ dependencies = [
 [[package]]
 name = "futures-core"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
 
 [[package]]
 name = "futures-executor"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
 dependencies = [
  "futures-core",
@@ -1348,7 +1385,9 @@ dependencies = [
 [[package]]
 name = "futures-io"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
@@ -1373,6 +1412,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
 dependencies = [
  "fastrand 2.4.1",
+ "fastrand 2.4.1",
  "futures-core",
  "futures-io",
  "parking",
@@ -1382,7 +1422,9 @@ dependencies = [
 [[package]]
 name = "futures-macro"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
@@ -1404,13 +1446,17 @@ dependencies = [
 [[package]]
 name = "futures-sink"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
 
 [[package]]
 name = "futures-task"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
 
 [[package]]
@@ -1426,7 +1472,9 @@ dependencies = [
 [[package]]
 name = "futures-util"
 version = "0.3.32"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
  "futures-channel",
@@ -1484,8 +1532,22 @@ dependencies = [
  "js-sys",
  "libc",
  "r-efi 5.3.0",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if 1.0.4",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -1611,7 +1673,9 @@ dependencies = [
 [[package]]
 name = "hashbrown"
 version = "0.17.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
 
 [[package]]
@@ -1659,7 +1723,9 @@ dependencies = [
 [[package]]
 name = "hex-conservative"
 version = "0.3.2"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 checksum = "830e599c2904b08f0834ee6337d8fe8f0ed4a63b5d9e7a7f49c0ffa06d08d360"
 dependencies = [
  "arrayvec",
@@ -1688,7 +1754,7 @@ dependencies = [
  "idna",
  "ipnet",
  "once_cell",
- "rand 0.9.4",
+ "rand 0.9.3",
  "socket2 0.5.10",
  "thiserror 2.0.18",
  "tinyvec",
@@ -1710,7 +1776,7 @@ dependencies = [
  "moka",
  "once_cell",
  "parking_lot",
- "rand 0.9.4",
+ "rand 0.9.3",
  "resolv-conf",
  "smallvec",
  "thiserror 2.0.18",
@@ -1839,7 +1905,9 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "1.9.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 checksum = "6299f016b246a94207e63da54dbe807655bf9e00044f73ded42c3ac5305fbcca"
 dependencies = [
  "atomic-waker",
@@ -1865,6 +1933,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
  "http 1.4.0",
+ "hyper 1.9.0",
  "hyper 1.9.0",
  "hyper-util",
  "log",
@@ -1899,8 +1968,10 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "hyper 1.9.0",
+ "hyper 1.9.0",
  "libc",
  "pin-project-lite",
+ "socket2 0.6.3",
  "socket2 0.6.3",
  "tokio",
  "tower-service",
@@ -1920,6 +1991,7 @@ dependencies = [
  "log",
  "wasm-bindgen",
  "windows-core",
+ "windows-core",
 ]
 
 [[package]]
@@ -1934,11 +2006,14 @@ dependencies = [
 [[package]]
 name = "icu_collections"
 version = "2.2.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "utf8_iter",
  "yoke",
  "zerofrom",
@@ -1948,7 +2023,9 @@ dependencies = [
 [[package]]
 name = "icu_locale_core"
 version = "2.2.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
@@ -1961,7 +2038,9 @@ dependencies = [
 [[package]]
 name = "icu_normalizer"
 version = "2.2.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
@@ -1975,13 +2054,17 @@ dependencies = [
 [[package]]
 name = "icu_normalizer_data"
 version = "2.2.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
 version = "2.2.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
@@ -1995,13 +2078,17 @@ dependencies = [
 [[package]]
 name = "icu_properties_data"
 version = "2.2.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
 version = "2.2.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
@@ -2012,6 +2099,12 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
+
+[[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "id-arena"
@@ -2043,33 +2136,42 @@ dependencies = [
 [[package]]
 name = "if-addrs"
 version = "0.13.4"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
 checksum = "69b2eeee38fef3aa9b4cc5f1beea8a2444fc00e7377cafae396de3f5c2065e24"
 dependencies = [
  "libc",
+ "windows-sys 0.59.0",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "if-addrs"
 version = "0.15.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 checksum = "c0a05c691e1fae256cf7013d99dad472dc52d5543322761f83ec8d47eab40d2b"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "if-watch"
 version = "3.2.2"
+version = "3.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 checksum = "71c02a5161c313f0cbdbadc511611893584a10a7b6153cb554bdf83ddce99ec2"
 dependencies = [
  "async-io 2.6.0",
  "core-foundation 0.9.4",
  "fnv",
  "futures",
+ "if-addrs 0.15.0",
  "if-addrs 0.15.0",
  "ipnet",
  "log",
@@ -2078,6 +2180,7 @@ dependencies = [
  "netlink-proto",
  "netlink-sys",
  "rtnetlink",
+ "system-configuration 0.7.0",
  "system-configuration 0.7.0",
  "tokio",
  "windows",
@@ -2096,6 +2199,7 @@ dependencies = [
  "http 1.4.0",
  "http-body-util",
  "hyper 1.9.0",
+ "hyper 1.9.0",
  "hyper-util",
  "log",
  "rand 0.8.6",
@@ -2107,10 +2211,15 @@ dependencies = [
 [[package]]
 name = "indexmap"
 version = "2.14.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
+ "hashbrown 0.17.0",
+ "serde",
+ "serde_core",
  "hashbrown 0.17.0",
  "serde",
  "serde_core",
@@ -2148,11 +2257,17 @@ dependencies = [
 [[package]]
 name = "ipconfig"
 version = "0.3.4"
+version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
 dependencies = [
  "socket2 0.6.3",
+ "socket2 0.6.3",
  "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
  "windows-registry",
  "windows-result",
  "windows-sys 0.61.2",
@@ -2161,7 +2276,9 @@ dependencies = [
 [[package]]
 name = "ipnet"
 version = "2.12.0"
+version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
@@ -2173,7 +2290,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 [[package]]
 name = "itoa"
 version = "1.0.18"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
@@ -2186,6 +2305,7 @@ dependencies = [
  "cfg-if 1.0.4",
  "combine",
  "jni-sys 0.3.1",
+ "jni-sys 0.3.1",
  "log",
  "thiserror 1.0.69",
  "walkdir",
@@ -2195,7 +2315,31 @@ dependencies = [
 [[package]]
 name = "jni-sys"
 version = "0.3.1"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6377a88cb3910bee9b0fa88d4f42e1d2da8e79915598f65fb0c7ee14c878af2"
+dependencies = [
+ "jni-sys-macros",
+]
+
+[[package]]
+name = "jni-sys-macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38c0b942f458fe50cdac086d2f946512305e5631e720728f2a61aabcd47a6264"
+dependencies = [
+ "quote",
+ "syn",
+]
 checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
 dependencies = [
  "jni-sys 0.4.1",
@@ -2233,9 +2377,13 @@ dependencies = [
 [[package]]
 name = "js-sys"
 version = "0.3.95"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
+ "cfg-if 1.0.4",
+ "futures-util",
  "cfg-if 1.0.4",
  "futures-util",
  "once_cell",
@@ -2313,7 +2461,7 @@ dependencies = [
  "jsonrpsee-types",
  "parking_lot",
  "pin-project",
- "rand 0.9.4",
+ "rand 0.9.3",
  "rustc-hash",
  "serde",
  "serde_json",
@@ -2333,6 +2481,7 @@ checksum = "6962d2bd295f75e97dd328891e58fce166894b974c1f7ce2e7597f02eeceb791"
 dependencies = [
  "base64 0.22.1",
  "http-body 1.0.1",
+ "hyper 1.9.0",
  "hyper 1.9.0",
  "hyper-rustls",
  "hyper-util",
@@ -2371,6 +2520,7 @@ dependencies = [
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
+ "hyper 1.9.0",
  "hyper 1.9.0",
  "hyper-util",
  "jsonrpsee-core",
@@ -2471,10 +2621,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
-name = "libc"
-version = "0.2.186"
+name = "leb128fmt"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
+name = "libc"
+version = "0.2.184"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
 name = "libm"
@@ -2846,11 +3002,15 @@ dependencies = [
 [[package]]
 name = "libredox"
 version = "0.1.16"
+version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "libc",
+ "plain",
+ "redox_syscall 0.7.4",
  "plain",
  "redox_syscall 0.7.4",
 ]
@@ -2875,13 +3035,17 @@ checksum = "ef53942eb7bf7ff43a617b3e2c1c4a5ecf5944a7c1bc12d7ee39bbb15e5c1519"
 [[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
 version = "0.8.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
@@ -2950,7 +3114,9 @@ dependencies = [
 [[package]]
 name = "memchr"
 version = "2.8.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
@@ -2997,7 +3163,9 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "1.2.0"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
@@ -3020,7 +3188,9 @@ dependencies = [
 [[package]]
 name = "moka"
 version = "0.12.15"
+version = "0.12.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
 dependencies = [
  "crossbeam-channel",
@@ -3120,20 +3290,26 @@ dependencies = [
 [[package]]
 name = "netlink-packet-core"
 version = "0.8.1"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
+checksum = "3463cbb78394cb0141e2c926b93fc2197e473394b761986eca3b9da2c63ae0f4"
 dependencies = [
+ "paste",
  "paste",
 ]
 
 [[package]]
 name = "netlink-packet-route"
 version = "0.28.0"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
+checksum = "4ce3636fa715e988114552619582b530481fd5ef176a1e5c1bf024077c2c9445"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "libc",
+ "log",
  "log",
  "netlink-packet-core",
 ]
@@ -3141,7 +3317,9 @@ dependencies = [
 [[package]]
 name = "netlink-proto"
 version = "0.12.0"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 checksum = "b65d130ee111430e47eed7896ea43ca693c387f097dd97376bffafbf25812128"
 dependencies = [
  "bytes",
@@ -3168,11 +3346,14 @@ dependencies = [
 [[package]]
 name = "nix"
 version = "0.30.1"
+version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
+checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if 1.0.4",
+ "cfg_aliases",
  "cfg_aliases",
  "libc",
 ]
@@ -3301,7 +3482,9 @@ dependencies = [
 [[package]]
 name = "num-conv"
 version = "0.2.1"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
 
 [[package]]
@@ -3358,7 +3541,9 @@ dependencies = [
 [[package]]
 name = "once_cell"
 version = "1.21.4"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
@@ -3369,11 +3554,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "openssl"
-version = "0.10.78"
+version = "0.10.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38c4372413cdaaf3cc79dd92d29d7d9f5ab09b51b10dded508fb90bb70b9222"
+checksum = "951c002c75e16ea2c65b8c7e4d3d51d5530d8dfa7d060b4776828c88cfb18ecf"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "cfg-if 1.0.4",
  "foreign-types",
  "libc",
@@ -3401,9 +3586,9 @@ checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
 name = "openssl-sys"
-version = "0.9.114"
+version = "0.9.112"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13ce1245cd07fcc4cfdb438f7507b0c7e4f3849a69fd84d52374c66d83741bb6"
+checksum = "57d55af3b3e226502be1526dfdba67ab0e9c96fc293004e79576b2b9edb0dbdb"
 dependencies = [
  "cc",
  "libc",
@@ -3480,7 +3665,9 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 [[package]]
 name = "pin-project"
 version = "1.1.11"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 checksum = "f1749c7ed4bcaf4c3d0a3efc28538844fb29bcdd7d2b67b2be7e20ba861ff517"
 dependencies = [
  "pin-project-internal",
@@ -3489,7 +3676,9 @@ dependencies = [
 [[package]]
 name = "pin-project-internal"
 version = "1.1.11"
+version = "1.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
@@ -3500,7 +3689,9 @@ dependencies = [
 [[package]]
 name = "pin-project-lite"
 version = "0.2.17"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
@@ -3512,10 +3703,13 @@ checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 [[package]]
 name = "piper"
 version = "0.2.5"
+version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
 dependencies = [
  "atomic-waker",
+ "fastrand 2.4.1",
  "fastrand 2.4.1",
  "futures-io",
 ]
@@ -3545,7 +3739,7 @@ dependencies = [
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "plain"
@@ -3580,6 +3774,7 @@ dependencies = [
  "hermit-abi 0.5.2",
  "pin-project-lite",
  "rustix 1.1.4",
+ "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
 
@@ -3592,7 +3787,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 [[package]]
 name = "potential_utf"
 version = "0.1.5"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
@@ -3624,11 +3821,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
+]
+
+[[package]]
 name = "proc-macro-crate"
+version = "3.5.0"
 version = "3.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
 dependencies = [
+ "toml_edit 0.25.11+spec-1.1.0",
  "toml_edit 0.25.11+spec-1.1.0",
 ]
 
@@ -3701,6 +3911,7 @@ dependencies = [
  "rustc-hash",
  "rustls",
  "socket2 0.6.3",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -3710,13 +3921,15 @@ dependencies = [
 [[package]]
 name = "quinn-proto"
 version = "0.11.14"
+version = "0.11.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
 dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand 0.9.3",
  "ring",
  "rustc-hash",
  "rustls",
@@ -3738,6 +3951,7 @@ dependencies = [
  "libc",
  "once_cell",
  "socket2 0.6.3",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -3745,7 +3959,9 @@ dependencies = [
 [[package]]
 name = "quote"
 version = "1.0.45"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
@@ -3756,6 +3972,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "r-efi"
@@ -3789,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.4"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
+checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
 dependencies = [
  "rand_chacha 0.9.0",
  "rand_core 0.9.5",
@@ -3902,16 +4124,18 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
 name = "redox_syscall"
 version = "0.7.4"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
 ]
 
 [[package]]
@@ -3951,7 +4175,9 @@ dependencies = [
 [[package]]
 name = "regex-syntax"
 version = "0.8.10"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
@@ -4043,9 +4269,13 @@ dependencies = [
 [[package]]
 name = "rtnetlink"
 version = "0.20.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
+checksum = "4b960d5d873a75b5be9761b1e73b146f52dddcd27bac75263f40fba686d4d7b5"
 dependencies = [
+ "futures-channel",
+ "futures-util",
  "futures-channel",
  "futures-util",
  "log",
@@ -4061,7 +4291,9 @@ dependencies = [
 [[package]]
 name = "rustc-hash"
 version = "2.1.2"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
@@ -4099,21 +4331,24 @@ dependencies = [
 [[package]]
 name = "rustix"
 version = "1.1.4"
+version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "errno",
  "libc",
+ "linux-raw-sys 0.12.1",
  "linux-raw-sys 0.12.1",
  "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
  "log",
  "once_cell",
@@ -4184,9 +4419,9 @@ checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
 dependencies = [
  "ring",
  "rustls-pki-types",
@@ -4213,7 +4448,9 @@ dependencies = [
 [[package]]
 name = "ryu"
 version = "1.0.23"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
@@ -4228,7 +4465,9 @@ dependencies = [
 [[package]]
 name = "schannel"
 version = "0.1.29"
+version = "0.1.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
 dependencies = [
  "windows-sys 0.61.2",
@@ -4264,10 +4503,12 @@ dependencies = [
 [[package]]
 name = "security-framework"
 version = "3.7.0"
+version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -4277,7 +4518,9 @@ dependencies = [
 [[package]]
 name = "security-framework-sys"
 version = "2.17.0"
+version = "2.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
 dependencies = [
  "core-foundation-sys",
@@ -4287,7 +4530,9 @@ dependencies = [
 [[package]]
 name = "semver"
 version = "1.0.28"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
@@ -4394,7 +4639,9 @@ dependencies = [
 [[package]]
 name = "shellexpand"
 version = "3.1.2"
+version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
  "dirs",
@@ -4464,10 +4711,13 @@ dependencies = [
 [[package]]
 name = "socket2"
 version = "0.6.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
+ "windows-sys 0.61.2",
  "windows-sys 0.61.2",
 ]
 
@@ -4604,7 +4854,7 @@ checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "byteorder",
  "bytes",
  "chrono",
@@ -4648,7 +4898,7 @@ checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
 dependencies = [
  "atoi",
  "base64 0.22.1",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "byteorder",
  "chrono",
  "crc",
@@ -4766,7 +5016,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 [[package]]
 name = "syn"
 version = "2.0.117"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
@@ -4811,10 +5063,12 @@ dependencies = [
 [[package]]
 name = "system-configuration"
 version = "0.7.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "core-foundation 0.9.4",
  "system-configuration-sys 0.6.0",
 ]
@@ -4867,12 +5121,17 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 [[package]]
 name = "tempfile"
 version = "3.27.0"
+version = "3.27.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand 2.4.1",
  "getrandom 0.4.2",
+ "fastrand 2.4.1",
+ "getrandom 0.4.2",
  "once_cell",
+ "rustix 1.1.4",
  "rustix 1.1.4",
  "windows-sys 0.61.2",
 ]
@@ -4929,7 +5188,9 @@ dependencies = [
 [[package]]
 name = "time"
 version = "0.3.47"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
@@ -4950,7 +5211,9 @@ checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 [[package]]
 name = "time-macros"
 version = "0.2.27"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
@@ -4960,7 +5223,9 @@ dependencies = [
 [[package]]
 name = "tinystr"
 version = "0.8.3"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
@@ -4970,7 +5235,9 @@ dependencies = [
 [[package]]
 name = "tinyvec"
 version = "1.11.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
@@ -4984,15 +5251,17 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.51.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
 dependencies = [
  "bytes",
  "libc",
  "mio 1.2.0",
+ "mio 1.2.0",
  "pin-project-lite",
  "signal-hook-registry",
+ "socket2 0.6.3",
  "socket2 0.6.3",
  "tokio-macros",
  "tracing",
@@ -5002,7 +5271,9 @@ dependencies = [
 [[package]]
 name = "tokio-macros"
 version = "2.7.0"
+version = "2.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
@@ -5083,7 +5354,9 @@ dependencies = [
 [[package]]
 name = "toml_datetime"
 version = "1.1.1+spec-1.1.0"
+version = "1.1.1+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
 dependencies = [
  "serde_core",
@@ -5101,27 +5374,33 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+ "winnow 0.7.15",
 ]
 
 [[package]]
 name = "toml_edit"
 version = "0.25.11+spec-1.1.0"
+version = "0.25.11+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
 dependencies = [
  "indexmap",
  "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
  "toml_parser",
- "winnow 1.0.2",
+ "winnow 1.0.1",
 ]
 
 [[package]]
 name = "toml_parser"
 version = "1.1.2+spec-1.1.0"
+version = "1.1.2+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
 dependencies = [
- "winnow 1.0.2",
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -5203,7 +5482,9 @@ dependencies = [
 [[package]]
 name = "tracing-subscriber"
 version = "0.3.23"
+version = "0.3.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 checksum = "cb7f578e5945fb242538965c2d0b04418d38ec25c79d160cd279bf0731c8d319"
 dependencies = [
  "matchers",
@@ -5250,7 +5531,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 [[package]]
 name = "unicode-ident"
 version = "1.0.24"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
@@ -5267,6 +5550,12 @@ name = "unicode-properties"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode-xid"
@@ -5318,10 +5607,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.1"
+version = "1.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd74a9687298c6858e9b88ec8935ec45d22e8fd5e6394fa1bd4e99a87789c76"
+checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
 dependencies = [
+ "getrandom 0.4.2",
  "getrandom 0.4.2",
  "js-sys",
  "wasm-bindgen",
@@ -5398,7 +5688,16 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 name = "wasip2"
 version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen 0.57.1",
 ]
@@ -5421,7 +5720,9 @@ checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 [[package]]
 name = "wasm-bindgen"
 version = "0.2.118"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if 1.0.4",
@@ -5434,7 +5735,9 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-futures"
 version = "0.4.68"
+version = "0.4.68"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
 dependencies = [
  "js-sys",
@@ -5444,7 +5747,9 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro"
 version = "0.2.118"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
@@ -5454,7 +5759,9 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-macro-support"
 version = "0.2.118"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
@@ -5467,7 +5774,9 @@ dependencies = [
 [[package]]
 name = "wasm-bindgen-shared"
 version = "0.2.118"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
@@ -5501,7 +5810,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -5510,7 +5819,9 @@ dependencies = [
 [[package]]
 name = "web-sys"
 version = "0.3.95"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
@@ -5533,14 +5844,14 @@ version = "0.26.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75c7f0ef91146ebfb530314f5f1d24528d7f0767efbfd31dce919275413e393e"
 dependencies = [
- "webpki-root-certs 1.0.7",
+ "webpki-root-certs 1.0.6",
 ]
 
 [[package]]
 name = "webpki-root-certs"
-version = "1.0.7"
+version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5607,9 +5918,15 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 [[package]]
 name = "windows"
 version = "0.62.2"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-numerics",
  "windows-collections",
  "windows-core",
  "windows-future",
@@ -5619,9 +5936,13 @@ dependencies = [
 [[package]]
 name = "windows-collections"
 version = "0.3.2"
+name = "windows-collections"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
+ "windows-core",
  "windows-core",
 ]
 
@@ -5635,7 +5956,19 @@ dependencies = [
  "windows-interface",
  "windows-link",
  "windows-result",
+ "windows-result",
  "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
+dependencies = [
+ "windows-core",
+ "windows-link",
+ "windows-threading",
 ]
 
 [[package]]
@@ -5680,9 +6013,25 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 [[package]]
 name = "windows-numerics"
 version = "0.3.1"
+name = "windows-numerics"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
+ "windows-core",
+ "windows-link",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
  "windows-core",
  "windows-link",
 ]
@@ -5831,6 +6180,15 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
+dependencies = [
+ "windows-link",
 ]
 
 [[package]]
@@ -6025,6 +6383,7 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 [[package]]
 name = "winnow"
 version = "0.7.15"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
@@ -6033,9 +6392,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ee1708bef14716a11bae175f579062d4554d95be2c6829f518df847b7b3fdd0"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
 dependencies = [
  "memchr",
 ]
@@ -6058,12 +6417,6 @@ checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
 dependencies = [
  "wit-bindgen-rust-macro",
 ]
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wit-bindgen-core"
@@ -6114,7 +6467,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags 2.11.0",
  "indexmap",
  "log",
  "serde",
@@ -6147,7 +6500,9 @@ dependencies = [
 [[package]]
 name = "writeable"
 version = "0.6.3"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
@@ -6204,7 +6559,9 @@ dependencies = [
 [[package]]
 name = "yoke"
 version = "0.8.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 checksum = "abe8c5fda708d9ca3df187cae8bfb9ceda00dd96231bed36e445a1a48e66f9ca"
 dependencies = [
  "stable_deref_trait",
@@ -6215,7 +6572,9 @@ dependencies = [
 [[package]]
 name = "yoke-derive"
 version = "0.8.2"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
@@ -6227,7 +6586,9 @@ dependencies = [
 [[package]]
 name = "zerocopy"
 version = "0.8.48"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 checksum = "eed437bf9d6692032087e337407a86f04cd8d6a16a37199ed57949d415bd68e9"
 dependencies = [
  "zerocopy-derive",
@@ -6236,7 +6597,9 @@ dependencies = [
 [[package]]
 name = "zerocopy-derive"
 version = "0.8.48"
+version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
@@ -6247,7 +6610,9 @@ dependencies = [
 [[package]]
 name = "zerofrom"
 version = "0.1.7"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 checksum = "69faa1f2a1ea75661980b013019ed6687ed0e83d069bc1114e2cc74c6c04c4df"
 dependencies = [
  "zerofrom-derive",
@@ -6256,7 +6621,9 @@ dependencies = [
 [[package]]
 name = "zerofrom-derive"
 version = "0.1.7"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
@@ -6284,7 +6651,9 @@ dependencies = [
 [[package]]
 name = "zerotrie"
 version = "0.2.4"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
@@ -6295,7 +6664,9 @@ dependencies = [
 [[package]]
 name = "zerovec"
 version = "0.11.6"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
@@ -6306,7 +6677,9 @@ dependencies = [
 [[package]]
 name = "zerovec-derive"
 version = "0.11.3"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
@@ -6317,7 +6690,9 @@ dependencies = [
 [[package]]
 name = "zmij"
 version = "1.0.21"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = { version = "0.3.28", features = ["thread-pool"]}
 bytes = "1.4.0"
 serde_json = "1.0.140"
 clap = { version = "4.4.2", features = ["derive", "string"] }
-bitcoin = { git = "https://github.com/braidpool/rust-bitcoin.git", branch = "cpunet",features=["serde"]}
+bitcoin = {version="0.32.5",features=["serde","std"]}
 bitcoin_hashes = { version = "0.16" }
 bitcoincore-rpc = { version = "0.19.0"}
 bitcoincore-rpc-json = { version = "0.19.0"}
@@ -30,7 +30,7 @@ bitcoincore-zmq = { version = "1.5.2", git = "https://github.com/antonilol/rust-
 shellexpand = "3.1.0"
 num = { version = "0.4.1", features = ["serde", "rand"] }
 rand = "0.8"
-secp256k1 = "0.30.0"
+secp256k1 = "0.29.1"
 libp2p = { version = "0.55.0", features = ["identify", "quic", "tokio","ping","macros","kad","dns","request-response","floodsub"] }
 toml = "0.8.22"
 jsonrpsee = {version = "0.25.1",features = ["full"]}

--- a/node/src/bead/mod.rs
+++ b/node/src/bead/mod.rs
@@ -2,9 +2,12 @@ use crate::committed_metadata::CommittedMetadata;
 use crate::uncommitted_metadata::UnCommittedMetadata;
 use crate::utils::BeadHash;
 use async_trait::async_trait;
+use bitcoin::block::Header as BlockHeader;
+use bitcoin::block::Version as BlockVersion;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
-use bitcoin::{BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget, TxMerkleNode};
+use bitcoin::hashes::Hash;
+use bitcoin::{BlockHash, CompactTarget, TxMerkleNode};
 use libp2p::futures::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 use libp2p::request_response::Codec;
 use libp2p::StreamProtocol;
@@ -52,8 +55,8 @@ impl Default for Bead {
                 bits: CompactTarget::from_consensus(1),
                 merkle_root: TxMerkleNode::from_byte_array(empty_merkle_bytes),
                 nonce: 0,
-                prev_blockhash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
-                time: BlockTime::from_u32(0),
+                prev_blockhash: BlockHash::all_zeros(),
+                time: 0,
                 version: BlockVersion::TWO,
             },
             committed_metadata: CommittedMetadata::default(),

--- a/node/src/bead/tests.rs
+++ b/node/src/bead/tests.rs
@@ -16,18 +16,16 @@ use bitcoin::absolute::Time;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
+use bitcoin::consensus::encode::Error as DeserializeError;
 use bitcoin::consensus::serialize;
-use bitcoin::consensus::DeserializeError;
 use bitcoin::ecdsa::Signature;
-use bitcoin::pow::CompactTargetExt;
+use bitcoin::hashes::Hash;
 use bitcoin::BlockHash;
-use bitcoin::BlockHeader;
-use bitcoin::BlockTime;
-use bitcoin::BlockVersion;
 use bitcoin::CompactTarget;
 use bitcoin::EcdsaSighashType;
 use bitcoin::TxMerkleNode;
 use bitcoin::Txid;
+use bitcoin::{block::Header as BlockHeader, block::Version as BlockVersion};
 use futures::executor::block_on;
 use libp2p::request_response::Codec;
 use std::collections::HashSet;
@@ -145,7 +143,7 @@ fn test_serialized_bead() {
         prev_blockhash: BlockHash::from_byte_array(test_bytes),
         bits: CompactTarget::from_consensus(32),
         nonce: 1,
-        time: BlockTime::from_u32(8328429),
+        time: 8328429,
         merkle_root: TxMerkleNode::from_byte_array(test_bytes),
     };
     let test_bead = TestBeadBuilder::new()
@@ -215,7 +213,7 @@ fn test_bead_response_serialization() {
         prev_blockhash: BlockHash::from_byte_array(test_bytes),
         bits: CompactTarget::from_consensus(32),
         nonce: 1,
-        time: BlockTime::from_u32(8328429),
+        time: 8328429,
         merkle_root: TxMerkleNode::from_byte_array(test_bytes),
     };
     let test_bead = TestBeadBuilder::new()

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -7,9 +7,10 @@ use crate::utils::test_utils::test_utility_functions::{
 };
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::consensus::serialize;
-use bitcoin::BlockVersion;
+use bitcoin::hashes::Hash;
 use bitcoin::CompactTarget;
-use bitcoin::{BlockHash, BlockHeader, BlockTime, EcdsaSighashType, TxMerkleNode};
+use bitcoin::{block::Header as BlockHeader, block::Version as BlockVersion};
+use bitcoin::{BlockHash, EcdsaSighashType, TxMerkleNode};
 use futures::StreamExt;
 use libp2p::floodsub::Topic;
 use libp2p::swarm::SwarmEvent;
@@ -60,7 +61,7 @@ fn create_test_bead() -> Bead {
         prev_blockhash: BlockHash::from_byte_array(test_bytes),
         bits: CompactTarget::from_consensus(486604799),
         nonce: 1,
-        time: BlockTime::from_u32(8328429),
+        time: 8328429,
         merkle_root: TxMerkleNode::from_byte_array(test_bytes),
     };
     Bead {
@@ -429,7 +430,7 @@ async fn test_floodsub_message_propagation() {
     });
 
     let result = rx.recv().await.unwrap();
-    let received_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&result);
+    let received_bead: Result<Bead, bitcoin::consensus::encode::Error> = deserialize(&result);
     assert_eq!(
         compute_block_hash(&received_bead.unwrap().block_header, &"cpunet".to_string()),
         compute_block_hash(&test_bead_ref.clone().block_header, &"cpunet".to_string())

--- a/node/src/committed_metadata/mod.rs
+++ b/node/src/committed_metadata/mod.rs
@@ -1,10 +1,9 @@
 use crate::utils::{hashset_to_vec_deterministic, vec_to_hashset, BeadHash};
-use bitcoin::absolute::MedianTimePast;
 use bitcoin::absolute::Time;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
-use bitcoin::consensus::Error;
-use bitcoin::io::{self, BufRead, Write};
+use bitcoin::consensus::encode::Error;
+use bitcoin::io::{self, Read, Write};
 use bitcoin::CompactTarget;
 use bitcoin::PublicKey;
 use bitcoin::Txid;
@@ -28,7 +27,7 @@ impl Encodable for TimeVec {
 }
 
 impl Decodable for TimeVec {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let len = u64::consensus_decode(r)?;
         let mut vec = Vec::with_capacity(len as usize);
         for _ in 0..len {
@@ -52,7 +51,7 @@ impl Encodable for TxIdVec {
     }
 }
 impl Decodable for TxIdVec {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let len = u64::consensus_decode(r)?;
         let mut vec = Vec::with_capacity(len as usize);
         for _ in 0..len {
@@ -86,7 +85,7 @@ impl Default for CommittedMetadata {
             parents: HashSet::new(),
             parent_bead_timestamps: TimeVec(Vec::new()),
             payout_address: "bc1".to_string(),
-            start_timestamp: MedianTimePast::MIN,
+            start_timestamp: Time::MIN,
             comm_pub_key: PublicKey::from_str(
                 "020202020202020202020202020202020202020202020202020202020202020202",
             )
@@ -108,7 +107,7 @@ impl Encodable for CommittedMetadata {
             .start_timestamp
             .to_consensus_u32()
             .consensus_encode(w)?;
-        let pubkey_bytes = self.comm_pub_key.to_vec();
+        let pubkey_bytes = self.comm_pub_key.to_bytes();
         len += pubkey_bytes.consensus_encode(w)?;
         len += self.min_target.consensus_encode(w)?;
         len += self.weak_target.consensus_encode(w)?;
@@ -118,7 +117,7 @@ impl Encodable for CommittedMetadata {
 }
 
 impl Decodable for CommittedMetadata {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let transaction_ids = TxIdVec::consensus_decode(r)?;
         let parents = vec_to_hashset(Vec::<BeadHash>::consensus_decode(r)?);
         let parent_bead_timestamps = TimeVec::consensus_decode(r)?;

--- a/node/src/committed_metadata/tests.rs
+++ b/node/src/committed_metadata/tests.rs
@@ -1,7 +1,6 @@
 use super::*;
 use crate::utils::hashset_to_vec_deterministic;
 use crate::utils::test_utils::test_utility_functions::TestCommittedMetadataBuilder;
-use bitcoin::absolute::MedianTimePast;
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::consensus::serialize;
 use bitcoin::BlockHash;
@@ -181,7 +180,6 @@ fn test_committed_metadata_default() {
         metadata.payout_address,
         data.payout_addresses.default.as_str()
     );
-    assert_eq!(metadata.start_timestamp, MedianTimePast::MIN);
     assert_eq!(
         metadata.comm_pub_key,
         parse_public_key(&data.public_keys.default_committed)

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -147,7 +147,7 @@ impl CoinbaseConfig {
             let network = Network::from_core_arg(core_arg).unwrap_or(Network::Bitcoin);
             let pool_payout_address = match network {
                 Network::Bitcoin => "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
-                Network::Testnet(_) => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+                Network::Testnet => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
                 Network::Signet => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
                 Network::Regtest => "bcrt1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
                 _ => "tb1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
@@ -196,7 +196,7 @@ mod test {
                 ],
             },
             bitcoin_config: BitcoinConfig {
-                network: Network::CPUNet,
+                network: Network::Regtest,
                 username: "username".to_string(),
                 password: "password".to_string(),
                 port: "18443".to_string(),

--- a/node/src/cpunet.rs
+++ b/node/src/cpunet.rs
@@ -1,11 +1,10 @@
 //! Cpunet implementation
 //Referenced - https://github.com/braidpool/rust-bitcoin/tree/cpunet
 use bitcoin::{
-    address::script_pubkey::ScriptBufExt,
     bech32,
     block::Header,
-    hashes::{sha256d, HashEngine},
-    BlockHash, BlockHeight, BlockHeightInterval, ScriptBuf, Target, WitnessProgram,
+    hashes::{sha256d, Hash, HashEngine},
+    BlockHash, ScriptBuf, Target, WitnessProgram,
 };
 use core::fmt;
 use std::str::FromStr;
@@ -24,17 +23,17 @@ pub struct CpunetParams {
     /// BIP16 activation time
     pub bip16_time: u32,
     /// BIP34 activation height
-    pub bip34_height: BlockHeight,
+    pub bip34_height: u32,
     /// BIP65 activation height
-    pub bip65_height: BlockHeight,
+    pub bip65_height: u32,
     /// BIP66 activation height
-    pub bip66_height: BlockHeight,
+    pub bip66_height: u32,
     /// Whether to enforce BIP94 (testnet4 rules)
     pub enforce_bip94: bool,
     /// Threshold for rule change activation (75% = 1512 of 2016)
-    pub rule_change_activation_threshold: BlockHeightInterval,
+    pub rule_change_activation_threshold: u32,
     /// Miner confirmation window for soft forks
-    pub miner_confirmation_window: BlockHeightInterval,
+    pub miner_confirmation_window: u32,
     /// Maximum proof-of-work target (minimum difficulty)
     pub pow_limit: Target,
     /// Maximum attainable target value
@@ -59,12 +58,12 @@ impl CpunetParams {
     pub const fn new() -> Self {
         Self {
             bip16_time: 1333238400, // Apr 1 2012
-            bip34_height: BlockHeight::from_u32(1),
-            bip65_height: BlockHeight::from_u32(1),
-            bip66_height: BlockHeight::from_u32(1),
+            bip34_height: 1,
+            bip65_height: 1,
+            bip66_height: 1,
             enforce_bip94: false,
-            rule_change_activation_threshold: BlockHeightInterval::from_u32(1512), // 75%
-            miner_confirmation_window: BlockHeightInterval::from_u32(2016),
+            rule_change_activation_threshold: 1512, // 75%
+            miner_confirmation_window: 2016,
             pow_limit: Target::MAX_ATTAINABLE_MAINNET,
             max_attainable_target: Target::MAX_ATTAINABLE_MAINNET,
             pow_target_spacing: 10 * 60,            // 10 minutes
@@ -142,7 +141,7 @@ impl Cpunet {
         engine.input(&header.version.to_consensus().to_le_bytes());
         engine.input(header.prev_blockhash.as_byte_array());
         engine.input(header.merkle_root.as_byte_array());
-        engine.input(&header.time.to_u32().to_le_bytes());
+        engine.input(&header.time.to_le_bytes());
         engine.input(&header.bits.to_consensus().to_le_bytes());
         engine.input(&header.nonce.to_le_bytes());
         engine.input("cpunet\0".as_bytes());
@@ -172,7 +171,6 @@ impl FromStr for Cpunet {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use bitcoin::script::ScriptExt;
     use bitcoin::WitnessVersion;
 
     #[test]

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -7,8 +7,8 @@ use crate::{
     utils::{compute_block_hash, BeadHash},
 };
 use bitcoin::{
-    absolute::MedianTimePast, ecdsa::Signature, BlockHash, BlockTime, BlockVersion, CompactTarget,
-    PublicKey, TxMerkleNode, Txid,
+    absolute::Time, block::Version as BlockVersion, ecdsa::Signature, hashes::Hash, BlockHash,
+    CompactTarget, PublicKey, TxMerkleNode, Txid,
 };
 use futures::lock::Mutex;
 use num::ToPrimitive;
@@ -97,7 +97,7 @@ impl DBHandler {
         let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
         let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
         let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
-        let public_key_bytes = bead.committed_metadata.comm_pub_key.to_vec();
+        let public_key_bytes = bead.committed_metadata.comm_pub_key.to_bytes();
         let signature_bytes = bead.uncommitted_metadata.signature.to_vec();
         let mut conn = match self.db_connection_pool.lock().await.begin().await {
             Ok(conn) => conn,
@@ -119,14 +119,18 @@ impl DBHandler {
             .bind(bead.block_header.bits.to_consensus())
             .bind(bead.block_header.nonce)
             .bind(payout_addr_bytes)
-            .bind(bead.committed_metadata.start_timestamp.to_u32())
+            .bind(bead.committed_metadata.start_timestamp.to_consensus_u32())
             .bind(public_key_bytes)
             .bind(bead.committed_metadata.min_target.to_consensus())
             .bind(bead.committed_metadata.weak_target.to_consensus())
             .bind(bead.committed_metadata.miner_ip)
             .bind(hex_converted_extranonce_1.to_string())
             .bind(hex_converted_extranonce_2.to_string())
-            .bind(bead.uncommitted_metadata.broadcast_timestamp.to_u32())
+            .bind(
+                bead.uncommitted_metadata
+                    .broadcast_timestamp
+                    .to_consensus_u32(),
+            )
             .bind(signature_bytes)
             .bind(txs_json)
             .bind(relative_json)
@@ -247,7 +251,7 @@ pub fn prepare_bead_tuple_data(
         let ts = beads[parent]
             .committed_metadata
             .start_timestamp
-            .to_u32()
+            .to_consensus_u32()
             .to_u64()
             .expect("An error occurred while casting u32 to u64");
 
@@ -322,7 +326,7 @@ pub async fn fetch_beads_in_batch(
 
             bead.block_header.version = BlockVersion::from_consensus(row.get::<i32, _>("nVersion"));
             bead.block_header.bits = CompactTarget::from_consensus(row.get::<u32, _>("nBits"));
-            bead.block_header.time = BlockTime::from_u32(row.get::<u32, _>("nTime"));
+            bead.block_header.time = row.get::<u32, _>("nTime");
             bead.block_header.nonce = row.get::<u32, _>("nNonce");
 
             let prev_bytes: Vec<u8> = row.get("hashPrevBlock");
@@ -364,12 +368,11 @@ pub async fn fetch_beads_in_batch(
             bead.committed_metadata.weak_target =
                 CompactTarget::from_consensus(row.get::<u32, _>("weak_target"));
             bead.committed_metadata.miner_ip = row.get("miner_ip");
-
             bead.committed_metadata.start_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("start_timestamp")).unwrap();
+                Time::from_consensus(row.get::<u32, _>("start_timestamp")).unwrap();
 
             bead.uncommitted_metadata.broadcast_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("broadcast_timestamp")).unwrap();
+                Time::from_consensus(row.get::<u32, _>("broadcast_timestamp")).unwrap();
 
             bead.uncommitted_metadata.extra_nonce_1 =
                 u32::from_str_radix(&row.get::<String, _>("extranonce1"), 16).unwrap();
@@ -442,7 +445,7 @@ pub async fn fetch_beads_in_batch(
                 bead.committed_metadata
                     .parent_bead_timestamps
                     .0
-                    .push(MedianTimePast::from_u32(timestamp as u32).unwrap());
+                    .push(Time::from_consensus(timestamp as u32).unwrap());
             }
 
             fetched_beads.push(bead);
@@ -481,14 +484,14 @@ pub async fn fetch_bead_by_bead_hash(
                     });
                 }
             };
-            let ntime = BlockTime::from_u32(row.get::<u32, _>("nTime"));
+            let ntime = row.get::<u32, _>("nTime");
             let nbits = CompactTarget::from_consensus(row.get::<u32, _>("nBits"));
             let nonce = row.get::<u32, _>("nNonce");
             let payout_address = std::str::from_utf8(&row.get::<Vec<u8>, _>("payout_address"))
                 .unwrap()
                 .to_string();
             let start_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("start_timestamp")).unwrap();
+                Time::from_consensus(row.get::<u32, _>("start_timestamp")).unwrap();
             let pub_key = PublicKey::from_slice(&row.get::<Vec<u8>, _>("comm_pub_key")).unwrap();
             let min_target = CompactTarget::from_consensus(row.get::<u32, _>("min_target"));
             let weak_target = CompactTarget::from_consensus(row.get::<u32, _>("weak_target"));
@@ -498,7 +501,7 @@ pub async fn fetch_bead_by_bead_hash(
             let extranonce_2 =
                 u32::from_str_radix(&row.get::<String, _>("extranonce2"), 16).unwrap();
             let broadcast_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("broadcast_timestamp")).unwrap();
+                Time::from_consensus(row.get::<u32, _>("broadcast_timestamp")).unwrap();
             let signature = Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).unwrap();
             bead_id = id;
             fetched_bead.block_header.version = version;
@@ -593,7 +596,7 @@ pub async fn fetch_bead_by_bead_hash(
             .committed_metadata
             .parent_bead_timestamps
             .0
-            .push(MedianTimePast::from_u32(parent_timestamp as u32).unwrap());
+            .push(Time::from_consensus(parent_timestamp as u32).unwrap());
         //Extending parent committment by parent hash
         fetched_bead
             .committed_metadata
@@ -711,7 +714,10 @@ pub mod test {
                 parent_timestamp_tuples.push((
                     (*parent_bead as u64),
                     (*bead_id as u64),
-                    current_parent_timestamp.to_u32().to_u64().unwrap(),
+                    current_parent_timestamp
+                        .to_consensus_u32()
+                        .to_u64()
+                        .unwrap(),
                 ));
             }
             for bead_tx in bead.committed_metadata.transaction_ids.0.iter() {
@@ -765,7 +771,7 @@ pub mod test {
             let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
             let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
             let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
-            let public_key_bytes = bead.committed_metadata.comm_pub_key.to_vec();
+            let public_key_bytes = bead.committed_metadata.comm_pub_key.to_bytes();
             let signature_bytes = bead.uncommitted_metadata.signature.to_vec();
             let mut test_insertion_tx = test_pool.begin().await.unwrap();
             if let Err(e) = sqlx::query(&INSERT_QUERY)
@@ -778,14 +784,18 @@ pub mod test {
                 .bind(bead.block_header.bits.to_consensus())
                 .bind(bead.block_header.nonce)
                 .bind(payout_addr_bytes)
-                .bind(bead.committed_metadata.start_timestamp.to_u32())
+                .bind(bead.committed_metadata.start_timestamp.to_consensus_u32())
                 .bind(public_key_bytes)
                 .bind(bead.committed_metadata.min_target.to_consensus())
                 .bind(bead.committed_metadata.weak_target.to_consensus())
                 .bind(bead.committed_metadata.miner_ip.clone())
                 .bind(hex_converted_extranonce_1.to_string())
                 .bind(hex_converted_extranonce_2.to_string())
-                .bind(bead.uncommitted_metadata.broadcast_timestamp.to_u32())
+                .bind(
+                    bead.uncommitted_metadata
+                        .broadcast_timestamp
+                        .to_consensus_u32(),
+                )
                 .bind(signature_bytes)
                 .bind(test_tx_json)
                 .bind(test_relative_json)

--- a/node/src/default_braidpool_config.toml
+++ b/node/src/default_braidpool_config.toml
@@ -14,7 +14,7 @@ miner_pubkey = ""
 
 [bitcoin_config]
 # The network can be "main", "testnet4" or "signet or cpunet(preferred)"
-network = "cpunet"
+network = "regtest"
 #rpcuser
 username = "username"
 #rpc password

--- a/node/src/ipc.rs
+++ b/node/src/ipc.rs
@@ -451,20 +451,21 @@ async fn get_template(
     let final_template =
         create_braidpool_template(&components.components, &config, block_height, NONCE)?;
 
-    let template_transaction_count = final_template.block_transaction_count();
-
-    let complete_block_bytes = final_template.complete_block_hex;
+    let complete_block_bytes = final_template.complete_block_hex.clone();
     if complete_block_bytes.is_empty() {
         return Err("Received empty template (0 bytes)".into());
     }
-
-    if template_transaction_count < MIN_TRANSACTION_COUNT {
-        warn!(
-            context = %context,
-            transaction_count = %template_transaction_count,
-            min_transaction_count = %MIN_TRANSACTION_COUNT,
-            "Template tx count smaller than minimum - using anyway"
-        );
+    if let Some(template_transaction_count) = final_template.block_transaction_count() {
+        if template_transaction_count < MIN_TRANSACTION_COUNT {
+            warn!(
+                context = %context,
+                transaction_count = %template_transaction_count,
+                min_transaction_count = %MIN_TRANSACTION_COUNT,
+                "Template tx count smaller than minimum - using anyway"
+            );
+        }
+    } else {
+        return Err("An error occurred due to invalid decode of tx count to varint during template formation".into());
     }
 
     let mut processed_template = (*components).clone();

--- a/node/src/ipc/client.rs
+++ b/node/src/ipc/client.rs
@@ -3,7 +3,7 @@ use crate::init_capnp::init::Client as InitClient;
 use crate::proxy_capnp::thread::Client as ThreadClient;
 use crate::utils::compute_block_hash;
 use crate::TemplateId;
-use bitcoin::BlockHeader;
+use bitcoin::block::Header as BlockHeader;
 use capnp_rpc::{rpc_twoparty_capnp, twoparty, RpcSystem};
 use futures::FutureExt;
 use std::collections::VecDeque;
@@ -995,7 +995,7 @@ impl SharedBitcoinClient {
             } => {
                 let block_hash = compute_block_hash(&header, &network_type);
                 let version = header.version.to_consensus() as u32;
-                let timestamp = header.time.to_u32();
+                let timestamp = header.time;
                 let nonce = header.nonce;
                 match bitcoin_client
                     .submit_solution(

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,8 +1,8 @@
 //These implementations must be defined under lib.rs as they are required for intergration tests
 use crate::db::db_handlers::prepare_bead_tuple_data;
 use bitcoin::{
-    consensus::encode::deserialize, ecdsa::Signature, pow::CompactTargetExt, BlockHash,
-    CompactTarget, EcdsaSighashType, Txid,
+    consensus::encode::deserialize, ecdsa::Signature, BlockHash, CompactTarget, EcdsaSighashType,
+    Txid,
 };
 use num::ToPrimitive;
 use std::{
@@ -177,11 +177,15 @@ pub async fn ipc_template_consumer(
 
             let candidate_block: Result<
                 bitcoin::blockdata::block::Block,
-                bitcoin::consensus::DeserializeError,
+                bitcoin::consensus::encode::Error,
             > = deserialize(&template_bytes);
-
             let merkle_branch_coinbase = ipc_template.components.coinbase_merkle_path.clone();
-            let (template_header, template_transactions) = candidate_block.unwrap().into_parts();
+            let (template_header, template_transactions) = match candidate_block {
+                Ok(template) => (template.header, template.txdata),
+                Err(_error) => {
+                    return Err(IPCtemplateError::TemplateConsumeError);
+                }
+            };
             let _coinbase_transaction = template_transactions.get(0);
 
             debug!(template_id = %template_id, template_header = ?template_header, "New block template");
@@ -285,7 +289,8 @@ impl SwarmHandler {
         //TODO: Will be used as seperate entity after altering `uncommitted_metadata`
         extranonce_1_raw_value: u32,
     ) -> Result<(), StratumErrors> {
-        let (candidate_block_header, candidate_block_transactions) = candidate_block.into_parts();
+        let candidate_block_header = candidate_block.header;
+        let candidate_block_transactions = candidate_block.txdata;
         let ids: Vec<Txid> = candidate_block_transactions
             .iter()
             .map(|tx| tx.compute_txid())
@@ -349,10 +354,7 @@ impl SwarmHandler {
         let unix_timestamp = duration_since_epoch.as_secs().to_u32().unwrap();
 
         let candidate_block_bead_uncommitted_metadata = UnCommittedMetadata {
-            broadcast_timestamp: bitcoin::blockdata::locktime::absolute::MedianTimePast::from_u32(
-                unix_timestamp,
-            )
-            .unwrap(),
+            broadcast_timestamp: bitcoin::absolute::Time::from_consensus(unix_timestamp).unwrap(),
             extra_nonce_1: extranonce_1_raw_value,
             extra_nonce_2: extranonce_2_raw_value,
             signature: sig,

--- a/node/src/macros.rs
+++ b/node/src/macros.rs
@@ -63,7 +63,7 @@ macro_rules! braidpool_protocol {
         }
 
         impl bitcoin::consensus::encode::Decodable for $name {
-            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::Error> {
+            fn consensus_decode<R: bitcoin::io::Read + ?Sized>(r: &mut R) -> core::result::Result<Self, bitcoin::consensus::encode::Error> {
                 let discriminant = u8::consensus_decode(r)?;
                 braidpool_protocol!(@decode discriminant, r, $name, $($variants)*)
             }
@@ -178,7 +178,7 @@ macro_rules! braidpool_protocol {
         }
     };
     (@decode_match $discrim:ident, $r:ident, $name:ident, $($rest:tt)*) => {
-        Err(bitcoin::consensus::Error::from(bitcoin::io::Error::new(
+        Err(bitcoin::consensus::encode::Error::from(bitcoin::io::Error::new(
             bitcoin::io::ErrorKind::InvalidData,
             concat!("Invalid message id for ", stringify!($name)),
         )))
@@ -221,7 +221,7 @@ macro_rules! impl_consensus_encoding {
 
         impl bitcoin::consensus::encode::Decodable for $thing {
             #[inline]
-            fn consensus_decode_from_finite_reader<R: bitcoin::io::BufRead + ?Sized>(
+            fn consensus_decode_from_finite_reader<R: bitcoin::io::Read + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$thing, bitcoin::consensus::encode::Error> {
                 Ok($thing {
@@ -230,7 +230,7 @@ macro_rules! impl_consensus_encoding {
             }
 
             #[inline]
-            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(
+            fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$thing, bitcoin::consensus::encode::Error> {
                 use bitcoin::io::Read;
@@ -306,9 +306,9 @@ macro_rules! impl_vec_wrapper {
                 &self,
                 w: &mut W,
             ) -> core::result::Result<usize, bitcoin::io::Error> {
-                use bitcoin::consensus::WriteExt;
+                use bitcoin::consensus::encode::{VarInt};
                 let mut len = 0;
-                len += w.emit_compact_size(self.0.len())?;
+                 len += VarInt(self.0.len() as u64).consensus_encode(w)?;
                 for c in self.0.iter() {
                     len += c.consensus_encode(w)?;
                 }
@@ -318,12 +318,11 @@ macro_rules! impl_vec_wrapper {
 
         impl bitcoin::consensus::encode::Decodable for $wrapper {
             #[inline]
-            fn consensus_decode_from_finite_reader<R: bitcoin::io::BufRead + ?Sized>(
+            fn consensus_decode_from_finite_reader<R: bitcoin::io::Read + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$wrapper, bitcoin::consensus::encode::Error> {
-                use bitcoin::consensus::ReadExt;
-                let len = r.read_compact_size()?;
-                // Limit the initial vec allocation to at most 8,000 bytes, which is
+                use bitcoin::consensus::encode::{VarInt};
+                let len = VarInt::consensus_decode(r)?.0 as usize;                  // Limit the initial vec allocation to at most 8,000 bytes, which is
                 // sufficient for most use cases. We don't allocate more space upfront
                 // than this, since `len` is an untrusted allocation capacity. If the
                 // vector does overflow the initial capacity `push` will just reallocate.
@@ -337,7 +336,7 @@ macro_rules! impl_vec_wrapper {
                 Ok($wrapper(ret))
             }
 
-            fn consensus_decode<R: bitcoin::io::BufRead + ?Sized>(
+            fn consensus_decode<R: bitcoin::io::Read + ?Sized>(
                 r: &mut R,
             ) -> core::result::Result<$wrapper, bitcoin::consensus::encode::Error> {
                 Self::consensus_decode_from_finite_reader(r)

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -577,7 +577,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                              size_bytes = %message.data.len(),
                              "Floodsub message received"
                          );
-                         let result_bead: Result<Bead, bitcoin::consensus::DeserializeError> = deserialize(&message.data);
+                         let result_bead: Result<Bead, bitcoin::consensus::encode::Error> = deserialize(&message.data);
                          match result_bead {
                              Ok(bead) => {
                                 info!(bead = ?bead, hash = %bead.block_header.block_hash(), "Received bead");
@@ -587,7 +587,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                      braid_data.extend(&bead)
                                  };
                                  if ibd_spinlock.load(Ordering::SeqCst){
-                                    let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_u32();
+                                    let broadcast_ts = bead.uncommitted_metadata.broadcast_timestamp.clone().to_consensus_u32();
                                     let (ts_tx, ts_rx) = tokio::sync::oneshot::channel();
                                     if let Err(e) = ibd_command_tx
                                         .send(IBDCommands::FetchAllTimestamps { sender: ts_tx })
@@ -1080,6 +1080,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         let status = braid_data.extend(&bead);
                                         let curr_beadhash = braid_data.compute_bead_hash(&bead).to_string();
                                         if let braid::AddBeadStatus::InvalidBead = status {
+                                            warn!("INVALID BEAD RECEIVED FROM PEER");
                                             // update the peer manager about the invalid bead
                                             {
                                                 let mut peer_manager = peer_manager_arc.write().await;
@@ -1115,7 +1116,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             //persisting the received beads from peer onto DB(disk)
                                             match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
                                                 Ok(_)=>{
-                                                    debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
+                                                    warn!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded sanmdfiasnASBNUIYFBNASUIYBNFYUI*ASBNFGYUIASHBNGYUIASHBNGYUIAGHBN");
                                                 },
                                                 Err(error)=>{
                                                     tracing::error!(

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1080,7 +1080,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         let status = braid_data.extend(&bead);
                                         let curr_beadhash = braid_data.compute_bead_hash(&bead).to_string();
                                         if let braid::AddBeadStatus::InvalidBead = status {
-                                            warn!("INVALID BEAD RECEIVED FROM PEER");
+                                            warn!("Invalid bead received from peer");
                                             // update the peer manager about the invalid bead
                                             {
                                                 let mut peer_manager = peer_manager_arc.write().await;
@@ -1116,7 +1116,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             //persisting the received beads from peer onto DB(disk)
                                             match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
                                                 Ok(_)=>{
-                                                    warn!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded sanmdfiasnASBNUIYFBNASUIYBNFYUI*ASBNFGYUIASHBNGYUIASHBNGYUIAGHBN");
+                                                    warn!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
                                                 },
                                                 Err(error)=>{
                                                     tracing::error!(

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -10,7 +10,6 @@ use crate::stratum::BlockTemplate;
 #[cfg(test)]
 use crate::utils::compute_block_hash;
 use crate::utils::BeadHash;
-use bitcoin::block::HeaderExt;
 use bitcoin::Transaction;
 use futures::lock::Mutex;
 use jsonrpsee::core::async_trait;

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -3,11 +3,11 @@ use crate::error::StratumErrors;
 use crate::template_creator::calculate_merkle_root;
 use crate::utils::compute_block_hash;
 use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
-use bitcoin::block::HeaderExt;
-use bitcoin::consensus::serialize;
+use bitcoin::consensus::{serialize, Decodable};
+use bitcoin::hashes::Hash;
 use bitcoin::io::Cursor;
-use bitcoin::{absolute::Decodable, Transaction};
-use bitcoin::{BlockHash, BlockHeader, BlockTime, TxMerkleNode, Txid, Witness};
+use bitcoin::Transaction;
+use bitcoin::{block::Header as BlockHeader, BlockHash, TxMerkleNode, Txid, Witness};
 use futures::{lock::Mutex, FutureExt};
 use num::ToPrimitive;
 use rand::RngCore;
@@ -59,13 +59,13 @@ pub struct BlockTemplate {
     pub coinbasevalue: Option<u64>,
     pub longpollid: Option<String>,
     pub target: bitcoin::Target,
-    pub mintime: Option<bitcoin::time::BlockTime>,
+    pub mintime: Option<u32>,
     pub mutable: Option<Vec<String>>,
     pub noncerange: Option<String>,
     pub sigoplimit: Option<u32>,
     pub sizelimit: Option<usize>,
     pub weightlimit: Option<bitcoin::blockdata::Weight>,
-    pub curtime: bitcoin::time::BlockTime,
+    pub curtime: u32,
     pub bits: bitcoin::CompactTarget,
     pub height: bitcoin::absolute::Height,
     pub default_witness_commitment: Option<Witness>,
@@ -77,7 +77,7 @@ impl Default for BlockTemplate {
             rules: None,
             vbavailable: None,
             vbrequired: None,
-            previousblockhash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
+            previousblockhash: BlockHash::all_zeros(),
             transactions: Vec::new(),
             coinbaseaux: None,
             coinbasevalue: None,
@@ -89,7 +89,7 @@ impl Default for BlockTemplate {
             sigoplimit: None,
             sizelimit: None,
             weightlimit: None,
-            curtime: bitcoin::BlockTime::from_u32(1759998900),
+            curtime: 1759998900,
             bits: bitcoin::CompactTarget::from_consensus(0),
             height: bitcoin::absolute::Height::ZERO,
             default_witness_commitment: None,
@@ -650,7 +650,7 @@ impl DownstreamClient {
             version: bitcoin::blockdata::block::Version::from_consensus(final_masked_version),
             prev_blockhash: submitted_job.blocktemplate.previousblockhash,
             merkle_root: merkle_root,
-            time: BlockTime::from_u32(ntime_u32),
+            time: ntime_u32,
             bits: submitted_job.blocktemplate.bits,
             nonce: nonce_u32,
         };
@@ -658,7 +658,7 @@ impl DownstreamClient {
         let target = bitcoin::Target::from_compact(compact_target);
         debug!(
             connection_id = %connection_id_hex,
-            target = %target.to_hex(),
+            target = %hex::encode(target.to_le_bytes()),
             "Mining target"
         );
         debug!(
@@ -675,7 +675,7 @@ impl DownstreamClient {
         };
         let prevhash_be_hex = hex::encode(header.prev_blockhash.to_byte_array());
         let merkle_root_be_hex = hex::encode(header.merkle_root.to_byte_array());
-        let time_be_hex = hex::encode(header.time.to_u32().to_be_bytes());
+        let time_be_hex = hex::encode(header.time.to_be_bytes());
         let bits_be_hex = hex::encode(header.bits.to_consensus().to_be_bytes());
         let nonce_be_hex = hex::encode(header.nonce.to_be_bytes());
 
@@ -709,7 +709,7 @@ impl DownstreamClient {
                 return Err(StratumErrors::InvalidCoinbase);
             }
         };
-        match coinbase_tx.inputs_mut().get_mut(0) {
+        match coinbase_tx.input.get_mut(0) {
             Some(input) => input.witness.push(witness_bytes),
             None => {
                 error!(connection_id = %connection_id_hex, "Coinbase transaction has no inputs");
@@ -721,8 +721,10 @@ impl DownstreamClient {
         block_transactions.extend(submitted_job.blocktemplate.transactions.clone());
 
         // Construct and log the complete block using rust-bitcoin's Block struct
-        let complete_block = bitcoin::Block::new_unchecked(header, block_transactions);
-
+        let complete_block = bitcoin::Block {
+            header,
+            txdata: block_transactions,
+        };
         // For cpunet, use custom block_hash calculation; otherwise use standard validate_pow
         let is_cpunet = Cpunet::is_cpunet_name(&self.network_name);
         let pow_result = if is_cpunet {
@@ -741,7 +743,7 @@ impl DownstreamClient {
             Ok(block_hash) => {
                 debug!(
                     connection_id = %connection_id_hex,
-                    target = %target.to_hex(),
+                    target = %target,
                     hash = %block_hash,
                     is_cpunet = is_cpunet,
                     "Header meets target"
@@ -785,7 +787,7 @@ impl DownstreamClient {
                 debug!(
                     connection_id = %connection_id_hex,
                     error = %e,
-                    target = %target.to_hex(),
+                    target = %target,
                     "Header does not meet target"
                 );
                 return Ok(StratumResponses::StandardResponse {
@@ -1404,14 +1406,14 @@ impl Notifier {
                 });
             }
         };
-        let coinbase_witness_commitment = match coinbase_transaction.inputs().get(0) {
+        let coinbase_witness_commitment = match coinbase_transaction.input.get(0) {
             Some(input) => input.witness.clone(),
             None => {
                 error!(template_id = %template_id, "Coinbase transaction has no inputs");
                 return Err(StratumErrors::InvalidCoinbase);
             }
         };
-        if let Some(input) = coinbase_transaction.inputs_mut().get_mut(0) {
+        if let Some(input) = coinbase_transaction.input.get_mut(0) {
             input.witness.clear();
         };
         let deserialized_coinbase = serialize::<Transaction>(&coinbase_transaction);
@@ -1464,7 +1466,7 @@ impl Notifier {
         };
         let bitcoin_block_version = notified_template.version.to_consensus();
         let bits = notified_template.bits;
-        let time = notified_template.curtime.to_u32();
+        let time = notified_template.curtime;
         //Adding support for segwit coinbase
         Ok(JobNotification {
             job_id: template_id.to_string(),
@@ -2129,8 +2131,8 @@ mod test {
         stratum::{ConnectionMapping, MiningJobMap, NotifyCmd, Server, StratumServerConfig},
     };
     use bitcoin::{
-        absolute::LockTime, pow::CompactTargetExt, script::ScriptBufExt, Amount, BlockHash,
-        BlockVersion, OutPoint, ScriptBuf, Sequence, TxIn, TxOut,
+        absolute::LockTime, block::Version as BlockVersion, Amount, BlockHash, OutPoint, ScriptBuf,
+        Sequence, TxIn, TxOut,
     };
     use futures::lock::Mutex;
     use tokio::{
@@ -2442,6 +2444,7 @@ mod test {
 
     #[tokio::test]
     async fn submit_work_no_version_rolling() {
+        use super::Cpunet;
         /*
         Test block taken - 00000020e6ebb395a1e2ba60f17650d790309e21af08062229ad955376ac574300000000e8de27818e402a0d5e6028f363be4b47d809ad348e6bc88ac2f9c2bedf0409e9337edf68ffff001d7aeb8b0601020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff1602611e089495ac0803000000094272616964706f6f6cffffffff0300f2052a01000000160014e470d0179325db88b55771f6c0a5139dd81d73180000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf900000000000000002a6a286272616964706f6f6c5f626561645f6d657461646174615f686173685f33326201020304050607080120000000000000000000000000000000000000000000000000000000000000000000000000
 
@@ -2462,15 +2465,9 @@ mod test {
         //There is a case in prevblockhash too but it can be discussed afterwards
         //Cleaning up connection channels from connection mapping as well as from global map arc of stratum server
         let test_coinbase_transaction: Transaction = Transaction {
-            version: bitcoin::TransactionVersion::TWO,
+            version:bitcoin::blockdata::transaction::Version::TWO,
             input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: Txid::from_str(
-                        "0000000000000000000000000000000000000000000000000000000000000000",
-                    )
-                    .unwrap(),
-                    vout: OutPoint::COINBASE_PREVOUT.vout,
-                },
+                previous_output: OutPoint::null(),
                 script_sig: ScriptBuf::from_hex(
                     "02611e080101010101010101094272616964706f6f6c",
                 )
@@ -2480,17 +2477,17 @@ mod test {
             }],
             output: vec![
                 TxOut {
-                    value: Amount::FIFTY_BTC,
+                    value: Amount::from_btc(50.0).unwrap(),
                     script_pubkey: ScriptBuf::from_hex("0014e470d0179325db88b55771f6c0a5139dd81d7318")
                         .unwrap(),
                 },
                 TxOut {
-                    value: Amount::from_sat(0).unwrap(),
+                    value: Amount::from_sat(0),
                     script_pubkey: ScriptBuf::from_hex("6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9")
                         .unwrap(),
                 },
                 TxOut {
-                    value: Amount::from_sat(0).unwrap(),
+                    value: Amount::from_sat(0),
                     script_pubkey: ScriptBuf::from_hex(
                         "6a286272616964706f6f6c5f626561645f6d657461646174615f686173685f3332620102030405060708",
                     )
@@ -2503,7 +2500,7 @@ mod test {
             bits: bitcoin::pow::CompactTarget::from_unprefixed_hex("1d00ffff").unwrap(),
             nonce: 0,
             version: BlockVersion::from_consensus(536870912),
-            time: BlockTime::from_u32(1759477299),
+            time: 1759477299,
             prev_blockhash: BlockHash::from_str(
                 "000000004357ac765395ad29220608af219e3090d75076f160bae2a195b3ebe6",
             )
@@ -2564,6 +2561,7 @@ mod test {
         ]);
         let test_extranonce_1 = hex::decode("9495ac08").unwrap();
         mock_downstream_handler.extranonce1 = test_extranonce_1;
+        mock_downstream_handler.network_name = "cpunet".to_string();
         let configure_response = mock_downstream_handler
             .handle_configure(&configure_test_request, 1)
             .await;

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -3,11 +3,11 @@ use crate::error::StratumErrors;
 use crate::template_creator::calculate_merkle_root;
 use crate::utils::compute_block_hash;
 use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
-use bitcoin::block::HeaderExt;
-use bitcoin::consensus::serialize;
+use bitcoin::consensus::{serialize, Decodable};
+use bitcoin::hashes::Hash;
 use bitcoin::io::Cursor;
-use bitcoin::{absolute::Decodable, Transaction};
-use bitcoin::{BlockHash, BlockHeader, BlockTime, TxMerkleNode, Txid, Witness};
+use bitcoin::Transaction;
+use bitcoin::{block::Header as BlockHeader, BlockHash, TxMerkleNode, Txid, Witness};
 use futures::{lock::Mutex, FutureExt};
 use num::ToPrimitive;
 use rand::RngCore;
@@ -59,13 +59,13 @@ pub struct BlockTemplate {
     pub coinbasevalue: Option<u64>,
     pub longpollid: Option<String>,
     pub target: bitcoin::Target,
-    pub mintime: Option<bitcoin::time::BlockTime>,
+    pub mintime: Option<u32>,
     pub mutable: Option<Vec<String>>,
     pub noncerange: Option<String>,
     pub sigoplimit: Option<u32>,
     pub sizelimit: Option<usize>,
     pub weightlimit: Option<bitcoin::blockdata::Weight>,
-    pub curtime: bitcoin::time::BlockTime,
+    pub curtime: u32,
     pub bits: bitcoin::CompactTarget,
     pub height: bitcoin::absolute::Height,
     pub default_witness_commitment: Option<Witness>,
@@ -77,7 +77,7 @@ impl Default for BlockTemplate {
             rules: None,
             vbavailable: None,
             vbrequired: None,
-            previousblockhash: BlockHash::GENESIS_PREVIOUS_BLOCK_HASH,
+            previousblockhash: BlockHash::all_zeros(),
             transactions: Vec::new(),
             coinbaseaux: None,
             coinbasevalue: None,
@@ -89,7 +89,7 @@ impl Default for BlockTemplate {
             sigoplimit: None,
             sizelimit: None,
             weightlimit: None,
-            curtime: bitcoin::BlockTime::from_u32(1759998900),
+            curtime: 1759998900,
             bits: bitcoin::CompactTarget::from_consensus(0),
             height: bitcoin::absolute::Height::ZERO,
             default_witness_commitment: None,
@@ -608,7 +608,7 @@ impl DownstreamClient {
             version: bitcoin::blockdata::block::Version::from_consensus(final_masked_version),
             prev_blockhash: submitted_job.blocktemplate.previousblockhash,
             merkle_root: merkle_root,
-            time: BlockTime::from_u32(ntime_u32),
+            time: ntime_u32,
             bits: submitted_job.blocktemplate.bits,
             nonce: nonce_u32,
         };
@@ -616,7 +616,7 @@ impl DownstreamClient {
         let target = bitcoin::Target::from_compact(compact_target);
         debug!(
             connection_id = %connection_id_hex,
-            target = %target.to_hex(),
+            target = %hex::encode(target.to_le_bytes()),
             "Mining target"
         );
         debug!(
@@ -633,7 +633,7 @@ impl DownstreamClient {
         };
         let prevhash_be_hex = hex::encode(header.prev_blockhash.to_byte_array());
         let merkle_root_be_hex = hex::encode(header.merkle_root.to_byte_array());
-        let time_be_hex = hex::encode(header.time.to_u32().to_be_bytes());
+        let time_be_hex = hex::encode(header.time.to_be_bytes());
         let bits_be_hex = hex::encode(header.bits.to_consensus().to_be_bytes());
         let nonce_be_hex = hex::encode(header.nonce.to_be_bytes());
 
@@ -667,7 +667,7 @@ impl DownstreamClient {
                 return Err(StratumErrors::InvalidCoinbase);
             }
         };
-        match coinbase_tx.inputs_mut().get_mut(0) {
+        match coinbase_tx.input.get_mut(0) {
             Some(input) => input.witness.push(witness_bytes),
             None => {
                 error!(connection_id = %connection_id_hex, "Coinbase transaction has no inputs");
@@ -679,8 +679,10 @@ impl DownstreamClient {
         block_transactions.extend(submitted_job.blocktemplate.transactions.clone());
 
         // Construct and log the complete block using rust-bitcoin's Block struct
-        let complete_block = bitcoin::Block::new_unchecked(header, block_transactions);
-
+        let complete_block = bitcoin::Block {
+            header,
+            txdata: block_transactions,
+        };
         // For cpunet, use custom block_hash calculation; otherwise use standard validate_pow
         let is_cpunet = Cpunet::is_cpunet_name(&self.network_name);
         let pow_result = if is_cpunet {
@@ -699,7 +701,7 @@ impl DownstreamClient {
             Ok(block_hash) => {
                 debug!(
                     connection_id = %connection_id_hex,
-                    target = %target.to_hex(),
+                    target = %target,
                     hash = %block_hash,
                     is_cpunet = is_cpunet,
                     "Header meets target"
@@ -743,7 +745,7 @@ impl DownstreamClient {
                 debug!(
                     connection_id = %connection_id_hex,
                     error = %e,
-                    target = %target.to_hex(),
+                    target = %target,
                     "Header does not meet target"
                 );
                 return Ok(StratumResponses::StandardResponse {
@@ -1361,14 +1363,14 @@ impl Notifier {
                 });
             }
         };
-        let coinbase_witness_commitment = match coinbase_transaction.inputs().get(0) {
+        let coinbase_witness_commitment = match coinbase_transaction.input.get(0) {
             Some(input) => input.witness.clone(),
             None => {
                 error!(template_id = %template_id, "Coinbase transaction has no inputs");
                 return Err(StratumErrors::InvalidCoinbase);
             }
         };
-        if let Some(input) = coinbase_transaction.inputs_mut().get_mut(0) {
+        if let Some(input) = coinbase_transaction.input.get_mut(0) {
             input.witness.clear();
         };
         let deserialized_coinbase = serialize::<Transaction>(&coinbase_transaction);
@@ -1421,7 +1423,7 @@ impl Notifier {
         };
         let bitcoin_block_version = notified_template.version.to_consensus();
         let bits = notified_template.bits;
-        let time = notified_template.curtime.to_u32();
+        let time = notified_template.curtime;
         //Adding support for segwit coinbase
         Ok(JobNotification {
             job_id: template_id.to_string(),
@@ -2086,8 +2088,8 @@ mod test {
         stratum::{ConnectionMapping, MiningJobMap, NotifyCmd, Server, StratumServerConfig},
     };
     use bitcoin::{
-        absolute::LockTime, pow::CompactTargetExt, script::ScriptBufExt, Amount, BlockHash,
-        BlockVersion, OutPoint, ScriptBuf, Sequence, TxIn, TxOut,
+        absolute::LockTime, block::Version as BlockVersion, Amount, BlockHash, OutPoint, ScriptBuf,
+        Sequence, TxIn, TxOut,
     };
     use futures::lock::Mutex;
     use tokio::{
@@ -2398,7 +2400,8 @@ mod test {
     //TODO: this test is currently conditional wrt to master branch for our forked rust-bitcoin hence commented out
 
     #[tokio::test]
-    async fn submit_work_version_rolling() {
+    async fn submit_work_no_version_rolling() {
+        use super::Cpunet;
         /*
         Test block taken - 00000020e6ebb395a1e2ba60f17650d790309e21af08062229ad955376ac574300000000e8de27818e402a0d5e6028f363be4b47d809ad348e6bc88ac2f9c2bedf0409e9337edf68ffff001d7aeb8b0601020000000001010000000000000000000000000000000000000000000000000000000000000000ffffffff1602611e089495ac0803000000094272616964706f6f6cffffffff0300f2052a01000000160014e470d0179325db88b55771f6c0a5139dd81d73180000000000000000266a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf900000000000000002a6a286272616964706f6f6c5f626561645f6d657461646174615f686173685f33326201020304050607080120000000000000000000000000000000000000000000000000000000000000000000000000
 
@@ -2419,15 +2422,9 @@ mod test {
         //There is a case in prevblockhash too but it can be discussed afterwards
         //Cleaning up connection channels from connection mapping as well as from global map arc of stratum server
         let test_coinbase_transaction: Transaction = Transaction {
-            version: bitcoin::TransactionVersion::TWO,
+            version:bitcoin::blockdata::transaction::Version::TWO,
             input: vec![TxIn {
-                previous_output: OutPoint {
-                    txid: Txid::from_str(
-                        "0000000000000000000000000000000000000000000000000000000000000000",
-                    )
-                    .unwrap(),
-                    vout: OutPoint::COINBASE_PREVOUT.vout,
-                },
+                previous_output: OutPoint::null(),
                 script_sig: ScriptBuf::from_hex(
                     "02611e080101010101010101094272616964706f6f6c",
                 )
@@ -2437,17 +2434,17 @@ mod test {
             }],
             output: vec![
                 TxOut {
-                    value: Amount::FIFTY_BTC,
+                    value: Amount::from_btc(50.0).unwrap(),
                     script_pubkey: ScriptBuf::from_hex("0014e470d0179325db88b55771f6c0a5139dd81d7318")
                         .unwrap(),
                 },
                 TxOut {
-                    value: Amount::from_sat(0).unwrap(),
+                    value: Amount::from_sat(0),
                     script_pubkey: ScriptBuf::from_hex("6a24aa21a9ede2f61c3f71d1defd3fa999dfa36953755c690689799962b48bebd836974e8cf9")
                         .unwrap(),
                 },
                 TxOut {
-                    value: Amount::from_sat(0).unwrap(),
+                    value: Amount::from_sat(0),
                     script_pubkey: ScriptBuf::from_hex(
                         "6a286272616964706f6f6c5f626561645f6d657461646174615f686173685f3332620102030405060708",
                     )
@@ -2460,7 +2457,7 @@ mod test {
             bits: bitcoin::pow::CompactTarget::from_unprefixed_hex("1d00ffff").unwrap(),
             nonce: 0,
             version: BlockVersion::from_consensus(536870912),
-            time: BlockTime::from_u32(1759477299),
+            time: 1759477299,
             prev_blockhash: BlockHash::from_str(
                 "000000004357ac765395ad29220608af219e3090d75076f160bae2a195b3ebe6",
             )
@@ -2522,6 +2519,7 @@ mod test {
         ]);
         let test_extranonce_1 = hex::decode("9495ac08").unwrap();
         mock_downstream_handler.extranonce1 = test_extranonce_1;
+        mock_downstream_handler.network_name = "cpunet".to_string();
         let configure_response = mock_downstream_handler
             .handle_configure(&configure_test_request, 1)
             .await;

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1847,7 +1847,7 @@ impl Server {
                     event = listener.accept()=>{
                         //Currently we do not accept connections from downstream during IBD wrt to sync nodes
                         if ibd_or_not.load(std::sync::atomic::Ordering::SeqCst) == true{
-                        warn!("Braid node not synced and is under IBD thus skipping the connection from downstream.");
+                        warn!("Braid node not synced and is under IBD,skipping the connection from downstream.");
                             continue;
                         }
                         else{

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -3,7 +3,8 @@ use crate::cpunet::Cpunet;
 use crate::error::CoinbaseError;
 use crate::ipc::client::BlockTemplateComponents;
 use crate::EXTRANONCE_SEPARATOR;
-use bitcoin::consensus::encode::{ReadExt, WriteExt};
+use bitcoin::consensus::encode::{deserialize_partial, serialize, VarInt};
+use bitcoin::hashes::Hash;
 use bitcoin::{
     absolute::LockTime,
     blockdata::{
@@ -17,7 +18,6 @@ use bitcoin::{
     Address, Amount, OutPoint, ScriptBuf, Sequence, Transaction, TxIn, TxOut, Txid,
 };
 use std::convert::TryFrom;
-use std::io::Cursor;
 use std::str::FromStr;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
@@ -105,7 +105,7 @@ impl FinalTemplate {
     pub fn block_transaction_count(&self) -> u64 {
         if self.complete_block_hex.len() >= Self::BLOCK_HEADER_LENGTH {
             let body = &self.complete_block_hex[Self::BLOCK_HEADER_LENGTH..];
-            match decode_varint(body) {
+            match deserialize_partial(body) {
                 Ok((count, _)) => count,
                 Err(_) => 0,
             }
@@ -180,28 +180,6 @@ pub fn parse_coinbase_transaction(coinbase_bytes: &[u8]) -> Result<Transaction, 
 
     let mut cursor = Cursor::new(coinbase_bytes);
     Transaction::consensus_decode(&mut cursor).map_err(|_| CoinbaseError::ConsensusDecodeError)
-}
-
-/// Decode a Bitcoin varint from bytes. Returns (value, bytes_read), where
-/// bytes_read may be < data.len() if additional trailing bytes are present.
-fn decode_varint(data: &[u8]) -> Result<(u64, usize), CoinbaseError> {
-    let mut cursor = Cursor::new(data);
-
-    match cursor.read_compact_size() {
-        Ok(value) => {
-            let bytes_read = cursor.position() as usize;
-            Ok((value, bytes_read))
-        }
-        Err(_) => Err(CoinbaseError::ConsensusDecodeError),
-    }
-}
-
-/// Encode a u64 as Bitcoin varint
-fn encode_varint(value: u64) -> Vec<u8> {
-    let mut buf = Vec::new();
-    buf.emit_compact_size(value)
-        .expect("Vec::write failure is impossible");
-    buf
 }
 
 fn find_transaction_end(tx_data: &[u8]) -> Result<usize, CoinbaseError> {
@@ -286,7 +264,7 @@ fn build_coinbase_input(
     witness.push(vec![0u8; 32]);
 
     Ok(TxIn {
-        previous_output: OutPoint::COINBASE_PREVOUT,
+        previous_output: OutPoint::null(),
         script_sig,
         sequence: Sequence::MAX,
         witness,
@@ -417,10 +395,7 @@ pub fn build_braidpool_coinbase_from_template(
     };
 
     let reward_payout = TxOut {
-        value: Amount::from_sat(total_available).map_err(|e| {
-            error!(error = %e, "Amount conversion failed");
-            CoinbaseError::InvalidBlockTemplateData
-        })?,
+        value: Amount::from_sat(total_available),
         script_pubkey: payout_script,
     };
 
@@ -479,10 +454,11 @@ pub fn build_complete_block(
     if cursor >= original_block_hex.len() {
         return Err(CoinbaseError::InvalidBlockTemplateData);
     }
-    let (tx_count, varint_size) = decode_varint(&original_block_hex[cursor..])?;
+    let (tx_count, varint_size) = deserialize_partial::<VarInt>(&original_block_hex[cursor..])
+        .expect("An error occurred while decoding VarInt representation");
     cursor += varint_size;
 
-    if tx_count == 0 {
+    if tx_count.0 == 0 {
         return Err(CoinbaseError::InvalidBlockTemplateData);
     }
     if cursor >= original_block_hex.len() {
@@ -492,7 +468,7 @@ pub fn build_complete_block(
     cursor += original_coinbase_end;
 
     // Collect remaining transactions (everything after coinbase)
-    let remaining_transactions = if tx_count > 1 && cursor < original_block_hex.len() {
+    let remaining_transactions = if tx_count.0 > 1 && cursor < original_block_hex.len() {
         original_block_hex[cursor..].to_vec()
     } else {
         Vec::new()
@@ -510,7 +486,7 @@ pub fn build_complete_block(
     complete_block.extend_from_slice(&updated_header);
 
     // Add transaction count
-    complete_block.extend_from_slice(&encode_varint(tx_count));
+    complete_block.extend_from_slice(&serialize(&VarInt(tx_count.0)));
 
     // Add new coinbase transaction
     complete_block.extend_from_slice(&new_coinbase_bytes);
@@ -775,42 +751,42 @@ fn coinbase_input_too_big_is_rejected() {
 fn test_varint_comprehensive() {
     // Single-byte encoding (0-252)
     for value in 0u64..=252 {
-        let encoded = encode_varint(value);
+        let encoded = serialize(&VarInt(value));
         assert_eq!(encoded.len(), 1, "Value {} should encode to 1 byte", value);
         assert_eq!(encoded[0], value as u8);
-        let (decoded, bytes_read) = decode_varint(&encoded).unwrap();
-        assert_eq!(decoded, value, "Failed to decode value {}", value);
+        let (decoded, bytes_read) = deserialize_partial::<VarInt>(&encoded).unwrap();
+        assert_eq!(decoded.0, value, "Failed to decode value {}", value);
         assert_eq!(bytes_read, 1);
     }
 
     // Multi-byte: 0xFD (2 bytes), 0xFE (4 bytes), 0xFF (8 bytes)
     let fd_values = [253u64, 254, 255, 256, 1000, 10000, 65535];
     for value in fd_values {
-        let encoded = encode_varint(value);
+        let encoded = serialize(&VarInt(value));
         assert_eq!(encoded.len(), 3, "Value {} should encode to 3 bytes", value);
         assert_eq!(encoded[0], 0xFD);
-        let (decoded, bytes_read) = decode_varint(&encoded).unwrap();
-        assert_eq!(decoded, value);
+        let (decoded, bytes_read) = deserialize_partial::<VarInt>(&encoded).unwrap();
+        assert_eq!(decoded.0, value);
         assert_eq!(bytes_read, 3);
     }
 
     let fe_values = [65536u64, 100000, 1000000, 4294967295];
     for value in fe_values {
-        let encoded = encode_varint(value);
+        let encoded = serialize(&VarInt(value));
         assert_eq!(encoded.len(), 5, "Value {} should encode to 5 bytes", value);
         assert_eq!(encoded[0], 0xFE);
-        let (decoded, bytes_read) = decode_varint(&encoded).unwrap();
-        assert_eq!(decoded, value);
+        let (decoded, bytes_read) = deserialize_partial::<VarInt>(&encoded).unwrap();
+        assert_eq!(decoded.0, value);
         assert_eq!(bytes_read, 5);
     }
 
     let ff_values = [4294967296u64, 1000000000000, u64::MAX];
     for value in ff_values {
-        let encoded = encode_varint(value);
+        let encoded = serialize(&VarInt(value));
         assert_eq!(encoded.len(), 9, "Value {} should encode to 9 bytes", value);
         assert_eq!(encoded[0], 0xFF);
-        let (decoded, bytes_read) = decode_varint(&encoded).unwrap();
-        assert_eq!(decoded, value);
+        let (decoded, bytes_read) = deserialize_partial::<VarInt>(&encoded).unwrap();
+        assert_eq!(decoded.0, value);
         assert_eq!(bytes_read, 9);
     }
 
@@ -836,40 +812,45 @@ fn test_varint_comprehensive() {
         u64::MAX,
     ];
     for &value in &roundtrip_values {
-        let encoded = encode_varint(value);
-        let (decoded, _) = decode_varint(&encoded).unwrap();
+        let encoded = serialize(&VarInt(value));
+        let (decoded, _) = deserialize_partial::<VarInt>(&encoded).unwrap();
         assert_eq!(
-            decoded, value,
+            decoded.0, value,
             "Roundtrip failed for value {}, encoded as {:?}",
             value, encoded
         );
     }
 
     // Error handling for malformed/short input
-    assert!(decode_varint(&[]).is_err());
-    assert!(decode_varint(&[0xFD, 0x01]).is_err());
-    assert!(decode_varint(&[0xFE, 0x01, 0x02, 0x03]).is_err());
-    assert!(decode_varint(&[0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]).is_err());
+    assert!(deserialize_partial::<VarInt>(&[]).is_err());
+    assert!(deserialize_partial::<VarInt>(&[0xFD, 0x01]).is_err());
+    assert!(deserialize_partial::<VarInt>(&[0xFE, 0x01, 0x02, 0x03]).is_err());
+    assert!(
+        deserialize_partial::<VarInt>(&[0xFF, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07]).is_err()
+    );
 
     // Protocol compatibility
-    assert_eq!(encode_varint(0), vec![0x00]);
-    assert_eq!(encode_varint(252), vec![0xFC]);
-    assert_eq!(encode_varint(253), vec![0xFD, 0xFD, 0x00]);
-    assert_eq!(encode_varint(65535), vec![0xFD, 0xFF, 0xFF]);
-    assert_eq!(encode_varint(65536), vec![0xFE, 0x00, 0x00, 0x01, 0x00]);
+    assert_eq!(serialize(&VarInt(0)), vec![0x00]);
+    assert_eq!(serialize(&VarInt(252)), vec![0xFC]);
+    assert_eq!(serialize(&VarInt(253)), vec![0xFD, 0xFD, 0x00]);
+    assert_eq!(serialize(&VarInt(65535)), vec![0xFD, 0xFF, 0xFF]);
     assert_eq!(
-        encode_varint(4294967296),
+        serialize(&VarInt(65536)),
+        vec![0xFE, 0x00, 0x00, 0x01, 0x00]
+    );
+    assert_eq!(
+        serialize(&VarInt(4294967296)),
         vec![0xFF, 0x00, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00]
     );
 
     // Little-endian byte order for multi-byte encodings
-    assert_eq!(encode_varint(0x1234), vec![0xFD, 0x34, 0x12]);
+    assert_eq!(serialize(&VarInt(0x1234)), vec![0xFD, 0x34, 0x12]);
     assert_eq!(
-        encode_varint(0x12345678),
+        serialize(&VarInt(0x12345678)),
         vec![0xFE, 0x78, 0x56, 0x34, 0x12]
     );
     assert_eq!(
-        encode_varint(0x123456789ABCDEF0),
+        serialize(&VarInt(0x123456789ABCDEF0)),
         vec![0xFF, 0xF0, 0xDE, 0xBC, 0x9A, 0x78, 0x56, 0x34, 0x12]
     );
 
@@ -883,7 +864,7 @@ fn test_varint_comprehensive() {
         (4294967296u64, 9), // Min 0xFF
     ];
     for &(value, expected_len) in &boundaries {
-        let encoded = encode_varint(value);
+        let encoded = serialize(&VarInt(value));
         assert_eq!(
             encoded.len(),
             expected_len,
@@ -891,31 +872,31 @@ fn test_varint_comprehensive() {
             value,
             expected_len
         );
-        let (decoded, bytes_read) = decode_varint(&encoded).unwrap();
-        assert_eq!(decoded, value);
+        let (decoded, bytes_read) = deserialize_partial::<VarInt>(&encoded).unwrap();
+        assert_eq!(decoded.0, value);
         assert_eq!(bytes_read, expected_len);
     }
 
     // Only consume required bytes, ignore trailing data
-    let mut data = encode_varint(1000);
+    let mut data = serialize(&VarInt(1000));
     data.extend_from_slice(&[0xFF, 0xFF, 0xFF]);
-    let (decoded, bytes_read) = decode_varint(&data).unwrap();
-    assert_eq!(decoded, 1000);
+    let (decoded, bytes_read) = deserialize_partial::<VarInt>(&data).unwrap();
+    assert_eq!(decoded.0, 1000);
     assert_eq!(bytes_read, 3);
     assert!(bytes_read < data.len());
 
     // Zero and Max value correctness
-    let encoded_zero = encode_varint(0);
+    let encoded_zero = serialize(&VarInt(0));
     assert_eq!(encoded_zero, vec![0x00]);
-    let (decoded_zero, bytes_read_zero) = decode_varint(&encoded_zero).unwrap();
-    assert_eq!(decoded_zero, 0);
+    let (decoded_zero, bytes_read_zero) = deserialize_partial::<VarInt>(&encoded_zero).unwrap();
+    assert_eq!(decoded_zero.0, 0);
     assert_eq!(bytes_read_zero, 1);
 
     let max_value = u64::MAX;
-    let encoded_max = encode_varint(max_value);
+    let encoded_max = serialize(&VarInt(max_value));
     assert_eq!(encoded_max.len(), 9);
     assert_eq!(encoded_max[0], 0xFF);
-    let (decoded_max, bytes_read_max) = decode_varint(&encoded_max).unwrap();
-    assert_eq!(decoded_max, max_value);
+    let (decoded_max, bytes_read_max) = deserialize_partial::<VarInt>(&encoded_max).unwrap();
+    assert_eq!(decoded_max.0, max_value);
     assert_eq!(bytes_read_max, 9);
 }

--- a/node/src/template_creator.rs
+++ b/node/src/template_creator.rs
@@ -102,15 +102,19 @@ impl FinalTemplate {
     /// Returns the number of transactions in the block
     ///
     /// The number of transactions is the first `varint` field after the block header.
-    pub fn block_transaction_count(&self) -> u64 {
+    pub fn block_transaction_count(&self) -> Option<u64> {
         if self.complete_block_hex.len() >= Self::BLOCK_HEADER_LENGTH {
             let body = &self.complete_block_hex[Self::BLOCK_HEADER_LENGTH..];
-            match deserialize_partial(body) {
-                Ok((count, _)) => count,
-                Err(_) => 0,
+            match deserialize_partial::<VarInt>(body) {
+                Ok((count, _)) => Some(count.0),
+                Err(e) => {
+                    error!(error = %e, "failed to decode block tx count varint");
+                    None
+                }
             }
         } else {
-            0
+            error!("The complete block hex is below header length");
+            None
         }
     }
 }
@@ -454,8 +458,14 @@ pub fn build_complete_block(
     if cursor >= original_block_hex.len() {
         return Err(CoinbaseError::InvalidBlockTemplateData);
     }
-    let (tx_count, varint_size) = deserialize_partial::<VarInt>(&original_block_hex[cursor..])
-        .expect("An error occurred while decoding VarInt representation");
+    let (tx_count, varint_size) = match deserialize_partial::<VarInt>(&original_block_hex[cursor..])
+    {
+        Ok(decoded_varint_tuple) => decoded_varint_tuple,
+        Err(error) => {
+            error!("An error occurred while decoding varint during complete block reconstruction - {:#?}",error);
+            return Err(CoinbaseError::ConsensusDecodeError);
+        }
+    };
     cursor += varint_size;
 
     if tx_count.0 == 0 {

--- a/node/src/uncommitted_metadata/mod.rs
+++ b/node/src/uncommitted_metadata/mod.rs
@@ -1,9 +1,9 @@
 use bitcoin::absolute::Time;
 use bitcoin::consensus::encode::Decodable;
 use bitcoin::consensus::encode::Encodable;
-use bitcoin::consensus::Error;
+use bitcoin::consensus::encode::Error;
 use bitcoin::ecdsa::Signature;
-use bitcoin::io::{self, BufRead, Write};
+use bitcoin::io::{self, Read, Write};
 use bitcoin::EcdsaSighashType;
 use core::str::FromStr;
 use serde::Deserialize;
@@ -26,7 +26,7 @@ impl Default for UnCommittedMetadata {
         Self {
             extra_nonce_1: 0,
             extra_nonce_2: 0,
-            broadcast_timestamp: bitcoin::blockdata::locktime::absolute::MedianTimePast::MIN,
+            broadcast_timestamp: Time::MIN,
             signature: default_sig,
         }
     }
@@ -46,7 +46,7 @@ impl Encodable for UnCommittedMetadata {
 }
 
 impl Decodable for UnCommittedMetadata {
-    fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
+    fn consensus_decode<R: Read + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let extra_nonce_1 = u32::consensus_decode(r)?;
         let extra_nonce_2 = u32::consensus_decode(r)?;
         let broadcast_timestamp = Time::from_consensus(u32::consensus_decode(r).unwrap()).unwrap();

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -7,7 +7,10 @@ use crate::{
 };
 use ::bitcoin::BlockHash;
 use bitcoin::{
-    absolute::MedianTimePast as Time, ecdsa::Signature, BlockHeader, BlockTime, BlockVersion,
+    absolute::Time,
+    block::{Header as BlockHeader, Version as BlockVersion},
+    ecdsa::Signature,
+    hashes::Hash,
     CompactTarget, EcdsaSighashType, TxMerkleNode,
 };
 // Standard Imports
@@ -133,7 +136,7 @@ pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
         prev_blockhash: prev_hash.unwrap_or(BlockHash::from_byte_array(test_bytes)),
         bits: CompactTarget::from_consensus(486604799),
         nonce: nonce,
-        time: BlockTime::from_u32(8328429),
+        time: 8328429,
         merkle_root: TxMerkleNode::from_byte_array(test_bytes),
     };
     Bead {

--- a/node/src/utils/test_utils.rs
+++ b/node/src/utils/test_utils.rs
@@ -9,9 +9,9 @@ pub use crate::committed_metadata::TimeVec;
 #[cfg(test)]
 use crate::uncommitted_metadata::UnCommittedMetadata;
 #[cfg(test)]
-pub use bitcoin::ecdsa::Signature;
+use bitcoin::block::Header as BlockHeader;
 #[cfg(test)]
-use bitcoin::BlockHeader;
+pub use bitcoin::ecdsa::Signature;
 #[cfg(test)]
 pub use bitcoin::{absolute::Time, p2p::address::AddrV2, PublicKey, Transaction};
 #[cfg(test)]
@@ -24,10 +24,10 @@ pub mod test_utility_functions {
     #[cfg(test)]
     use bitcoin::Txid;
     use bitcoin::{
-        pow::CompactTargetExt, BlockHash, BlockTime, BlockVersion, CompactTarget, EcdsaSighashType,
+        block::Version as BlockVersion, hashes::Hash, BlockHash, CompactTarget, EcdsaSighashType,
         TxMerkleNode,
     };
-    use rand::{rngs::OsRng, thread_rng, RngCore};
+    use rand::{rngs::OsRng, RngCore};
     use secp256k1::{Message, Secp256k1, SecretKey};
     use serde::{Deserialize, Serialize};
 
@@ -313,11 +313,9 @@ pub mod test_utility_functions {
         }
     }
     fn generate_random_public_key_string() -> String {
-        let secp = Secp256k1::new();
-        let mut rng = thread_rng();
-        let secret_key = SecretKey::new(&mut rng);
-        let public_key = PublicKey::new(secret_key.public_key(&secp));
-        public_key.to_string()
+        let secp = &Secp256k1::new();
+        let secret_key = SecretKey::new(&mut rand::thread_rng());
+        hex::encode(secret_key.public_key(secp).serialize())
     }
 
     pub fn emit_bead() -> Bead {
@@ -325,7 +323,7 @@ pub mod test_utility_functions {
 
         let random_public_key = generate_random_public_key_string()
             .parse::<bitcoin::PublicKey>()
-            .unwrap();
+            .expect("An error occurred while generating Secret key rand bytes");
         // Generate a reasonable timestamp (between 2020-01-01 and now)
         let now = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)
@@ -392,7 +390,7 @@ pub mod test_utility_functions {
             prev_blockhash: BlockHash::from_byte_array(bytes),
             bits: CompactTarget::from_consensus(486604799),
             nonce: rand::random::<u32>(),
-            time: BlockTime::from_u32(0),
+            time: 0,
             merkle_root: TxMerkleNode::from_byte_array(bytes),
         };
 


### PR DESCRIPTION
- It alters the current functionalities on the basis of forked dependency for `rust-bitcoin`  to follow the upstream tagged version of `0.32.5` instead.