### PR TITLE
Adding CLI option to set stratum port

### DIFF
--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -1,4 +1,5 @@
 use clap::Parser;
+use std::net::SocketAddr;
 use std::path::PathBuf;
 
 #[derive(Parser, Debug, Clone)]
@@ -41,7 +42,36 @@ pub struct Cli {
     #[arg(long, default_value = "~/.bitcoin/.cookie")]
     pub rpccookie: Option<String>,
 
+    /// TCP port for the local Stratum server
+    #[arg(long, default_value_t = 3333)]
+    pub stratum_port: u16,
+
+    /// Bind address for the local node RPC server
+    #[arg(long, default_value = "127.0.0.1:6682")]
+    pub rpc_bind: SocketAddr,
+
     /// Path to Bitcoin Core IPC socket
     #[arg(long, default_value = "/tmp/bitcoin-cpunet.sock")]
     pub ipc_socket: String,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::Cli;
+    use clap::Parser;
+
+    #[test]
+    fn rpc_bind_parses_socket_address() {
+        let cli = Cli::try_parse_from(["braid", "--rpc-bind", "127.0.0.1:1234"]).unwrap();
+
+        assert_eq!(cli.rpc_bind.ip().to_string(), "127.0.0.1");
+        assert_eq!(cli.rpc_bind.port(), 1234);
+    }
+
+    #[test]
+    fn rpc_bind_rejects_address_without_port() {
+        let result = Cli::try_parse_from(["braid", "--rpc-bind", "127.0.0.1"]);
+
+        assert!(result.is_err());
+    }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -62,6 +62,7 @@ use tokio::sync::{
 async fn main() -> Result<(), Box<dyn Error>> {
     // Initialize tracing with colors and module prefixes
     setup_tracing()?;
+    let args = cli::Cli::parse();
     let (mut ibd_manager, ibd_command_tx) = IBDManager::new();
     //IBD cache handler
     let _ibd_handler = tokio::spawn(async move {
@@ -145,7 +146,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //Intializing `notifier` for mining.notify
     let mut notifier: Notifier = Notifier::new(notification_rx, Arc::clone(&mining_job_map));
     //Stratum configuration initialization
-    let stratum_config: StratumServerConfig = StratumServerConfig::default();
+    let stratum_config = StratumServerConfig {
+        port: args.stratum_port,
+        ..StratumServerConfig::default()
+    };
     let (block_submission_tx, block_submission_rx) =
         tokio::sync::mpsc::unbounded_channel::<node::stratum::BlockSubmissionRequest>();
     //IBD notifier task after peer_discovery
@@ -199,7 +203,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
         mpsc::channel::<tokio::signal::unix::SignalKind>(32);
     let main_task_token = CancellationToken::new();
     let ipc_task_token = main_task_token.clone();
-    let args = cli::Cli::parse();
     let datadir_str = args.datadir.to_str().ok_or_else(|| {
         std::io::Error::new(
             std::io::ErrorKind::InvalidInput,
@@ -388,20 +391,27 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
     // peer_manager_arc is created above and shared between swarm and RPC server
     //spawning the rpc server
-    let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
+    let rpc_addr = args.rpc_bind.to_string();
     let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args).unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     });
-    let server_join = tokio::spawn(run_rpc_server(
-        Arc::clone(&braid),
-        rpc_addr,
-        peer_manager_arc.clone(),
-        connection_mapping_for_rpc.clone(),
-        latest_template.clone(),
-        rpc_proxy_tx,
-        bitcoin_rpc_config,
-    ));
+    let rpc_braid = Arc::clone(&braid);
+    let rpc_peer_manager = peer_manager_arc.clone();
+    let rpc_connection_mapping = connection_mapping_for_rpc.clone();
+    let rpc_latest_template = latest_template.clone();
+    let server_join = tokio::spawn(async move {
+        run_rpc_server(
+            rpc_braid,
+            &rpc_addr,
+            rpc_peer_manager,
+            rpc_connection_mapping,
+            rpc_latest_template,
+            rpc_proxy_tx,
+            bitcoin_rpc_config,
+        )
+        .await
+    });
     match server_join.await {
         Ok(Ok(_addr)) => {}
         Ok(Err(())) => {

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -28,7 +28,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, RwLock};
-use tracing::{info, warn};
+use tracing::{error, info, warn};
 
 #[cfg(test)]
 use {
@@ -1039,9 +1039,13 @@ pub async fn run_rpc_server(
         .set_rpc_middleware(rpc_middleware)
         .build(bind_address)
         .await
-        .unwrap();
+        .map_err(|e| {
+            error!(bind_address = %bind_address, error = %e, "Failed to build RPC server");
+        })?;
     //listening address for incoming requests/connection
-    let addr = server.local_addr().unwrap();
+    let addr = server.local_addr().map_err(|e| {
+        error!(bind_address = %bind_address, error = %e, "Failed to get RPC local address");
+    })?;
     //context for the served server
     let rpc_impl = RpcServerImpl::new(
         braid_shared_pointer,

--- a/selftest.sh
+++ b/selftest.sh
@@ -5,12 +5,12 @@
 
 cd node
 cargo build
-cargo run -- --bind=127.0.0.1:8000 &
+cargo run -- --bind=127.0.0.1:8000 --stratum-port=3333 --rpc-bind=127.0.0.1:6682 &
 sleep 1
-cargo run -- --addnode=/ip4/127.0.0.1/udp/8000/quic-v1 --bind=127.0.0.1:9000 &
+cargo run -- --addnode=/ip4/127.0.0.1/udp/8000/quic-v1 --bind=127.0.0.1:9000 --stratum-port=3334 --rpc-bind=127.0.0.1:6683 &
 sleep 1
 echo
 echo ">>> Press any key to exit"
-read
+read -r _
 
 killall node

--- a/selftest.sh
+++ b/selftest.sh
@@ -10,7 +10,7 @@ sleep 1
 cargo run -- --addnode=/ip4/127.0.0.1/udp/8000/quic-v1 --bind=127.0.0.1:9000 --stratum-port=3334 --rpc-bind=127.0.0.1:6683 &
 sleep 1
 echo
-echo ">>> Press any key to exit"
+echo ">>> Press Enter to exit"
 read -r _
 
 killall node


### PR DESCRIPTION
## Summary
Current implementation doesn't have any option to set the stratum port from the CLI. This is especially needed when testing and running two nodes simultaneously. Further, the RPC bind port was hardcoded in the main file and was marked as a "TODO".

This PR solves the issue by getting both of these from the CLI args.

## Usage:
``cargo run -- --addnode=/ip4/127.0.0.1/udp/8000/quic-v1 --bind=127.0.0.1:9000 --stratum-port=3334 --rpc-bind=127.0.0.1:6683``

Added tage: 
- ``stratum-port``
- `rps-bind`


