### PR TITLE
node: honor braid_rpc_config.rpc_server_addr at startup

### DIFF
--- a/docs/braidpool_setup.md
+++ b/docs/braidpool_setup.md
@@ -60,7 +60,7 @@ You can find all available command-line arguments in [node/src/cli.rs](https://g
 -   `--ipc-socket <PATH>`: Specifies the path to the UNIX domain socket file (should be the same as bitcoin node).
 -   `--network <NETWORK>`: Sets the network. Valid options are `mainnet`, `testnet4`, `signet`, and `cpunet`. The default is `mainnet`.
 
-If `~/.braidpool/braidpool-config.toml` exists, the node will also load `braid_rpc_config.rpc_server_addr` from that config file when binding the JSON-RPC server.
+If `<datadir>/braidpool-config.toml` exists, the node will also load `braid_rpc_config.rpc_server_addr` from that config file when binding the JSON-RPC server. Here, `<datadir>` is the directory passed via `--datadir` or the default data directory if `--datadir` is not provided. The file must be a complete, valid `BraidpoolConfig` TOML document, not just a `[braid_rpc_config]` snippet.
 
 ## Setting up cpuminer for downstream connection
   - If you don't have a physical miner, you can do tests with CPUMiner.

--- a/docs/braidpool_setup.md
+++ b/docs/braidpool_setup.md
@@ -60,6 +60,8 @@ You can find all available command-line arguments in [node/src/cli.rs](https://g
 -   `--ipc-socket <PATH>`: Specifies the path to the UNIX domain socket file (should be the same as bitcoin node).
 -   `--network <NETWORK>`: Sets the network. Valid options are `mainnet`, `testnet4`, `signet`, and `cpunet`. The default is `mainnet`.
 
+If `~/.braidpool/braidpool-config.toml` exists, the node will also load `braid_rpc_config.rpc_server_addr` from that config file when binding the JSON-RPC server.
+
 ## Setting up cpuminer for downstream connection
   - If you don't have a physical miner, you can do tests with CPUMiner.
   - Firstly installation of `cpuminer` for connecting a downstream to the stratum service (can be done by any external ASIC device or cpu based).

--- a/node/src/config.rs
+++ b/node/src/config.rs
@@ -2,6 +2,8 @@ use bitcoin::Network;
 use core::panic;
 use serde::{Deserialize, Serialize};
 use std::fs;
+use std::io;
+use std::path::Path;
 #[derive(Deserialize, Serialize, Clone)]
 pub struct NetworkConfig {
     //Address to which the current braidpool node will bind to
@@ -39,6 +41,9 @@ pub struct BraidpoolConfig {
 pub struct BraidRpcConfig {
     pub rpc_server_addr: String,
 }
+
+pub const DEFAULT_CONFIG_FILENAME: &str = "braidpool-config.toml";
+
 impl Default for BraidRpcConfig {
     fn default() -> Self {
         BraidRpcConfig {
@@ -46,19 +51,45 @@ impl Default for BraidRpcConfig {
         }
     }
 }
+
+impl Default for BraidpoolConfig {
+    fn default() -> Self {
+        toml::from_str(include_str!("default_braidpool_config.toml"))
+            .expect("default braidpool config should be valid")
+    }
+}
+
 #[allow(dead_code)]
 impl BraidpoolConfig {
-    pub fn load_from_config_file(path: &str) -> BraidpoolConfig {
-        let contents = match fs::read_to_string(path) {
-            Ok(c) => c,
-            Err(error) => {
-                panic!("An error occurred while reading the file {}", error);
-            }
-        };
-        let config: BraidpoolConfig = toml::from_str(&contents).unwrap();
-
-        config
+    pub fn load_from_config_path(path: &Path) -> Result<BraidpoolConfig, io::Error> {
+        let contents = fs::read_to_string(path)?;
+        toml::from_str(&contents).map_err(|error| {
+            io::Error::new(
+                io::ErrorKind::InvalidData,
+                format!(
+                    "Failed to parse braidpool config at {}: {}",
+                    path.display(),
+                    error
+                ),
+            )
+        })
     }
+
+    pub fn load_from_config_file(path: &str) -> BraidpoolConfig {
+        Self::load_from_config_path(Path::new(path)).unwrap_or_else(|error| {
+            panic!("An error occurred while loading the config file {}", error);
+        })
+    }
+
+    pub fn load_from_datadir(datadir: &Path) -> Result<BraidpoolConfig, io::Error> {
+        let config_path = datadir.join(DEFAULT_CONFIG_FILENAME);
+        if !config_path.exists() {
+            return Ok(BraidpoolConfig::default());
+        }
+
+        Self::load_from_config_path(&config_path)
+    }
+
     pub fn with_listen_address(mut self, listen_address: String) -> Self {
         self.braidnetwork_config.listen_address = listen_address;
         return self;
@@ -132,11 +163,13 @@ impl CoinbaseConfig {
 
 #[cfg(test)]
 mod test {
+    use std::fs;
     use std::path::Path;
+    use std::time::{SystemTime, UNIX_EPOCH};
 
     use bitcoin::Network;
 
-    use crate::config::{BraidRpcConfig, MinerConfig};
+    use crate::config::{BraidRpcConfig, MinerConfig, DEFAULT_CONFIG_FILENAME};
 
     use super::{BitcoinConfig, BraidDirectoryConfig, BraidpoolConfig, NetworkConfig};
     #[test]
@@ -205,5 +238,64 @@ mod test {
             from_file.braid_rpc_config.rpc_server_addr,
             built.braid_rpc_config.rpc_server_addr
         );
+    }
+
+    #[test]
+    fn load_from_datadir_uses_default_when_config_is_missing() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!("braidpool-config-test-{}", unique));
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let config = BraidpoolConfig::load_from_datadir(&temp_dir).unwrap();
+
+        assert_eq!(
+            config.braid_rpc_config.rpc_server_addr,
+            BraidpoolConfig::default().braid_rpc_config.rpc_server_addr
+        );
+
+        fs::remove_dir_all(temp_dir).unwrap();
+    }
+
+    #[test]
+    fn load_from_datadir_reads_rpc_addr_from_config_file() {
+        let unique = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let temp_dir = std::env::temp_dir().join(format!("braidpool-config-test-{}", unique));
+        fs::create_dir_all(&temp_dir).unwrap();
+        let config_path = temp_dir.join(DEFAULT_CONFIG_FILENAME);
+        let config_contents = r#"
+[braidnetwork_config]
+listen_address = "/ip4/127.0.0.1/tcp/6885"
+peer_nodes = []
+
+[braid_directory]
+path = "~/.braidpool"
+
+[miner_config]
+miner_pubkey = ""
+
+[bitcoin_config]
+network = "cpunet"
+username = "username"
+password = "password"
+cookie_path = "~/.bitcoin/regtest/.cookie"
+port = "18443"
+bitcoind_ip = "0.0.0.0"
+
+[braid_rpc_config]
+rpc_server_addr = "127.0.0.1:7777"
+"#;
+        fs::write(&config_path, config_contents).unwrap();
+
+        let config = BraidpoolConfig::load_from_datadir(&temp_dir).unwrap();
+
+        assert_eq!(config.braid_rpc_config.rpc_server_addr, "127.0.0.1:7777");
+
+        fs::remove_dir_all(temp_dir).unwrap();
     }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -22,6 +22,7 @@ use node::{
     bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
     behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
     braid, cli,
+    config::BraidpoolConfig,
     db::db_handlers::DBHandler,
     ibd_manager::{IBDCommands, IBDManager, IBD_BATCH_SIZE},
     ipc_template_consumer,
@@ -226,6 +227,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
     }
 
     let datadir_path = Path::new(&*datadir);
+    let node_config = BraidpoolConfig::load_from_datadir(datadir_path).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            format!("Failed to load node config: {}", e),
+        )
+    })?;
     let keystore_path = datadir_path.join("keystore");
     #[cfg(unix)]
     {
@@ -387,15 +394,15 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // Create RPC proxy command channel - sender goes to RPC server, receiver goes to IPC handler
     let (rpc_proxy_tx, rpc_proxy_rx) = tokio::sync::mpsc::unbounded_channel::<RpcProxyCommand>();
     // peer_manager_arc is created above and shared between swarm and RPC server
-    //spawning the rpc server
-    let rpc_addr = "127.0.0.1:6682"; // TODO: Load from config file
+    // Use the configured RPC bind address when present; otherwise fall back to the default config.
+    let rpc_addr = node_config.braid_rpc_config.rpc_server_addr.clone();
     let bitcoin_rpc_config = BitcoinRpcConfig::from_cli_args(&args).unwrap_or_else(|e| {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     });
     let server_join = tokio::spawn(run_rpc_server(
         Arc::clone(&braid),
-        rpc_addr,
+        &rpc_addr,
         peer_manager_arc.clone(),
         connection_mapping_for_rpc.clone(),
         latest_template.clone(),

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -228,10 +228,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     let datadir_path = Path::new(&*datadir);
     let node_config = BraidpoolConfig::load_from_datadir(datadir_path).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidData,
-            format!("Failed to load node config: {}", e),
-        )
+        std::io::Error::new(e.kind(), format!("Failed to load node config: {}", e))
     })?;
     let keystore_path = datadir_path.join("keystore");
     #[cfg(unix)]
@@ -400,15 +397,22 @@ async fn main() -> Result<(), Box<dyn Error>> {
         eprintln!("Error: {}", e);
         std::process::exit(1);
     });
-    let server_join = tokio::spawn(run_rpc_server(
-        Arc::clone(&braid),
-        &rpc_addr,
-        peer_manager_arc.clone(),
-        connection_mapping_for_rpc.clone(),
-        latest_template.clone(),
-        rpc_proxy_tx,
-        bitcoin_rpc_config,
-    ));
+    let braid_for_rpc = Arc::clone(&braid);
+    let peer_manager_for_rpc = peer_manager_arc.clone();
+    let connection_mapping_for_rpc_task = connection_mapping_for_rpc.clone();
+    let latest_template_for_rpc = latest_template.clone();
+    let server_join = tokio::spawn(async move {
+        run_rpc_server(
+            braid_for_rpc,
+            &rpc_addr,
+            peer_manager_for_rpc,
+            connection_mapping_for_rpc_task,
+            latest_template_for_rpc,
+            rpc_proxy_tx,
+            bitcoin_rpc_config,
+        )
+        .await
+    });
     match server_join.await {
         Ok(Ok(_addr)) => {}
         Ok(Err(())) => {


### PR DESCRIPTION
## Summary
Closes #431.

The node already exposes `braid_rpc_config.rpc_server_addr` in the config layer and in `default_braidpool_config.toml`, but startup still hardcodes the RPC bind address in `main.rs`.

This PR makes startup honor `braid_rpc_config.rpc_server_addr` by loading node config from `~/.braidpool/braidpool-config.toml` when present and otherwise falling back to the existing default config.

## Changes
- load `BraidpoolConfig` from the node datadir during startup
- use `braid_rpc_config.rpc_server_addr` when starting the RPC server
- add tests covering datadir config loading and fallback to default config
- document the runtime config file location in `docs/braidpool_setup.md`

## Notes
There is related upstream work in:
- `#356`, which is a broader config-loading / CLI precedence PR
- `#435`, which adds CLI flags for RPC bind and stratum port

This PR is intentionally narrower and only addresses the config-backed RPC bind bug reported in `#431`.

## Testing
I added targeted config-loading tests, but I could not run `cargo test` or `cargo fmt` through Cargo locally because the current local Cargo toolchain (`1.81.0`) fails to parse this workspace with an `edition2024` manifest error.
