### PR TITLE
Frontend Migration: Deprecate Simulator API and adopt Braidpool RPC

### DIFF
--- a/dashboard/src/URLs.ts
+++ b/dashboard/src/URLs.ts
@@ -8,9 +8,6 @@ export const WEBSOCKET_URLS = {
   // Main WebSocket for general real-time updates (used in multiple components)
   MAIN_WEBSOCKET: 'ws://localhost:5000',
 
-  // WebSocket for BraidPool DAG visualization (simulator API)
-  BRAIDPOOL_DAG_WEBSOCKET: 'ws://localhost:65433/',
-
   // WebSocket for block viewer updates (mempool)
   BLOCK_VIEWER_WEBSOCKET: 'http://localhost:8080/api/v1/ws',
 } as const;

--- a/dashboard/src/components/BraidPoolDAG/BraidPoolDAG.tsx
+++ b/dashboard/src/components/BraidPoolDAG/BraidPoolDAG.tsx
@@ -82,7 +82,6 @@ const GraphVisualization: React.FC = () => {
 
     socket.onopen = () => {
       if (!isMounted) return;
-      console.log('Connected to WebSocket', url);
       setConnectionStatus('Connected');
     };
 
@@ -104,7 +103,6 @@ const GraphVisualization: React.FC = () => {
           return;
         }
         const parsedData = parsed.data;
-        console.log('Received braidpool data:', parsedData);
         if (!isPlayingRef.current) {
           return;
         }

--- a/dashboard/src/components/BraidPoolDAG/BraidPoolDAG.tsx
+++ b/dashboard/src/components/BraidPoolDAG/BraidPoolDAG.tsx
@@ -179,9 +179,7 @@ const GraphVisualization: React.FC = () => {
             parsedData.highestWorkPath?.length > 0
           ) {
             const latestBeadHash =
-              parsedData.highestWorkPath[
-                parsedData.highestWorkPath.length - 1
-              ];
+              parsedData.highestWorkPath[parsedData.highestWorkPath.length - 1];
             setLatestBeadHashForHighlight(latestBeadHash);
           }
           // The `latestBeadHashForHighlight` will remain set until the next time the condition is met.

--- a/dashboard/src/components/BraidPoolDAG/BraidPoolDAG.tsx
+++ b/dashboard/src/components/BraidPoolDAG/BraidPoolDAG.tsx
@@ -76,7 +76,7 @@ const GraphVisualization: React.FC = () => {
   }, []);
 
   useEffect(() => {
-    const url = WEBSOCKET_URLS.BRAIDPOOL_DAG_WEBSOCKET;
+    const url = WEBSOCKET_URLS.MAIN_WEBSOCKET;
     const socket = new WebSocket(url);
     let isMounted = true;
 
@@ -100,8 +100,11 @@ const GraphVisualization: React.FC = () => {
       if (!isMounted) return;
       try {
         const parsed = JSON.parse(event.data);
+        if (parsed.type !== 'braidpool_bead_info') {
+          return;
+        }
         const parsedData = parsed.data;
-        console.log('Received data:', parsedData);
+        console.log('Received braidpool data:', parsedData);
         if (!isPlayingRef.current) {
           return;
         }
@@ -127,7 +130,7 @@ const GraphVisualization: React.FC = () => {
             : 0;
 
         const graphData: GraphData = {
-          highest_work_path: parsedData.highest_work_path,
+          highestWorkPath: parsedData.highestWorkPath || [],
           parents: parsedData.parents,
           cohorts: parsedData.cohorts,
           children,
@@ -173,11 +176,11 @@ const GraphVisualization: React.FC = () => {
           // If the counter is divisible by 100, set the latest bead's hash
           if (
             newCounter % 100 === 0 &&
-            parsedData.highest_work_path.length > 0
+            parsedData.highestWorkPath?.length > 0
           ) {
             const latestBeadHash =
-              parsedData.highest_work_path[
-                parsedData.highest_work_path.length - 1
+              parsedData.highestWorkPath[
+                parsedData.highestWorkPath.length - 1
               ];
             setLatestBeadHashForHighlight(latestBeadHash);
           }
@@ -185,12 +188,14 @@ const GraphVisualization: React.FC = () => {
           return newCounter;
         });
 
-        setTotalBeads(bead_count);
-        setTotalCohorts(parsedData.cohorts.length);
+        setTotalBeads(parsedData.braidInfo?.bead_count ?? bead_count);
+        setTotalCohorts(
+          parsedData.braidInfo?.cohort_count ?? parsedData.cohorts.length
+        );
         setMaxCohortSize(
           Math.max(...parsedData.cohorts.map((c: string | any[]) => c.length))
         );
-        setHwpLength(parsedData.highest_work_path.length);
+        setHwpLength(parsedData.highestWorkPath?.length || 0);
         setLoading(false);
 
         // Trigger animation if cohorts changed
@@ -361,7 +366,7 @@ const GraphVisualization: React.FC = () => {
       children: graphData.children[id],
     }));
 
-    const hwPath = graphData.highest_work_path;
+    const hwPath = graphData.highestWorkPath;
     const cohorts = graphData.cohorts;
     const positions = layoutNodes(allNodes, hwPath);
     const hwPathSet = new Set(hwPath);

--- a/dashboard/src/components/BraidPoolDAG/BraidPoolDAGUtils.ts
+++ b/dashboard/src/components/BraidPoolDAG/BraidPoolDAGUtils.ts
@@ -100,11 +100,13 @@ export function layoutNodes(
   // Process non-HW nodes
   allNodes.filter((n) => !hwPathSet.has(n.id)).forEach((n) => setXCoord(n.id));
 
-  // Adjust tail nodes (no children)
-  const maxX = Math.max(...Object.values(proposedX));
   allNodes.forEach((n) => {
     if ((!n.children || n.children.length === 0) && !hwPathSet.has(n.id)) {
-      proposedX[n.id] = maxX;
+      const parents = Array.from(allParents[n.id] || []);
+      if (parents.length > 0) {
+        const maxParentX = Math.max(...parents.map((p) => proposedX[p] ?? 0));
+        proposedX[n.id] = maxParentX + 1;
+      }
     }
   });
 

--- a/dashboard/src/components/BraidPoolDAG/BraidPoolDAGUtils.ts
+++ b/dashboard/src/components/BraidPoolDAG/BraidPoolDAGUtils.ts
@@ -102,10 +102,10 @@ export function layoutNodes(
 
   allNodes.forEach((n) => {
     if ((!n.children || n.children.length === 0) && !hwPathSet.has(n.id)) {
-      const parents = Array.from(allParents[n.id] || []);
-      if (parents.length > 0) {
-        const maxParentX = Math.max(...parents.map((p) => proposedX[p] ?? 0));
-        proposedX[n.id] = maxParentX + 1;
+      let maxParentX = 0;
+      for (const p of allParents[n.id] || []) {
+        const x = proposedX[p] ?? 0;
+        if (x > maxParentX) maxParentX = x;
       }
     }
   });

--- a/dashboard/src/components/BraidPoolDAG/Types.ts
+++ b/dashboard/src/components/BraidPoolDAG/Types.ts
@@ -9,7 +9,7 @@ export interface NodeIdMapping {
 }
 
 export interface GraphData {
-  highest_work_path: string[];
+  highestWorkPath: string[];
   parents: Record<string, string[]>;
   children: Record<string, string[]>;
   cohorts: string[][];


### PR DESCRIPTION

### **Overview**

This PR depends on another PR and should be merged after it. It introduces frontend changes to deprecate the Simulator API and switch all data fetching to Braidpool RPC methods. The UI now displays Braidpool data instead of simulator data.


### **Changes**

* Removed/deprecated Simulator API usage
* Updated frontend logic to reflect RPC-based data


### **Dependency**

* Depends on: **#427**


