### PR TITLE
feat: add payout verifier scaffold and v1alpha invariant spec

### DIFF
--- a/braidpool-primitives/src/lib.rs
+++ b/braidpool-primitives/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod bead;
 pub mod braid;
 pub mod utils;
+pub mod verifier;

--- a/braidpool-primitives/src/verifier/mod.rs
+++ b/braidpool-primitives/src/verifier/mod.rs
@@ -1,0 +1,115 @@
+use std::collections::BTreeMap;
+
+/// High-level status emitted by verifier implementations.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VerificationStatus {
+    Pass,
+    Fail,
+    Unresolved,
+}
+
+/// Invariant identifiers for the payout verification pipeline.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum InvariantId {
+    Inv001ValueConservation,
+    Inv002RcaAncestryCorrectness,
+    Inv003CoinbaseMaturityWindow,
+    Inv004MinerAllocationExactness,
+    Inv005DeterministicOutputOrdering,
+    Inv006EpochBoundaryCorrectness,
+    Inv007CommitmentIntegrity,
+    Inv008DustMinOutputPolicy,
+    Inv009NoPhantomRecipients,
+    Inv010ReplayStability,
+}
+
+/// Machine-readable verification issue with an invariant mapping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationIssue {
+    pub invariant: InvariantId,
+    pub detail: String,
+}
+
+/// Summary object used by CLI/API adapters.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VerificationReport {
+    pub ruleset: String,
+    pub status: VerificationStatus,
+    pub determinism_hash: Option<String>,
+    pub issues: Vec<VerificationIssue>,
+}
+
+/// Minimal, implementation-agnostic input needed for payout verification.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PayoutVerificationInput {
+    pub snapshot_id: String,
+    pub epoch_id: u64,
+    pub expected_payout_hash: String,
+    pub candidate_payout_hash: String,
+}
+
+/// Optional invariant-level outcomes to help with diagnostics and reports.
+pub type InvariantResults = BTreeMap<InvariantId, bool>;
+
+/// Core trait for the deterministic payout verifier.
+///
+/// The production implementation should:
+/// - deterministically reconstruct expected payout state
+/// - validate candidate payout artifacts against invariant checks
+/// - produce stable results for the same input snapshot/ruleset
+pub trait PayoutVerifier {
+    fn ruleset(&self) -> &str;
+
+    fn verify(&self, input: &PayoutVerificationInput) -> VerificationReport;
+
+    fn evaluate_invariants(&self, input: &PayoutVerificationInput) -> InvariantResults;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    struct NoopVerifier;
+
+    impl PayoutVerifier for NoopVerifier {
+        fn ruleset(&self) -> &str {
+            "v1alpha"
+        }
+
+        fn verify(&self, _input: &PayoutVerificationInput) -> VerificationReport {
+            VerificationReport {
+                ruleset: self.ruleset().to_string(),
+                status: VerificationStatus::Unresolved,
+                determinism_hash: None,
+                issues: Vec::new(),
+            }
+        }
+
+        fn evaluate_invariants(&self, _input: &PayoutVerificationInput) -> InvariantResults {
+            BTreeMap::new()
+        }
+    }
+
+    #[test]
+    fn verifier_scaffold_has_stable_ruleset_name() {
+        let verifier = NoopVerifier;
+        assert_eq!(verifier.ruleset(), "v1alpha");
+    }
+
+    #[test]
+    #[ignore = "red scaffold: enable once value-conservation check is implemented"]
+    fn inv001_value_conservation_red_test() {
+        // This intentionally fails to demonstrate expected red-test behavior for INV-001.
+        assert!(false, "expected value conservation enforcement to fail until implemented");
+    }
+
+    #[test]
+    #[ignore = "red scaffold: enable once replay-stability check is implemented"]
+    fn inv010_replay_stability_red_test() {
+        // This intentionally fails to demonstrate expected red-test behavior for INV-010.
+        assert!(
+            false,
+            "expected replay stability check to fail until deterministic hash pipeline exists"
+        );
+    }
+}

--- a/docs/index.md
+++ b/docs/index.md
@@ -7,6 +7,8 @@
 * [Bitcoin Hashrate Derivatives Trading](derivatives.md) describes how we can replace FPPS with a
   marketplace of hashrate forwards or options
 * [Roadmap](roadmap.md) is the roadmap for braidpool
+* [Payout Verifier Invariants](payout_verifier_invariants.md) defines the v1alpha invariant scaffold
+  for deterministic RCA/UHPO payout verification
 
 # Works in Progress
 * [Braidpool Consensus](braid_consensus.md) is a draft specification for the consensus rules

--- a/docs/payout_verifier_invariants.md
+++ b/docs/payout_verifier_invariants.md
@@ -1,0 +1,45 @@
+# Payout Verifier Invariants (v1alpha)
+
+This document defines the invariant scaffold for a deterministic payout verification pipeline.
+The goal is to verify whether candidate RCA/UHPO payout artifacts are consistent with reconstructed
+braid state and accounting rules.
+
+## Scope
+
+- The rules below are implementation targets for the payout verifier.
+- The current `v1alpha` ruleset is intentionally narrow and verification-first.
+- Full signing protocol behavior (FROST/ROAST orchestration) is out of scope.
+
+## Invariants
+
+| ID | Name | Description | Verification Intent |
+| --- | --- | --- | --- |
+| INV-001 | Value Conservation | Value flow must conserve amounts across payout transitions. | Reject payouts with mismatched input/output value accounting. |
+| INV-002 | RCA Ancestry Correctness | Candidate RCA must spend the previously agreed RCA lineage. | Prevent invalid branch spending and payout history divergence. |
+| INV-003 | Coinbase Maturity Window | Eligible coinbase inputs must satisfy maturity policy constraints. | Block premature payout spend construction. |
+| INV-004 | Miner Allocation Exactness | Candidate miner outputs must match expected accounting snapshot balances. | Prevent under/overpayment for any miner participant. |
+| INV-005 | Deterministic Output Ordering | Payout outputs must follow canonical deterministic ordering. | Ensure stable serialization and hash reproducibility. |
+| INV-006 | Epoch Boundary Correctness | Settled contributions must belong to allowed accounting windows only. | Prevent leakage across epochs or incorrect settlement windows. |
+| INV-007 | Commitment Integrity | Metadata commitments must match reconstructed payout state commitments. | Detect tampering or inconsistent commitment materialization. |
+| INV-008 | Dust/Min Output Policy | Outputs must satisfy minimum policy constraints for standardness/usability. | Reject economically unusable payout fragments. |
+| INV-009 | No Phantom Recipients | Candidate recipients must exist in the accounting state for the snapshot. | Prevent unauthorized recipient insertion. |
+| INV-010 | Replay Stability | Same snapshot and ruleset must yield identical verification hash/status. | Guarantee deterministic verifier behavior across repeated runs. |
+
+## Error Model
+
+Verifier implementations should emit:
+
+- an invariant identifier (`INV-00X`)
+- a machine-readable reason code/message
+- optional context for debugging (snapshot ID, epoch, candidate hash)
+
+## Execution Modes
+
+- **strict**: fail closed if required data is missing
+- **unresolved**: return unresolved status when completeness assumptions are not met
+
+## Notes for Incremental Implementation
+
+1. Implement INV-001 and INV-010 first to establish accounting and determinism baselines.
+2. Keep ruleset versioning explicit (`v1alpha`) in all reports.
+3. Treat this document as the source of truth for verifier test planning.


### PR DESCRIPTION
## What this PR does

Adds an initial scaffold for deterministic payout verification in Braidpool, including:

- a new verifier module scaffold in `braidpool-primitives`:
  - `PayoutVerifier` trait
  - verification status/report/input types
  - invariant identifiers for `INV-001` to `INV-010`
- a new invariants document:
  - `docs/payout_verifier_invariants.md` (`ruleset=v1alpha`)
- docs index update:
  - link added in `docs/index.md`
- scaffold tests:
  - one baseline scaffold test
  - two intentionally red tests marked `#[ignore]` for future implementation (`INV-001`, `INV-010`)

## Why this is needed

Payout correctness is a critical risk surface for decentralized mining pools.  
This PR establishes a reviewable foundation (interfaces + invariant contract) for deterministic RCA/UHPO verification without changing runtime payout behavior yet.

## Scope

This PR is intentionally limited to scaffold/spec work only:
- no signing protocol implementation
- no runtime payout logic changes
- no dashboard/frontend changes

## Validation

Run:

```sh
cargo test -p braidpool-primitives
```

Note: INV-001 and INV-010 red scaffold tests are intentionally marked #[ignore] and will be enabled in follow-up implementation PRs