### PR TITLE
fix(stratum): derive extranonce1 from atomic connection_id counter

### DIFF
--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -8,10 +8,9 @@ use bitcoin::{absolute::Decodable, Transaction};
 use bitcoin::{BlockHash, BlockHeader, BlockTime, TxMerkleNode, Txid, Witness};
 use futures::{lock::Mutex, FutureExt};
 use num::ToPrimitive;
-use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use std::sync::atomic::AtomicBool;
+use std::sync::atomic::{AtomicBool, AtomicU32, Ordering};
 use std::time::UNIX_EPOCH;
 use std::{collections::HashMap, net::SocketAddr, sync::Arc};
 use tokio::{
@@ -1080,15 +1079,13 @@ impl DownstreamClient {
     }
 }
 
+static NEXT_CONNECTION_ID: AtomicU32 = AtomicU32::new(0);
+
 impl Default for DownstreamClient {
     fn default() -> Self {
-        //ExtraNonce1. - Hex-encoded, per-connection unique string which will be used for creating generation transactions later.
-        //4 bytes
-        let mut extranonce1_bytes = [0; 4];
-        rand::thread_rng().fill_bytes(&mut extranonce1_bytes);
-        let connection_id = rand::thread_rng().next_u32(); // FIXME use a counter here, not an RNG
-                                                           // (will collide with 65k mining devices)
-        let extranonce1_hex = hex::encode(&extranonce1_bytes); // FIXME should be connection_id
+        let connection_id = NEXT_CONNECTION_ID.fetch_add(1, Ordering::SeqCst);
+        let extranonce1_bytes = connection_id.to_be_bytes();
+        let extranonce1_hex = hex::encode(extranonce1_bytes);
         debug!(
             connection_id = %format!("{:x}", connection_id),
             extranonce1 = %extranonce1_hex,
@@ -1100,7 +1097,6 @@ impl Default for DownstreamClient {
             subscribed: false,
             suggest_difficulty_done: false,
             channel_configured: false,
-            //generating a random u32 client connection id
             connection_id,
             extranonce1: Vec::from(extranonce1_bytes),
             version_rolling_mask: None,
@@ -2535,5 +2531,31 @@ mod test {
             mr.to_string(),
             "690699e45d09d84d81cb58a4f8ba734e7fc90856d8b24524797f9a54ff57b1a1".to_string()
         );
+    }
+
+    #[test]
+    fn test_unique_extranonce1_per_connection() {
+        let client1 = DownstreamClient::default();
+        let client2 = DownstreamClient::default();
+        let client3 = DownstreamClient::default();
+
+        // connection_ids must be strictly increasing
+        assert!(client2.connection_id() > client1.connection_id());
+        assert!(client3.connection_id() > client2.connection_id());
+
+        // extranonce1 must be unique across all three connections
+        assert_ne!(client1.extranonce1, client2.extranonce1);
+        assert_ne!(client2.extranonce1, client3.extranonce1);
+        assert_ne!(client1.extranonce1, client3.extranonce1);
+
+        // extranonce1 must be exactly EXTRANONCE1_SIZE bytes
+        assert_eq!(client1.extranonce1.len(), EXTRANONCE1_SIZE);
+        assert_eq!(client2.extranonce1.len(), EXTRANONCE1_SIZE);
+        assert_eq!(client3.extranonce1.len(), EXTRANONCE1_SIZE);
+
+        // extranonce1 must match the big-endian encoding of connection_id
+        assert_eq!(client1.extranonce1, client1.connection_id().to_be_bytes().to_vec());
+        assert_eq!(client2.extranonce1, client2.connection_id().to_be_bytes().to_vec());
+        assert_eq!(client3.extranonce1, client3.connection_id().to_be_bytes().to_vec());
     }
 }

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -2554,8 +2554,17 @@ mod test {
         assert_eq!(client3.extranonce1.len(), EXTRANONCE1_SIZE);
 
         // extranonce1 must match the big-endian encoding of connection_id
-        assert_eq!(client1.extranonce1, client1.connection_id().to_be_bytes().to_vec());
-        assert_eq!(client2.extranonce1, client2.connection_id().to_be_bytes().to_vec());
-        assert_eq!(client3.extranonce1, client3.connection_id().to_be_bytes().to_vec());
+        assert_eq!(
+            client1.extranonce1,
+            client1.connection_id().to_be_bytes().to_vec()
+        );
+        assert_eq!(
+            client2.extranonce1,
+            client2.connection_id().to_be_bytes().to_vec()
+        );
+        assert_eq!(
+            client3.extranonce1,
+            client3.connection_id().to_be_bytes().to_vec()
+        );
     }
 }


### PR DESCRIPTION
Fixes #461.

When multiple miners connect to the same Braidpool node they received identical extranonce1 values, causing them to search the exact same nonce space and duplicate work. Root cause: extranonce1 and connection_id were generated by two independent rand::thread_rng() calls,  neither derived from the other  and random assignment collides with near-certainty around 65k concurrent miners (birthday problem on a 32-bit space). Both FIXME comments in DownstreamClient::default() point at exactly this.

I've Replaced both RNG calls with a single monotonically increasing AtomicU32 counter. extranonce1 is now derived directly from connection_id via to_be_bytes(), so miner 0 gets 00000000, miner 1 gets 00000001, and so on,  guaranteed unique, non-overlapping nonce partitions. Removes the now-unused rand::RngCore import and adds a test asserting monotone IDs, unique extranonces, correct size, and correct big-endian encoding.

Note: Ordering::SeqCst on the counter could be relaxed to Ordering::Relaxed in a followup, the counter only needs to produce unique values, not coordinate memory visibility with anything else.