### PR TITLE
fix: add aria-labels for download buttons in Dashboard

### DIFF
--- a/dashboard/src/components/BeadsTab/Reward/RewardsDashboard.tsx
+++ b/dashboard/src/components/BeadsTab/Reward/RewardsDashboard.tsx
@@ -138,7 +138,7 @@ export function RewardsDashboard() {
             <h2 className="text-white text-lg font-semibold">Block Rewards</h2>
             <ActionIconButton
               onClick={handleDownloadRewardsChart}
-              ariaLabel='Download Reward Chart'
+              ariaLabel="Download Reward Chart"
               icon={
                 <svg
                   xmlns="http://www.w3.org/2000/svg"

--- a/dashboard/src/components/BeadsTab/Reward/RewardsDashboard.tsx
+++ b/dashboard/src/components/BeadsTab/Reward/RewardsDashboard.tsx
@@ -138,6 +138,7 @@ export function RewardsDashboard() {
             <h2 className="text-white text-lg font-semibold">Block Rewards</h2>
             <ActionIconButton
               onClick={handleDownloadRewardsChart}
+              ariaLabel='Download Reward Chart'
               icon={
                 <svg
                   xmlns="http://www.w3.org/2000/svg"

--- a/dashboard/src/components/BitcoinStats/Prices.tsx
+++ b/dashboard/src/components/BitcoinStats/Prices.tsx
@@ -346,6 +346,7 @@ const BitcoinPriceTracker: React.FC = () => {
           <div className="flex items-center gap-2 mb-2">
             <p className="font-semibold text-base">Bitcoin Price Range (24h)</p>
             <ActionIconButton
+              ariaLabel="Download price range chart"
               onClick={handleDownloadPriceRange}
               icon={
                 <svg
@@ -427,6 +428,7 @@ const BitcoinPriceTracker: React.FC = () => {
               Bitcoin Price History (Live)
             </p>
             <ActionIconButton
+              ariaLabel="Download price history"
               onClick={handleDownloadPriceHistory}
               icon={
                 <svg

--- a/dashboard/src/components/Mempool/MempoolLatencyStats.tsx
+++ b/dashboard/src/components/Mempool/MempoolLatencyStats.tsx
@@ -211,7 +211,7 @@ const MempoolLatencyStats = () => {
           <div className="absolute right-3 top-3 z-10">
             <ActionIconButton
               onClick={handleDownloadFeeDist}
-              ariaLabel='Download Fee Distribution'
+              ariaLabel="Download Fee Distribution"
               icon={
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -255,7 +255,7 @@ const MempoolLatencyStats = () => {
         <div className="absolute right-3 top-0 z-10">
           <ActionIconButton
             onClick={handleDownloadBlockFees}
-            ariaLabel='Download Block Fees'
+            ariaLabel="Download Block Fees"
             icon={
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/dashboard/src/components/Mempool/MempoolLatencyStats.tsx
+++ b/dashboard/src/components/Mempool/MempoolLatencyStats.tsx
@@ -211,6 +211,7 @@ const MempoolLatencyStats = () => {
           <div className="absolute right-3 top-3 z-10">
             <ActionIconButton
               onClick={handleDownloadFeeDist}
+              ariaLabel='Download Fee Distribution'
               icon={
                 <svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -254,6 +255,7 @@ const MempoolLatencyStats = () => {
         <div className="absolute right-3 top-0 z-10">
           <ActionIconButton
             onClick={handleDownloadBlockFees}
+            ariaLabel='Download Block Fees'
             icon={
               <svg
                 xmlns="http://www.w3.org/2000/svg"

--- a/dashboard/src/components/Mempool/__tests__/MempoolLatencyStats.test.tsx
+++ b/dashboard/src/components/Mempool/__tests__/MempoolLatencyStats.test.tsx
@@ -140,7 +140,7 @@ interface MockWebSocketEventHandlers {
 
 class MockWebSocket implements WebSocket, MockWebSocketEventHandlers {
   readonly url: string;
-  readyState: WebSocket['readyState'] = WebSocket.OPEN;
+  readyState: WebSocket['readyState'] = 1;
   onopen: ((event: Event) => void) | null = null;
   onclose: ((event: CloseEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;

--- a/dashboard/src/components/Mempool/__tests__/MempoolLatencyStats.test.tsx
+++ b/dashboard/src/components/Mempool/__tests__/MempoolLatencyStats.test.tsx
@@ -140,7 +140,7 @@ interface MockWebSocketEventHandlers {
 
 class MockWebSocket implements WebSocket, MockWebSocketEventHandlers {
   readonly url: string;
-  readyState: number;
+  readyState: WebSocket['readyState']= WebSocket.OPEN;
   onopen: ((event: Event) => void) | null = null;
   onclose: ((event: CloseEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;

--- a/dashboard/src/components/Mempool/__tests__/MempoolLatencyStats.test.tsx
+++ b/dashboard/src/components/Mempool/__tests__/MempoolLatencyStats.test.tsx
@@ -140,7 +140,7 @@ interface MockWebSocketEventHandlers {
 
 class MockWebSocket implements WebSocket, MockWebSocketEventHandlers {
   readonly url: string;
-  readyState: WebSocket['readyState']= WebSocket.OPEN;
+  readyState: WebSocket['readyState'] = WebSocket.OPEN;
   onopen: ((event: Event) => void) | null = null;
   onclose: ((event: CloseEvent) => void) | null = null;
   onerror: ((event: Event) => void) | null = null;

--- a/dashboard/src/components/NodeHealth/Bandwidth.tsx
+++ b/dashboard/src/components/NodeHealth/Bandwidth.tsx
@@ -37,7 +37,7 @@ const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
       <div className="absolute right-3 top-3 z-10">
         <ActionIconButton
           onClick={handleDownload}
-          ariaLabel='Download Bandwidth Chart'
+          ariaLabel="Download Bandwidth Chart"
           icon={
             <svg
               xmlns="http://www.w3.org/2000/svg"

--- a/dashboard/src/components/NodeHealth/Bandwidth.tsx
+++ b/dashboard/src/components/NodeHealth/Bandwidth.tsx
@@ -37,6 +37,7 @@ const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
       <div className="absolute right-3 top-3 z-10">
         <ActionIconButton
           onClick={handleDownload}
+          ariaLabel='Download Bandwidth Chart'
           icon={
             <svg
               xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
Improves accessibility of the BitcoinPriceTracker charts by adding descriptive ARIA labels to the icon-only download buttons, ensuring screen readers can announce their purpose.