### PR TITLE
Modifying `extend` to return  adopted orphan beads 

### DIFF
--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -11,7 +11,9 @@ pub struct Cohort(pub HashSet<usize>);
 pub enum AddBeadStatus {
     DagAlreadyContainsBead,
     InvalidBead,
-    BeadAdded,
+    // Returning any promoted orphan beads whose parents have
+    // been extended currently .
+    BeadAdded { promoted_orphans: Vec<Bead> },
     ParentsNotYetReceived,
 }
 #[derive(Debug, Clone)]
@@ -82,7 +84,11 @@ impl Braid {
                 bead.block_header.block_hash()
             );
             *self = Braid::new(vec![bead.clone()]);
-            return AddBeadStatus::BeadAdded;
+            // Genesis resets the braid, so there is never an existing orphan set
+            // to promote here.
+            return AddBeadStatus::BeadAdded {
+                promoted_orphans: Vec::new(),
+            };
         }
         // No parents: bad block i.e. the extend will add beads after the genesis
         //bead is done and the extension of genesis beads to Braid shall be done via Braid::new
@@ -181,15 +187,16 @@ impl Braid {
             self.cohort_tips.push(self.tips.clone());
         }
 
-        self.process_orphan_beads();
+        // Adding this bead may have supplied the missing parent for one or more
+        // parked orphans; promote whichever became connectable and surface them
+        // to the caller.
+        let promoted_orphans = self.process_orphan_beads();
 
-        AddBeadStatus::BeadAdded
+        AddBeadStatus::BeadAdded { promoted_orphans }
     }
 
-    /// Process orphan beads to see if any can now be added to the braid
-    /// This method checks if all parents of orphan beads are now available
-    /// and recursively extends the braid with those beads
-    fn process_orphan_beads(&mut self) {
+    fn process_orphan_beads(&mut self) -> Vec<Bead> {
+        let mut promoted = Vec::new();
         // Process orphans in reverse order to maintain proper indexing
         let mut i = self.orphan_beads.len();
         while i > 0 {
@@ -210,11 +217,15 @@ impl Braid {
 
                 // Now extend with the orphan bead
                 match self.extend(&orphan_bead) {
-                    AddBeadStatus::BeadAdded => {
+                    AddBeadStatus::BeadAdded { promoted_orphans } => {
+                        // This orphan is now connected: record it, along with any
+                        // beads its own addition promoted.
+                        promoted.push(orphan_bead);
+                        promoted.extend(promoted_orphans);
                         // Recursively process remaining orphans as this addition
-                        // might enable more orphans to be processed
-                        self.process_orphan_beads();
-                        return; // Exit current processing as recursion will handle the rest
+                        // might enable more orphans to be processed.
+                        promoted.extend(self.process_orphan_beads());
+                        return promoted; // Exit current processing as recursion will handle the rest
                     }
                     AddBeadStatus::DagAlreadyContainsBead => {
                         continue;
@@ -228,6 +239,7 @@ impl Braid {
                 }
             }
         }
+        promoted
     }
 
     pub fn check_genesis_beads(&self, genesis_beads: &Vec<BeadHash>) -> GenesisCheckStatus {

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -1,3 +1,4 @@
+use super::AddBeadStatus;
 use super::Bead;
 use super::Braid;
 use crate::braid::consensus_functions::check_cohort;
@@ -1904,5 +1905,130 @@ fn test_get_beads_after_multiple_tips() {
         returned_beads.len(),
         returned_beads2.len(),
         "Order of input tips should not affect result"
+    );
+}
+
+/// A bead added with no parked orphans depending on it should report an empty
+/// `promoted_orphans` set.
+#[test]
+fn test_extend_without_orphans_promotes_nothing() {
+    let genesis = emit_bead();
+    let mut braid = Braid::new(vec![genesis.clone()]);
+
+    let mut child = emit_bead();
+    child
+        .committed_metadata
+        .parents
+        .insert(genesis.block_header.block_hash());
+
+    match braid.extend(&child) {
+        AddBeadStatus::BeadAdded { promoted_orphans } => {
+            assert!(
+                promoted_orphans.is_empty(),
+                "no orphans were waiting, so none should be promoted"
+            );
+        }
+        other => panic!("expected BeadAdded, got {:?}", other),
+    }
+}
+
+/// An orphan that arrives before its parent is parked; when the parent arrives
+/// the orphan is promoted and reported back through `BeadAdded`.
+#[test]
+fn test_extend_reports_promoted_orphan() {
+    let genesis = emit_bead();
+    let mut braid = Braid::new(vec![genesis.clone()]);
+
+    let mut child = emit_bead();
+    child
+        .committed_metadata
+        .parents
+        .insert(genesis.block_header.block_hash());
+
+    let mut grandchild = emit_bead();
+    grandchild
+        .committed_metadata
+        .parents
+        .insert(child.block_header.block_hash());
+
+    // Grandchild arrives before its parent `child` -> parked as an orphan.
+    assert!(
+        matches!(
+            braid.extend(&grandchild),
+            AddBeadStatus::ParentsNotYetReceived
+        ),
+        "grandchild should be parked while its parent is missing"
+    );
+    assert_eq!(braid.orphan_beads.len(), 1);
+
+    // The parent arrives: `child` is added and `grandchild` becomes connectable.
+    match braid.extend(&child) {
+        AddBeadStatus::BeadAdded { promoted_orphans } => {
+            assert_eq!(promoted_orphans.len(), 1, "grandchild should be promoted");
+            assert_eq!(
+                promoted_orphans[0].block_header.block_hash(),
+                grandchild.block_header.block_hash()
+            );
+        }
+        other => panic!("expected BeadAdded, got {:?}", other),
+    }
+    assert!(
+        braid.orphan_beads.is_empty(),
+        "the orphan set should be drained once the parent arrives"
+    );
+}
+
+/// A chain of orphans (each depending on the previous) that arrive before their
+/// common ancestor should all be promoted transitively in a single `extend`.
+#[test]
+fn test_extend_promotes_transitive_orphan_chain() {
+    let genesis = emit_bead();
+    let mut braid = Braid::new(vec![genesis.clone()]);
+
+    let mut a = emit_bead();
+    a.committed_metadata
+        .parents
+        .insert(genesis.block_header.block_hash());
+    let mut b = emit_bead();
+    b.committed_metadata
+        .parents
+        .insert(a.block_header.block_hash());
+    let mut c = emit_bead();
+    c.committed_metadata
+        .parents
+        .insert(b.block_header.block_hash());
+
+    // `c` and `b` arrive before `a`; both are parked.
+    assert!(matches!(
+        braid.extend(&c),
+        AddBeadStatus::ParentsNotYetReceived
+    ));
+    assert!(matches!(
+        braid.extend(&b),
+        AddBeadStatus::ParentsNotYetReceived
+    ));
+    assert_eq!(braid.orphan_beads.len(), 2);
+
+    // `a` connects the whole chain: `b` then `c` are promoted transitively.
+    match braid.extend(&a) {
+        AddBeadStatus::BeadAdded { promoted_orphans } => {
+            assert_eq!(
+                promoted_orphans.len(),
+                2,
+                "both b and c should be promoted, got {:?}",
+                promoted_orphans.len()
+            );
+            let promoted_hashes: HashSet<_> = promoted_orphans
+                .iter()
+                .map(|bead| bead.block_header.block_hash())
+                .collect();
+            assert!(promoted_hashes.contains(&b.block_header.block_hash()));
+            assert!(promoted_hashes.contains(&c.block_header.block_hash()));
+        }
+        other => panic!("expected BeadAdded, got {:?}", other),
+    }
+    assert!(
+        braid.orphan_beads.is_empty(),
+        "all transitively-connectable orphans should be drained"
     );
 }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -366,7 +366,7 @@ impl SwarmHandler {
         };
         let status = braid_data.extend(&weak_share);
         match status {
-            AddBeadStatus::BeadAdded => {
+            AddBeadStatus::BeadAdded { .. } => {
                 let new_tips: Vec<_> = braid_data.tips.iter().map(|&idx| idx).collect();
                 let bead_hash = weak_share.block_header.block_hash();
                 info!(

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -647,7 +647,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             let mut peer_manager = peer_manager_arc.write().await;
                                             peer_manager.penalize_for_invalid_bead(&message.source);
                                         }
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
+                                    } else if let braid::AddBeadStatus::BeadAdded { .. } = status {
 
                                      //Considering the index of the beads in braid will be same as the (insertion ids-1)
                                         let bead_id = match braid_data
@@ -732,7 +732,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 }
                                                 continue;
                                             },
-                                            braid::AddBeadStatus::BeadAdded | braid::AddBeadStatus::DagAlreadyContainsBead =>{
+                                            braid::AddBeadStatus::BeadAdded { .. } | braid::AddBeadStatus::DagAlreadyContainsBead =>{
                                                 ibd_spinlock.store(false,Ordering::SeqCst);
                                                 continue;
                                             },
@@ -774,7 +774,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             let mut peer_manager = peer_manager_arc.write().await;
                                             peer_manager.penalize_for_invalid_bead(&message.source);
                                         }
-                                    } else if let braid::AddBeadStatus::BeadAdded = status {
+                                    } else if let braid::AddBeadStatus::BeadAdded { .. } = status {
                                         let bead_id = match braid_data
                                             .bead_index_mapping
                                             .get(&bead.block_header.block_hash()) {
@@ -1111,7 +1111,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 let mut peer_manager = peer_manager_arc.write().await;
                                                 peer_manager.penalize_for_invalid_bead(&peer);
                                             }
-                                        } else if let braid::AddBeadStatus::BeadAdded = status {
+                                        } else if let braid::AddBeadStatus::BeadAdded { .. } = status {
 
                                             let bead_id = match braid_data
                                                 .bead_index_mapping

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -332,7 +332,7 @@ impl RpcServer for RpcServerImpl {
         drop(braid_data);
 
         match success_status {
-            AddBeadStatus::BeadAdded => {
+            AddBeadStatus::BeadAdded { .. } => {
                 let _ = self.dashboard_events.new_bead.send(Some(bead));
                 Ok("Bead added successfully".to_string())
             }


### PR DESCRIPTION
- Changing the `extend` function signatures to return ~~promoted_orphan_beads~~ adopted_orphan_beads .
- Updating the caller sites, the update of the usage of returned beads will be update in coming PRs .