### PR TITLE
Fixed CWD dependency

### DIFF
--- a/tests/test_braid.py
+++ b/tests/test_braid.py
@@ -1,5 +1,10 @@
+import os
 import unittest
+from pathlib import Path
 from braid import *
+
+# Keep fixture lookup stable regardless of where tests are launched from.
+TEST_CASE_DIR = str(Path(__file__).resolve().parent / "braids") + os.sep
 
 class TestCohortMethods(unittest.TestCase):
     """ Test harness for unittest. """

--- a/tests/test_simulator_api.py
+++ b/tests/test_simulator_api.py
@@ -6,6 +6,8 @@ import websockets
 import time
 import subprocess
 import signal
+import sys
+from pathlib import Path
 
 class TestSimulatorAPI(unittest.TestCase):
     """Test the Simulator API websocket connection and message handling."""
@@ -13,10 +15,13 @@ class TestSimulatorAPI(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Start the simulator API server for testing."""
+        tests_dir = Path(__file__).resolve().parent
+        simulator_api_path = tests_dir / "simulator_api.py"
         cls.server_process = subprocess.Popen(
-            ["python", "simulator_api.py"],
+            [sys.executable, str(simulator_api_path)],
             stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE
+            stderr=subprocess.PIPE,
+            cwd=str(tests_dir)
         )
         # Give the server time to start
         time.sleep(1)


### PR DESCRIPTION
## Summary
Some Python test files have a dependency of running from the `tests` folder only; otherwise, errors were thrown stating 
"No directory found". This PR solves this issue by solving the path in the test code files.

Screenshots for the error:
<img width="1327" height="425" alt="image" src="https://github.com/user-attachments/assets/28e575b9-070e-4591-9715-bc5f83ffc3c1" />


Testing method:
Run the tests: `test_braid.py` and `test_simulator_api.py` from the project root. It should work fine now.