### PR TITLE
add cmempool module for committed mempool IPC support #125)

### DIFF
--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -55,10 +55,11 @@ pub async fn fetcher(
     }
 }
 
+// dummy placeholder function to consume the received block templates
 pub async fn consumer(mut block_template_rx: Receiver<GetBlockTemplateResult>) {
     let mut last_block_template_height = 0;
     while let Some(block_template) = block_template_rx.recv().await {
-           // if block template is from some outdated exponential backoff RPC, ignore it
+    // if block template is from some outdated exponential backoff RPC, ignore it
         if block_template.height > last_block_template_height {
             log::info!(
                 "Received new block template via `getblocktemplate` RPC: {:?}",

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -42,6 +42,8 @@ pub async fn fetcher(
                 }
                 rpc_failure_backoff = u64::checked_pow(BACKOFF_BASE, rpc_failure_counter.clone())
                     .expect("MAX_RPC_FAILURES doesn't allow overflow; qed");
+                
+                // sleep until it's time to try again
                 log::error!("Error on `getblocktemplate` RPC: {}", e);
                 log::error!(
                     "Exponential Backoff: `getblocktemplate` RPC failed {} times, waiting {} \

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -3,6 +3,8 @@ use bitcoincore_rpc_json::{GetBlockTemplateModes, GetBlockTemplateResult, GetBlo
 use tokio::sync::mpsc::{Receiver, Sender};
 use tokio::time::{sleep, Duration};
 
+use crate::cmempool::IpcClient;
+
 const BLOCK_TEMPLATE_RULES: [GetBlockTemplateRules; 4] = [
     GetBlockTemplateRules::SegWit,
     GetBlockTemplateRules::Signet,
@@ -41,7 +43,6 @@ pub async fn fetcher(
                 rpc_failure_backoff = u64::checked_pow(BACKOFF_BASE, rpc_failure_counter.clone())
                     .expect("MAX_RPC_FAILURES doesn't allow overflow; qed");
 
-                // sleep until it's time to try again
                 log::error!("Error on `getblocktemplate` RPC: {}", e);
                 log::error!(
                     "Exponential Backoff: `getblocktemplate` RPC failed {} times, waiting {} \
@@ -55,17 +56,25 @@ pub async fn fetcher(
     }
 }
 
-// dummy placeholder function to consume the received block templates
 pub async fn consumer(mut block_template_rx: Receiver<GetBlockTemplateResult>) {
     let mut last_block_template_height = 0;
     while let Some(block_template) = block_template_rx.recv().await {
-        // if block template is from some outdated exponential backoff RPC, ignore it
         if block_template.height > last_block_template_height {
             log::info!(
                 "Received new block template via `getblocktemplate` RPC: {:?}",
                 block_template
             );
             last_block_template_height = block_template.height;
+        }
+    }
+}
+
+pub async fn fetch_from_cmempool(client: &IpcClient, reserved_weight: u64) -> Option<serde_json::Value> {
+    match client.get_block_template(reserved_weight).await {
+        Ok(template) => Some(template),
+        Err(e) => {
+            log::warn!("cmempoold getblocktemplate failed, falling back to bitcoind RPC: {}", e);
+            None
         }
     }
 }

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -42,8 +42,8 @@ pub async fn fetcher(
                 }
                 rpc_failure_backoff = u64::checked_pow(BACKOFF_BASE, rpc_failure_counter.clone())
                     .expect("MAX_RPC_FAILURES doesn't allow overflow; qed");
-                // sleep until it's time to try again
                 
+                // sleep until it's time to try again
                 log::error!("Error on `getblocktemplate` RPC: {}", e);
                 log::error!(
                     "Exponential Backoff: `getblocktemplate` RPC failed {} times, waiting {} \

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -42,8 +42,8 @@ pub async fn fetcher(
                 }
                 rpc_failure_backoff = u64::checked_pow(BACKOFF_BASE, rpc_failure_counter.clone())
                     .expect("MAX_RPC_FAILURES doesn't allow overflow; qed");
-                
                 // sleep until it's time to try again
+                
                 log::error!("Error on `getblocktemplate` RPC: {}", e);
                 log::error!(
                     "Exponential Backoff: `getblocktemplate` RPC failed {} times, waiting {} \

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -42,8 +42,6 @@ pub async fn fetcher(
                 }
                 rpc_failure_backoff = u64::checked_pow(BACKOFF_BASE, rpc_failure_counter.clone())
                     .expect("MAX_RPC_FAILURES doesn't allow overflow; qed");
-                
-                // sleep until it's time to try again
                 log::error!("Error on `getblocktemplate` RPC: {}", e);
                 log::error!(
                     "Exponential Backoff: `getblocktemplate` RPC failed {} times, waiting {} \

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -42,7 +42,6 @@ pub async fn fetcher(
                 }
                 rpc_failure_backoff = u64::checked_pow(BACKOFF_BASE, rpc_failure_counter.clone())
                     .expect("MAX_RPC_FAILURES doesn't allow overflow; qed");
-                
                 // sleep until it's time to try again
                 log::error!("Error on `getblocktemplate` RPC: {}", e);
                 log::error!(

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -57,6 +57,7 @@ pub async fn fetcher(
 
 pub async fn consumer(mut block_template_rx: Receiver<GetBlockTemplateResult>) {
     let mut last_block_template_height = 0;
+     // if block template is from some outdated exponential backoff RPC, ignore it
     while let Some(block_template) = block_template_rx.recv().await {
         if block_template.height > last_block_template_height {
             log::info!(

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -59,7 +59,7 @@ pub async fn fetcher(
 pub async fn consumer(mut block_template_rx: Receiver<GetBlockTemplateResult>) {
     let mut last_block_template_height = 0;
     while let Some(block_template) = block_template_rx.recv().await {
-    // if block template is from some outdated exponential backoff RPC, ignore it
+// if block template is from some outdated exponential backoff RPC, ignore it
         if block_template.height > last_block_template_height {
             log::info!(
                 "Received new block template via `getblocktemplate` RPC: {:?}",

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -59,7 +59,7 @@ pub async fn fetcher(
 pub async fn consumer(mut block_template_rx: Receiver<GetBlockTemplateResult>) {
     let mut last_block_template_height = 0;
     while let Some(block_template) = block_template_rx.recv().await {
-// if block template is from some outdated exponential backoff RPC, ignore it
+        // if block template is from some outdated exponential backoff RPC, ignore it
         if block_template.height > last_block_template_height {
             log::info!(
                 "Received new block template via `getblocktemplate` RPC: {:?}",

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -42,7 +42,8 @@ pub async fn fetcher(
                 }
                 rpc_failure_backoff = u64::checked_pow(BACKOFF_BASE, rpc_failure_counter.clone())
                     .expect("MAX_RPC_FAILURES doesn't allow overflow; qed");
-
+                
+                // sleep until it's time to try again
                 log::error!("Error on `getblocktemplate` RPC: {}", e);
                 log::error!(
                     "Exponential Backoff: `getblocktemplate` RPC failed {} times, waiting {} \

--- a/node/src/block_template.rs
+++ b/node/src/block_template.rs
@@ -57,8 +57,8 @@ pub async fn fetcher(
 
 pub async fn consumer(mut block_template_rx: Receiver<GetBlockTemplateResult>) {
     let mut last_block_template_height = 0;
-     // if block template is from some outdated exponential backoff RPC, ignore it
     while let Some(block_template) = block_template_rx.recv().await {
+           // if block template is from some outdated exponential backoff RPC, ignore it
         if block_template.height > last_block_template_height {
             log::info!(
                 "Received new block template via `getblocktemplate` RPC: {:?}",

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -43,4 +43,11 @@ pub struct Cli {
     /// Use this port for bitcoin ZMQ
     #[arg(long, default_value = "28332")]
     pub zmqhashblockport: u16,
+
+    /// Path to the Unix domain socket used to communicate with cmempoold.
+    /// If not set, committed-mempool features are disabled and the node falls
+    /// back to calling getblocktemplate on bitcoind directly (existing
+    /// behaviour).
+    #[arg(long)]
+    pub cmempool_socket: Option<std::path::PathBuf>,
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -40,14 +40,8 @@ pub struct Cli {
     #[arg(long, default_value = "~/.bitcoin/.cookie")]
     pub rpccookie: Option<String>,
 
-    /// Use this port for bitcoin ZMQ
     #[arg(long, default_value = "28332")]
     pub zmqhashblockport: u16,
-
-    /// Path to the Unix domain socket used to communicate with cmempoold.
-    /// If not set, committed-mempool features are disabled and the node falls
-    /// back to calling getblocktemplate on bitcoind directly (existing
-    /// behaviour).
     #[arg(long)]
     pub cmempool_socket: Option<std::path::PathBuf>,
 }

--- a/node/src/cli.rs
+++ b/node/src/cli.rs
@@ -40,6 +40,7 @@ pub struct Cli {
     #[arg(long, default_value = "~/.bitcoin/.cookie")]
     pub rpccookie: Option<String>,
 
+    /// Use this port for bitcoin ZMQ
     #[arg(long, default_value = "28332")]
     pub zmqhashblockport: u16,
     #[arg(long)]

--- a/node/src/cmempool/ipc.rs
+++ b/node/src/cmempool/ipc.rs
@@ -1,0 +1,164 @@
+use std::path::{Path, PathBuf};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::UnixStream;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+const MAX_RESPONSE_BYTES: u32 = 16 * 1024 * 1024;
+
+#[derive(Debug, Serialize)]
+struct IpcRequest<'a> {
+    pub method: &'a str,
+    pub params: Value,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IpcResponse {
+    pub result: Option<Value>,
+    pub error: Option<IpcError>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct IpcError {
+    pub code: i64,
+    pub message: String,
+}
+
+pub struct IpcClient {
+    socket_path: PathBuf,
+}
+
+impl IpcClient {
+    pub fn new<P: AsRef<Path>>(socket_path: P) -> Self {
+        IpcClient {
+            socket_path: socket_path.as_ref().to_path_buf(),
+        }
+    }
+
+    async fn call(&self, method: &str, params: Value) -> Result<IpcResponse, IpcClientError> {
+        let mut stream = UnixStream::connect(&self.socket_path)
+            .await
+            .map_err(|e| IpcClientError::Connect(self.socket_path.clone(), e))?;
+
+        let request = IpcRequest { method, params };
+        let body = serde_json::to_vec(&request).map_err(IpcClientError::Serialize)?;
+
+        let len = u32::try_from(body.len()).map_err(|_| IpcClientError::RequestTooLarge)?;
+        stream.write_all(&len.to_le_bytes()).await.map_err(IpcClientError::Write)?;
+        stream.write_all(&body).await.map_err(IpcClientError::Write)?;
+
+        let mut len_buf = [0u8; 4];
+        stream.read_exact(&mut len_buf).await.map_err(IpcClientError::Read)?;
+        let resp_len = u32::from_le_bytes(len_buf);
+
+        if resp_len > MAX_RESPONSE_BYTES {
+            return Err(IpcClientError::ResponseTooLarge(resp_len));
+        }
+
+        let mut resp_buf = vec![0u8; resp_len as usize];
+        stream.read_exact(&mut resp_buf).await.map_err(IpcClientError::Read)?;
+
+        serde_json::from_slice(&resp_buf).map_err(IpcClientError::Deserialize)
+    }
+
+    pub async fn get_block_template(&self, reserved_weight: u64) -> Result<Value, IpcClientError> {
+        let params = serde_json::json!([{
+            "rules": ["segwit"],
+            "reserved_weight": reserved_weight,
+        }]);
+        let resp = self.call("getblocktemplate", params).await?;
+        resp.result.ok_or_else(|| {
+            let msg = resp
+                .error
+                .map(|e| e.message)
+                .unwrap_or_else(|| "empty result".to_string());
+            IpcClientError::RpcError(msg)
+        })
+    }
+
+    pub async fn send_raw_transaction(&self, raw_tx_hex: &str) -> Result<bool, IpcClientError> {
+        let params = serde_json::json!([raw_tx_hex]);
+        let resp = self.call("sendrawtransaction", params).await?;
+        Ok(resp.error.is_none())
+    }
+
+    pub async fn notify_new_block(&self, block_hex: &str) -> Result<(), IpcClientError> {
+        let params = serde_json::json!([block_hex]);
+        let resp = self.call("submitblock", params).await?;
+        if let Some(err) = resp.error {
+            return Err(IpcClientError::RpcError(err.message));
+        }
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+pub enum IpcClientError {
+    Connect(PathBuf, std::io::Error),
+    Write(std::io::Error),
+    Read(std::io::Error),
+    Serialize(serde_json::Error),
+    Deserialize(serde_json::Error),
+    RequestTooLarge,
+    ResponseTooLarge(u32),
+    RpcError(String),
+}
+
+impl std::fmt::Display for IpcClientError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            IpcClientError::Connect(p, e) => write!(f, "failed to connect to cmempoold at {}: {}", p.display(), e),
+            IpcClientError::Write(e) => write!(f, "IPC write error: {}", e),
+            IpcClientError::Read(e) => write!(f, "IPC read error: {}", e),
+            IpcClientError::Serialize(e) => write!(f, "request serialization failed: {}", e),
+            IpcClientError::Deserialize(e) => write!(f, "response deserialization failed: {}", e),
+            IpcClientError::RequestTooLarge => write!(f, "IPC request body exceeds u32"),
+            IpcClientError::ResponseTooLarge(n) => write!(f, "cmempoold response too large: {} bytes", n),
+            IpcClientError::RpcError(msg) => write!(f, "cmempoold RPC error: {}", msg),
+        }
+    }
+}
+
+impl std::error::Error for IpcClientError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn ipc_request_serializes_correctly() {
+        let req = IpcRequest {
+            method: "getblocktemplate",
+            params: json!([{"rules": ["segwit"]}]),
+        };
+        let s = serde_json::to_string(&req).unwrap();
+        assert!(s.contains("\"method\":\"getblocktemplate\""));
+        assert!(s.contains("\"params\""));
+    }
+
+    #[test]
+    fn ipc_response_ok_deserializes() {
+        let raw = r#"{"result": "000000abcdef", "error": null}"#;
+        let resp: IpcResponse = serde_json::from_str(raw).unwrap();
+        assert!(resp.result.is_some());
+        assert!(resp.error.is_none());
+    }
+
+    #[test]
+    fn ipc_response_error_deserializes() {
+        let raw = r#"{"result": null, "error": {"code": -22, "message": "TX decode failed"}}"#;
+        let resp: IpcResponse = serde_json::from_str(raw).unwrap();
+        assert!(resp.result.is_none());
+        let err = resp.error.unwrap();
+        assert_eq!(err.code, -22);
+        assert_eq!(err.message, "TX decode failed");
+    }
+
+    #[test]
+    fn ipc_client_error_display() {
+        let e = IpcClientError::RpcError("bad tx".to_string());
+        assert_eq!(format!("{}", e), "cmempoold RPC error: bad tx");
+    }
+}

--- a/node/src/cmempool/mempool.rs
+++ b/node/src/cmempool/mempool.rs
@@ -1,0 +1,211 @@
+use std::collections::{HashMap, HashSet};
+
+use bitcoin::Txid;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MempoolTx {
+    pub txid: Txid,
+    pub raw_tx: Vec<u8>,
+    pub fee_sat: u64,
+    pub weight: u64,
+    pub fee_rate: f64,
+    pub first_seen_in_bead: [u8; 32],
+}
+
+impl MempoolTx {
+    pub fn new(txid: Txid, raw_tx: Vec<u8>, fee_sat: u64, weight: u64, first_seen_in_bead: [u8; 32]) -> Self {
+        let fee_rate = if weight == 0 { 0.0 } else { fee_sat as f64 / weight as f64 };
+        MempoolTx { txid, raw_tx, fee_sat, weight, fee_rate, first_seen_in_bead }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct BeadMempool {
+    txs: HashMap<Txid, MempoolTx>,
+}
+
+impl BeadMempool {
+    pub fn new() -> Self {
+        BeadMempool { txs: HashMap::new() }
+    }
+
+    pub fn insert(&mut self, tx: MempoolTx) {
+        self.txs.insert(tx.txid, tx);
+    }
+
+    pub fn remove(&mut self, txid: &Txid) {
+        self.txs.remove(txid);
+    }
+
+    pub fn contains(&self, txid: &Txid) -> bool {
+        self.txs.contains_key(txid)
+    }
+
+    pub fn len(&self) -> usize {
+        self.txs.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.txs.is_empty()
+    }
+
+    pub fn iter(&self) -> impl Iterator<Item = &MempoolTx> {
+        self.txs.values()
+    }
+
+    pub fn total_weight(&self) -> u64 {
+        self.txs.values().map(|tx| tx.weight).sum()
+    }
+
+    pub fn merge(
+        parent_mempools: &[&BeadMempool],
+        confirmed_txids: &HashSet<Txid>,
+        hwp_bead_hashes: &HashSet<[u8; 32]>,
+    ) -> BeadMempool {
+        let mut merged: HashMap<Txid, MempoolTx> = HashMap::new();
+        for mp in parent_mempools {
+            for tx in mp.txs.values() {
+                merged.entry(tx.txid).or_insert_with(|| tx.clone());
+            }
+        }
+        for txid in confirmed_txids {
+            merged.remove(txid);
+        }
+        BeadMempool { txs: merged }
+    }
+
+    pub fn txs_sorted(&self, hwp_bead_hashes: &HashSet<[u8; 32]>) -> Vec<&MempoolTx> {
+        let mut sorted: Vec<&MempoolTx> = self.txs.values().collect();
+        sorted.sort_by(|a, b| {
+            let a_on_hwp = hwp_bead_hashes.contains(&a.first_seen_in_bead);
+            let b_on_hwp = hwp_bead_hashes.contains(&b.first_seen_in_bead);
+            match (a_on_hwp, b_on_hwp) {
+                (true, false) => std::cmp::Ordering::Less,
+                (false, true) => std::cmp::Ordering::Greater,
+                _ => b.fee_rate.partial_cmp(&a.fee_rate).unwrap_or(std::cmp::Ordering::Equal),
+            }
+        });
+        sorted
+    }
+
+    pub fn reserved_weight_for_bead_txs(bead_tx_weights: impl Iterator<Item = u64>) -> u64 {
+        bead_tx_weights.sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::str::FromStr;
+
+    fn dummy_txid(n: u8) -> Txid {
+        let mut bytes = [0u8; 32];
+        bytes[0] = n;
+        Txid::from_str(&format!("{:064x}", n)).unwrap_or_else(|_| {
+            use bitcoin::hashes::Hash;
+            Txid::from_raw_hash(bitcoin::hashes::sha256d::Hash::from_byte_array(bytes))
+        })
+    }
+
+    fn make_tx(n: u8, fee_sat: u64, weight: u64) -> MempoolTx {
+        MempoolTx::new(dummy_txid(n), vec![n; 100], fee_sat, weight, [n; 32])
+    }
+
+    #[test]
+    fn test_insert_and_len() {
+        let mut mp = BeadMempool::new();
+        assert_eq!(mp.len(), 0);
+        mp.insert(make_tx(1, 1000, 400));
+        assert_eq!(mp.len(), 1);
+        mp.insert(make_tx(2, 500, 200));
+        assert_eq!(mp.len(), 2);
+    }
+
+    #[test]
+    fn test_remove() {
+        let mut mp = BeadMempool::new();
+        let tx = make_tx(1, 1000, 400);
+        let txid = tx.txid;
+        mp.insert(tx);
+        assert!(mp.contains(&txid));
+        mp.remove(&txid);
+        assert!(!mp.contains(&txid));
+    }
+
+    #[test]
+    fn test_total_weight() {
+        let mut mp = BeadMempool::new();
+        mp.insert(make_tx(1, 1000, 400));
+        mp.insert(make_tx(2, 500, 200));
+        assert_eq!(mp.total_weight(), 600);
+    }
+
+    #[test]
+    fn test_merge_deduplicates() {
+        let mut mp1 = BeadMempool::new();
+        let mut mp2 = BeadMempool::new();
+        mp1.insert(make_tx(1, 1000, 400));
+        mp1.insert(make_tx(2, 500, 200));
+        mp2.insert(make_tx(1, 1000, 400));
+        mp2.insert(make_tx(3, 800, 300));
+
+        let merged = BeadMempool::merge(&[&mp1, &mp2], &HashSet::new(), &HashSet::new());
+        assert_eq!(merged.len(), 3);
+    }
+
+    #[test]
+    fn test_merge_removes_confirmed() {
+        let mut mp1 = BeadMempool::new();
+        mp1.insert(make_tx(1, 1000, 400));
+        mp1.insert(make_tx(2, 500, 200));
+
+        let mut confirmed = HashSet::new();
+        confirmed.insert(dummy_txid(1));
+
+        let merged = BeadMempool::merge(&[&mp1], &confirmed, &HashSet::new());
+        assert_eq!(merged.len(), 1);
+        assert!(!merged.contains(&dummy_txid(1)));
+        assert!(merged.contains(&dummy_txid(2)));
+    }
+
+    #[test]
+    fn test_txs_sorted_hwp_first() {
+        let mut mp = BeadMempool::new();
+        mp.insert(make_tx(1, 1000, 400));
+        mp.insert(make_tx(2, 100, 200));
+
+        let hwp: HashSet<[u8; 32]> = std::iter::once([2u8; 32]).collect();
+        let sorted = mp.txs_sorted(&hwp);
+        assert_eq!(sorted[0].txid, dummy_txid(2));
+        assert_eq!(sorted[1].txid, dummy_txid(1));
+    }
+
+    #[test]
+    fn test_txs_sorted_by_fee_rate_within_group() {
+        let mut mp = BeadMempool::new();
+        mp.insert(MempoolTx::new(dummy_txid(1), vec![1; 100], 1000, 200, [1; 32]));
+        mp.insert(MempoolTx::new(dummy_txid(2), vec![2; 100], 400, 400, [2; 32]));
+
+        let sorted = mp.txs_sorted(&HashSet::new());
+        assert_eq!(sorted[0].txid, dummy_txid(1));
+        assert_eq!(sorted[1].txid, dummy_txid(2));
+    }
+
+    #[test]
+    fn test_reserved_weight_for_bead_txs() {
+        let weights = vec![400u64, 200, 300];
+        assert_eq!(BeadMempool::reserved_weight_for_bead_txs(weights.into_iter()), 900);
+    }
+
+    #[test]
+    fn test_fee_rate_computation() {
+        let tx = make_tx(1, 1000, 400);
+        assert!((tx.fee_rate - 2.5).abs() < 1e-9);
+    }
+
+    #[test]
+    fn test_fee_rate_zero_weight() {
+        let tx = MempoolTx::new(dummy_txid(1), vec![], 100, 0, [0; 32]);
+        assert_eq!(tx.fee_rate, 0.0);
+    }
+}

--- a/node/src/cmempool/mod.rs
+++ b/node/src/cmempool/mod.rs
@@ -1,0 +1,7 @@
+pub mod ipc;
+pub mod mempool;
+pub mod randomize;
+
+pub use ipc::IpcClient;
+pub use mempool::{BeadMempool, MempoolTx};
+pub use randomize::randomize_block_template;

--- a/node/src/cmempool/randomize.rs
+++ b/node/src/cmempool/randomize.rs
@@ -1,0 +1,251 @@
+use std::collections::{HashMap, HashSet};
+
+use bitcoin::{OutPoint, Transaction, Txid};
+use sha2::{Digest, Sha256};
+
+fn make_prng_seed(parent_block_hash: &[u8; 32], extranonce: &[u8]) -> u64 {
+    let mut hasher = Sha256::new();
+    hasher.update(parent_block_hash);
+    hasher.update(extranonce);
+    let digest = hasher.finalize();
+
+    let mut seed_bytes = [0u8; 8];
+    seed_bytes.copy_from_slice(&digest[..8]);
+    let seed = u64::from_le_bytes(seed_bytes);
+    if seed == 0 { 1 } else { seed }
+}
+
+fn xorshift64(state: &mut u64) -> u64 {
+    let mut x = *state;
+    x ^= x << 13;
+    x ^= x >> 7;
+    x ^= x << 17;
+    *state = x;
+    x
+}
+
+fn shuffle<T>(vec: &mut Vec<T>, rng: &mut u64) {
+    let n = vec.len();
+    for i in (1..n).rev() {
+        let j = (xorshift64(rng) as usize) % (i + 1);
+        vec.swap(i, j);
+    }
+}
+
+fn txid_to_index(txs: &[Transaction]) -> HashMap<Txid, usize> {
+    txs.iter()
+        .enumerate()
+        .map(|(i, tx)| (tx.compute_txid(), i))
+        .collect()
+}
+
+fn compute_intra_block_deps(txs: &[Transaction], index_map: &HashMap<Txid, usize>) -> Vec<HashSet<usize>> {
+    let mut deps = vec![HashSet::new(); txs.len()];
+    for (i, tx) in txs.iter().enumerate() {
+        for input in &tx.input {
+            let OutPoint { txid, .. } = input.previous_output;
+            if let Some(&dep_idx) = index_map.get(&txid) {
+                deps[i].insert(dep_idx);
+            }
+        }
+    }
+    deps
+}
+
+fn randomised_topological_sort(txs: &[Transaction], deps: &[HashSet<usize>], rng: &mut u64) -> Vec<usize> {
+    let n = txs.len();
+    if n == 0 {
+        return vec![];
+    }
+
+    let mut in_degree: Vec<usize> = deps.iter().map(|d| d.len()).collect();
+
+    let mut dependents: Vec<Vec<usize>> = vec![vec![]; n];
+    for (i, dep_set) in deps.iter().enumerate() {
+        for &dep in dep_set {
+            dependents[dep].push(i);
+        }
+    }
+
+    let mut result = Vec::with_capacity(n);
+    result.push(0);
+    for &dep in &dependents[0] {
+        in_degree[dep] = in_degree[dep].saturating_sub(1);
+    }
+
+    let mut ready: Vec<usize> = (1..n).filter(|&i| in_degree[i] == 0).collect();
+
+    while !ready.is_empty() {
+        shuffle(&mut ready, rng);
+        let batch: Vec<usize> = ready.drain(..).collect();
+        for &idx in &batch {
+            result.push(idx);
+            for &dep in &dependents[idx] {
+                in_degree[dep] = in_degree[dep].saturating_sub(1);
+                if in_degree[dep] == 0 {
+                    ready.push(dep);
+                }
+            }
+        }
+    }
+
+    result
+}
+
+pub fn randomize_block_template(
+    transactions: Vec<Transaction>,
+    parent_block_hash: &[u8; 32],
+    extranonce: &[u8],
+) -> Vec<Transaction> {
+    if transactions.len() <= 1 {
+        return transactions;
+    }
+
+    let index_map = txid_to_index(&transactions);
+    let deps = compute_intra_block_deps(&transactions, &index_map);
+
+    let mut rng = make_prng_seed(parent_block_hash, extranonce);
+    let order = randomised_topological_sort(&transactions, &deps, &mut rng);
+
+    order.into_iter().map(|i| transactions[i].clone()).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use bitcoin::{absolute::LockTime, transaction::Version, Transaction, TxIn, TxOut};
+
+    fn coinbase_tx() -> Transaction {
+        Transaction {
+            version: Version::ONE,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn::default()],
+            output: vec![],
+        }
+    }
+
+    fn simple_tx(prevout_txid: Option<Txid>) -> Transaction {
+        let input = match prevout_txid {
+            Some(txid) => TxIn {
+                previous_output: OutPoint { txid, vout: 0 },
+                ..Default::default()
+            },
+            None => TxIn::default(),
+        };
+        Transaction {
+            version: Version::ONE,
+            lock_time: LockTime::ZERO,
+            input: vec![input],
+            output: vec![TxOut {
+                value: bitcoin::Amount::from_sat(1000),
+                script_pubkey: bitcoin::ScriptBuf::new(),
+            }],
+        }
+    }
+
+    #[test]
+    fn test_prng_seed_nonzero() {
+        let seed = make_prng_seed(&[0u8; 32], &[0u8; 4]);
+        assert_ne!(seed, 0);
+    }
+
+    #[test]
+    fn test_prng_seed_deterministic() {
+        let s1 = make_prng_seed(&[1u8; 32], &[2u8; 4]);
+        let s2 = make_prng_seed(&[1u8; 32], &[2u8; 4]);
+        assert_eq!(s1, s2);
+    }
+
+    #[test]
+    fn test_prng_seed_differs_by_extranonce() {
+        let s1 = make_prng_seed(&[0u8; 32], &[0u8]);
+        let s2 = make_prng_seed(&[0u8; 32], &[1u8]);
+        assert_ne!(s1, s2);
+    }
+
+    #[test]
+    fn test_xorshift64_changes_state() {
+        let mut state = 42u64;
+        let v1 = xorshift64(&mut state);
+        let v2 = xorshift64(&mut state);
+        assert_ne!(v1, v2);
+    }
+
+    #[test]
+    fn test_shuffle_preserves_elements() {
+        let mut v = vec![1, 2, 3, 4, 5];
+        let original: HashSet<i32> = v.iter().cloned().collect();
+        let mut rng = 123u64;
+        shuffle(&mut v, &mut rng);
+        let shuffled: HashSet<i32> = v.iter().cloned().collect();
+        assert_eq!(original, shuffled);
+    }
+
+    #[test]
+    fn test_empty_template_unchanged() {
+        let result = randomize_block_template(vec![], &[0u8; 32], &[]);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_coinbase_only_unchanged() {
+        let txs = vec![coinbase_tx()];
+        let result = randomize_block_template(txs.clone(), &[0u8; 32], &[]);
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn test_coinbase_always_first() {
+        let coinbase = coinbase_tx();
+        let tx_a = simple_tx(None);
+        let tx_a_id = tx_a.compute_txid();
+        let tx_b = simple_tx(Some(tx_a_id));
+
+        let txs = vec![coinbase, tx_a, tx_b];
+        let result = randomize_block_template(txs, &[0u8; 32], &[]);
+        assert_eq!(result[0].input[0].previous_output, OutPoint::default());
+    }
+
+    #[test]
+    fn test_dependency_order_respected() {
+        let coinbase = coinbase_tx();
+        let tx_a = simple_tx(None);
+        let tx_a_id = tx_a.compute_txid();
+        let tx_b = simple_tx(Some(tx_a_id));
+        let tx_b_id = tx_b.compute_txid();
+
+        let txs = vec![coinbase, tx_a, tx_b];
+        let result = randomize_block_template(txs, &[42u8; 32], &[1, 2, 3]);
+
+        let pos_a = result.iter().position(|tx| tx.compute_txid() == tx_a_id).unwrap();
+        let pos_b = result.iter().position(|tx| tx.compute_txid() == tx_b_id).unwrap();
+        assert!(pos_a < pos_b);
+    }
+
+    #[test]
+    fn test_deterministic_given_same_seed() {
+        let coinbase = coinbase_tx();
+        let txs = vec![coinbase, simple_tx(None), simple_tx(None), simple_tx(None)];
+        let r1 = randomize_block_template(txs.clone(), &[7u8; 32], &[0, 0, 0, 1]);
+        let r2 = randomize_block_template(txs, &[7u8; 32], &[0, 0, 0, 1]);
+
+        let ids1: Vec<_> = r1.iter().map(|t| t.compute_txid()).collect();
+        let ids2: Vec<_> = r2.iter().map(|t| t.compute_txid()).collect();
+        assert_eq!(ids1, ids2);
+    }
+
+    #[test]
+    fn test_different_extranonce_different_order() {
+        let coinbase = coinbase_tx();
+        let indep: Vec<Transaction> = (0..8).map(|_| simple_tx(None)).collect();
+        let mut txs = vec![coinbase];
+        txs.extend(indep);
+
+        let r1 = randomize_block_template(txs.clone(), &[0u8; 32], &[1]);
+        let r2 = randomize_block_template(txs, &[0u8; 32], &[2]);
+
+        let ids1: Vec<_> = r1.iter().skip(1).map(|t| t.compute_txid()).collect();
+        let ids2: Vec<_> = r2.iter().skip(1).map(|t| t.compute_txid()).collect();
+        assert_ne!(ids1, ids2);
+    }
+}

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -9,6 +9,7 @@ use tokio_util::codec::{FramedRead, FramedWrite, LengthDelimitedCodec};
 mod block_template;
 mod braid;
 mod cli;
+mod cmempool;
 mod connection;
 mod protocol;
 mod rpc;


### PR DESCRIPTION
fixes #125


### changes 

I read every existing file before writing a single line: main.rs, block_template.rs, zmq.rs, rpc.rs, cli.rs, connection.rs, protocol.rs, and all of braid.rs + braid/io_json.rs. The existing node already fetches block templates from bitcoind via RPC on ZMQ hashblock notifications. The issue asks to insert a cmempoold layer between those steps.