### PR TITLE
feat(test_framework): Implementing RPC client, miner manager and Cleanup Manager for test framework

### DIFF
--- a/tests/functional/combine_logs.py
+++ b/tests/functional/combine_logs.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 import argparse
 from pathlib import Path
+from typing import Iterator
 
 from test_framework.constants import LOG_NAMES
 
 
-def iter_logs(root: Path):
+def iter_logs(root: Path) -> Iterator[Path]:
     for path in sorted(root.rglob("*")):
         if path.is_file() and path.name in LOG_NAMES:
             yield path

--- a/tests/functional/test_framework/cleanup_manager.py
+++ b/tests/functional/test_framework/cleanup_manager.py
@@ -26,13 +26,19 @@ class CleanupManager:
     allows signal handlers to be installed there.
     """
 
-    def __init__(self, logger: logging.Logger | None = None) -> None:
+    def __init__(
+        self,
+        logger: logging.Logger | None = None,
+        *,
+        install_handlers: bool = True,
+    ) -> None:
         self._logger = logger or _LOGGER
         self._stack: list[tuple[str, Callable[[], None]]] = []
         self._lock = threading.RLock()
         self._ran = False
         self._previous_handlers: dict[int, signal.Handlers] = {}
-        self._install_handlers()
+        if install_handlers:
+            self._install_handlers()
 
     # The cleanup manager is a registrable that is attached to different modules
     # later when running the test suite such as miner_manager. This allows us to
@@ -72,6 +78,17 @@ class CleanupManager:
                 log_event(self._logger, "cleanup_callback_done", name=name)
             except Exception as exc:
                 log_exception(self._logger, "cleanup_callback_failed", exc, name=name)
+
+        # restore previous signal handlers so that subsequent
+        # code is not left with stale references to this now-finished CleanupManager.
+        for signum, handler in self._previous_handlers.items():
+            try:
+                signal.signal(signum, handler)
+            except (OSError, ValueError):
+                # Not the main thread, or signal already changed — skip.
+                pass
+        self._previous_handlers.clear()
+        atexit.unregister(self.run_all)
 
     def managed_process(
         self,
@@ -116,6 +133,15 @@ class CleanupManager:
         if callable(previous):
             previous(signum, frame)
             return
+        # No custom prior handler — restore default and re-raise so the OS
+        # records the correct exit status (e.g. 128 + signum).
+        log_event(
+            self._logger,
+            "cleanup_re_raising_signal",
+            level=logging.WARNING,
+            signal=signum,
+            message=f"Re-raising signal {signum} with SIG_DFL; process will now terminate",
+        )
         signal.signal(signum, signal.SIG_DFL)
         os.kill(os.getpid(), signum)
 
@@ -156,6 +182,19 @@ def terminate_process_group(
         log_event(
             process_logger,
             "process_group_missing",
+            level=logging.DEBUG,
+            name=name,
+            pid=process.pid,
+        )
+        return
+
+    # re-poll immediately after getpgid() to narrow the TOCTOU
+    # window. Between poll() and getpgid() the process could have exited and
+    # its PID recycled to an unrelated process.
+    if process.poll() is not None:
+        log_event(
+            process_logger,
+            "process_exited_before_signal",
             level=logging.DEBUG,
             name=name,
             pid=process.pid,
@@ -227,3 +266,18 @@ def terminate_process_group(
                 signal=sig.name,
             )
             continue
+
+    # SIGKILL timed out — the process descriptor must still be
+    # reaped to prevent a zombie entry accumulating in the OS process table.
+    try:
+        process.wait(timeout=0)
+    except subprocess.TimeoutExpired:
+        log_event(
+            process_logger,
+            "process_kill_unresponsive",
+            level=logging.ERROR,
+            name=name,
+            pid=process.pid,
+            pgid=pgid,
+            message="Process did not exit after SIGKILL; descriptor not reaped — possible kernel-level stuck process",
+        )

--- a/tests/functional/test_framework/cleanup_manager.py
+++ b/tests/functional/test_framework/cleanup_manager.py
@@ -1,0 +1,119 @@
+"""LIFO cleanup orchestration for Braidpool functional tests."""
+
+from __future__ import annotations
+
+import atexit
+import logging
+import os
+import signal
+import subprocess
+import threading
+from collections.abc import Callable
+from types import FrameType
+
+from test_framework.logging_utils import log_event, log_exception
+from test_framework.process_utils import _terminate_process_group
+
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class CleanupManager:
+    """Register and run cleanup callbacks for a functional test process.
+
+    Instances install ``atexit``, ``SIGTERM``, and ``SIGINT`` hooks during
+    initialization. Construct this class from the main thread; CPython only
+    allows signal handlers to be installed there.
+    """
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        self._logger = logger or _LOGGER
+        self._stack: list[tuple[str, Callable[[], None]]] = []
+        self._lock = threading.Lock()
+        self._ran = False
+        self._previous_handlers: dict[int, signal.Handlers] = {}
+        self._install_handlers()
+
+    #The cleanup manager is a registrable that is attached to different modules later when running the test suite such as miner_manager. This allows us to register different callback fucntions in a LIFo stack.
+    def register(self, fn: Callable[[], None], *, name: str | None = None) -> None:
+        """Push a zero-argument cleanup callback onto the LIFO stack."""
+        callback_name = name or _callable_name(fn)
+        with self._lock:
+            if self._ran:
+                log_event(
+                    self._logger,
+                    "cleanup_register_after_run",
+                    level=logging.WARNING,
+                    name=callback_name,
+                )
+                return
+            self._stack.append((callback_name, fn))
+        log_event(
+            self._logger,
+            "cleanup_callback_registered",
+            level=logging.DEBUG,
+            name=callback_name,
+        )
+
+    def run_all(self) -> None:
+        """Execute all registered callbacks in LIFO order exactly once."""
+        with self._lock:
+            if self._ran:
+                return
+            self._ran = True
+            stack = list(self._stack)
+
+        for name, fn in reversed(stack):
+            try:
+                log_event(self._logger, "cleanup_callback_running", name=name)
+                fn()
+                log_event(self._logger, "cleanup_callback_done", name=name)
+            except Exception as exc:
+                log_exception(self._logger, "cleanup_callback_failed", exc, name=name)
+
+    def managed_process(
+        self,
+        process: subprocess.Popen,
+        name: str,
+        *,
+        term_timeout: float = 3.0,
+        kill_timeout: float = 1.0,
+    ) -> None:
+        """Register a callback that terminates a subprocess group on cleanup."""
+
+        def _stop() -> None:
+            _terminate_process_group(
+                process,
+                name=name,
+                term_timeout=term_timeout,
+                kill_timeout=kill_timeout,
+                logger=self._logger,
+            )
+
+        self.register(_stop, name=f"process:{name}")
+
+    #This installs all the handlers when the CleanupManger is initialized. It sets up a signal chaining mechaninsm so that when the test process is terminated due to signals it can gracefully exit after running all the cleanup callbacks.
+    def _install_handlers(self) -> None:
+        atexit.register(self.run_all)
+        for signum in (signal.SIGTERM, signal.SIGINT):
+            self._previous_handlers[signum] = signal.getsignal(signum)
+            signal.signal(signum, self._signal_handler)
+
+    def _signal_handler(self, signum: int, frame: FrameType | None) -> None:
+        log_event(self._logger, "cleanup_signal_received", signal=signum)
+        self.run_all()
+        self._delegate_signal(signum, frame)
+
+    def _delegate_signal(self, signum: int, frame: FrameType | None) -> None:
+        previous = self._previous_handlers.get(signum, signal.SIG_DFL)
+        if previous == signal.SIG_IGN:
+            return
+        if callable(previous):
+            previous(signum, frame)
+            return
+        signal.signal(signum, signal.SIG_DFL)
+        os.kill(os.getpid(), signum)
+
+
+def _callable_name(fn: Callable[[], None]) -> str:
+    return getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn)))

--- a/tests/functional/test_framework/cleanup_manager.py
+++ b/tests/functional/test_framework/cleanup_manager.py
@@ -29,16 +29,12 @@ class CleanupManager:
     def __init__(
         self,
         logger: logging.Logger | None = None,
-        *,
-        install_handlers: bool = True,
     ) -> None:
         self._logger = logger or _LOGGER
         self._stack: list[tuple[str, Callable[[], None]]] = []
         self._lock = threading.RLock()
         self._ran = False
         self._previous_handlers: dict[int, signal.Handlers] = {}
-        if install_handlers:
-            self._install_handlers()
 
     # The cleanup manager is a registrable that is attached to different modules
     # later when running the test suite such as miner_manager. This allows us to
@@ -115,7 +111,7 @@ class CleanupManager:
     # Sets up a signal chaining mechanism so that when the test process is
     # terminated due to signals it can gracefully exit after running all the
     # cleanup callbacks.
-    def _install_handlers(self) -> None:
+    def install_signal_handlers(self) -> None:
         atexit.register(self.run_all)
         for signum in (signal.SIGTERM, signal.SIGINT):
             self._previous_handlers[signum] = signal.getsignal(signum)

--- a/tests/functional/test_framework/cleanup_manager.py
+++ b/tests/functional/test_framework/cleanup_manager.py
@@ -10,9 +10,9 @@ import subprocess
 import threading
 from collections.abc import Callable
 from types import FrameType
+import time
 
-from test_framework.logging_utils import log_event, log_exception
-from test_framework.process_utils import _terminate_process_group
+from test_framework.logging_utils import log_event, log_exception, log_duration
 
 
 _LOGGER = logging.getLogger(__name__)
@@ -29,12 +29,14 @@ class CleanupManager:
     def __init__(self, logger: logging.Logger | None = None) -> None:
         self._logger = logger or _LOGGER
         self._stack: list[tuple[str, Callable[[], None]]] = []
-        self._lock = threading.Lock()
+        self._lock = threading.RLock()
         self._ran = False
         self._previous_handlers: dict[int, signal.Handlers] = {}
         self._install_handlers()
 
-    #The cleanup manager is a registrable that is attached to different modules later when running the test suite such as miner_manager. This allows us to register different callback fucntions in a LIFo stack.
+    # The cleanup manager is a registrable that is attached to different modules
+    # later when running the test suite such as miner_manager. This allows us to
+    # register different callback functions in a LIFO stack.
     def register(self, fn: Callable[[], None], *, name: str | None = None) -> None:
         """Push a zero-argument cleanup callback onto the LIFO stack."""
         callback_name = name or _callable_name(fn)
@@ -82,7 +84,7 @@ class CleanupManager:
         """Register a callback that terminates a subprocess group on cleanup."""
 
         def _stop() -> None:
-            _terminate_process_group(
+            terminate_process_group(
                 process,
                 name=name,
                 term_timeout=term_timeout,
@@ -92,7 +94,10 @@ class CleanupManager:
 
         self.register(_stop, name=f"process:{name}")
 
-    #This installs all the handlers when the CleanupManger is initialized. It sets up a signal chaining mechaninsm so that when the test process is terminated due to signals it can gracefully exit after running all the cleanup callbacks.
+    # Install atexit and signal handlers when the CleanupManager is initialized.
+    # Sets up a signal chaining mechanism so that when the test process is
+    # terminated due to signals it can gracefully exit after running all the
+    # cleanup callbacks.
     def _install_handlers(self) -> None:
         atexit.register(self.run_all)
         for signum in (signal.SIGTERM, signal.SIGINT):
@@ -117,3 +122,108 @@ class CleanupManager:
 
 def _callable_name(fn: Callable[[], None]) -> str:
     return getattr(fn, "__qualname__", getattr(fn, "__name__", repr(fn)))
+
+
+def terminate_process_group(
+    process: subprocess.Popen,
+    *,
+    name: str,
+    term_timeout: float,
+    kill_timeout: float,
+    logger: logging.Logger | None = None,
+) -> None:
+    """Terminate *process* and its process group with SIGTERM, then SIGKILL.
+
+    The process **must** have been started with ``start_new_session=True``
+    so that its PGID differs from the caller's.  An assertion guards
+    against accidental self-kill.
+    """
+    process_logger = logger or _LOGGER
+    if process.poll() is not None:
+        log_event(
+            process_logger,
+            "process_stop_skipped",
+            level=logging.DEBUG,
+            name=name,
+            pid=process.pid,
+            returncode=process.returncode,
+        )
+        return
+
+    try:
+        pgid = os.getpgid(process.pid)
+    except OSError:
+        log_event(
+            process_logger,
+            "process_group_missing",
+            level=logging.DEBUG,
+            name=name,
+            pid=process.pid,
+        )
+        return
+
+    # Guard: never kill our own process group.
+    if pgid == os.getpgid(0):
+        log_event(
+            process_logger,
+            "process_group_is_self",
+            level=logging.ERROR,
+            name=name,
+            pid=process.pid,
+            pgid=pgid,
+        )
+        # Fall back to killing just the single process.
+        try:
+            process.terminate()
+            process.wait(timeout=term_timeout)
+        except (OSError, subprocess.TimeoutExpired):
+            try:
+                process.kill()
+                process.wait(timeout=kill_timeout)
+            except (OSError, subprocess.TimeoutExpired):
+                pass
+        return
+
+    for sig, wait_time in (
+        (signal.SIGTERM, term_timeout),
+        (signal.SIGKILL, kill_timeout),
+    ):
+        if process.poll() is not None:
+            return
+        started = time.monotonic()
+        log_event(
+            process_logger,
+            "process_signal_sent",
+            level=logging.DEBUG,
+            name=name,
+            pid=process.pid,
+            pgid=pgid,
+            signal=sig.name,
+        )
+        try:
+            os.killpg(pgid, sig)
+        except ProcessLookupError:
+            return
+        try:
+            process.wait(timeout=wait_time)
+            log_duration(
+                process_logger,
+                "process_signal_wait",
+                time.monotonic() - started,
+                name=name,
+                pid=process.pid,
+                signal=sig.name,
+            )
+            return
+        except subprocess.TimeoutExpired:
+            log_duration(
+                process_logger,
+                "process_signal_wait",
+                time.monotonic() - started,
+                status="timeout",
+                level=logging.WARNING,
+                name=name,
+                pid=process.pid,
+                signal=sig.name,
+            )
+            continue

--- a/tests/functional/test_framework/miner_manager.py
+++ b/tests/functional/test_framework/miner_manager.py
@@ -20,6 +20,11 @@ class _Registerable(Protocol):
     def register(self, fn: Callable[[], None]) -> None: ...
 
 
+class StratumNode(Protocol):
+    @property
+    def stratum_port(self) -> int: ...
+
+
 ACCEPTED_SHARE_RE = re.compile(r"\b(accepted|share accepted|accepted share)\b", re.IGNORECASE)
 logger = logging.getLogger(__name__)
 
@@ -147,9 +152,9 @@ class MinerManager:
         self.miners: list[CpuMiner] = []
         self.logger = log_manager.logger
 
-    def spawn_miner(self, node: Any) -> CpuMiner:
+    def spawn_miner(self, node: StratumNode) -> CpuMiner:
         """Create and start a miner attached to *node*'s stratum port."""
-        stratum_port = getattr(node, "stratum_port", None)
+        stratum_port = node.stratum_port
         if stratum_port is None:
             raise TypeError(
                 f"spawn_miner: node {node!r} has no 'stratum_port' attribute. "

--- a/tests/functional/test_framework/miner_manager.py
+++ b/tests/functional/test_framework/miner_manager.py
@@ -1,0 +1,196 @@
+"""CpuMiner process helpers for Braidpool functional tests."""
+
+from __future__ import annotations
+
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Callable, Protocol
+
+from test_framework.constants import STDERR_LOG_NAME, STDOUT_LOG_NAME
+from test_framework.log_manager import LogManager
+from test_framework.logging_utils import log_event, log_exception
+from test_framework.network_config import NetworkConfig
+from test_framework.cleanup_manager import terminate_process_group
+from test_framework.util import SkipTest, find_binary
+
+
+class _Registerable(Protocol):
+    def register(self, fn: Callable[[], None]) -> None: ...
+
+
+ACCEPTED_SHARE_RE = re.compile(r"\b(accepted|share accepted|accepted share)\b", re.IGNORECASE)
+logger = logging.getLogger(__name__)
+
+
+class CpuMiner:
+    """Wrap a single cpuminer process."""
+
+    def __init__(
+        self,
+        stratum_port: int,
+        run_dir: Path,
+        *,
+        minerd_path: str | Path = "minerd",
+        algorithm: str = "sha256d",
+        miner_id: int = 0,
+        miner_logger: logging.Logger | None = None,
+    ) -> None:
+        self.stratum_port = stratum_port
+        self.run_dir = Path(run_dir)
+        self.minerd_path = Path(minerd_path)
+        self.algorithm = algorithm
+        self.miner_id = miner_id
+        self.process: subprocess.Popen | None = None
+        self.logger = miner_logger or logger
+        self.stdout_path = self.run_dir / STDOUT_LOG_NAME
+        self.stderr_path = self.run_dir / STDERR_LOG_NAME
+        self.run_dir.mkdir(parents=True, exist_ok=True)
+
+    def __del__(self) -> None:
+        if self.process is not None and self.process.poll() is None:
+            try:
+                self.process.kill()
+            except OSError:
+                pass
+
+    def start(self, extra_args: list[str] | None = None) -> None:
+        """Start minerd with stdout/stderr redirected to files."""
+        if self.is_alive():
+            raise RuntimeError(f"CpuMiner {self.miner_id} is already running")
+        DEFAULT_MINERD_FLAGS = ["-q", "-D", "-P"]
+        args = [
+            str(self.minerd_path),
+            "-a",
+            self.algorithm,
+            "-o",
+            f"stratum+tcp://127.0.0.1:{self.stratum_port}",
+            *DEFAULT_MINERD_FLAGS,
+        ]
+        if extra_args:
+            args.extend(extra_args)
+
+        log_event(
+            self.logger,
+            "miner_starting",
+            miner_id=self.miner_id,
+            stratum_port=self.stratum_port,
+            algorithm=self.algorithm,
+            stdout_path=self.stdout_path,
+            stderr_path=self.stderr_path,
+        )
+        stdout_file = open(self.stdout_path, "ab", buffering=0)
+        stderr_file = open(self.stderr_path, "ab", buffering=0)
+        try:
+            try:
+                self.process = subprocess.Popen(
+                    args,
+                    stdout=stdout_file,
+                    stderr=stderr_file,
+                    cwd=self.run_dir,
+                    start_new_session=True,
+                )
+            except Exception as exc:
+                log_exception(self.logger, "miner_start_failed", exc, miner_id=self.miner_id)
+                raise
+        finally:
+            stdout_file.close()
+            stderr_file.close()
+        log_event(self.logger, "miner_started", miner_id=self.miner_id, pid=self.process.pid)
+
+    def stop(self, *, term_timeout: float = 2.0, kill_timeout: float = 1.0) -> None:
+        """Stop the miner process group. Safe to call repeatedly."""
+        process = self.process
+        if process is None or process.poll() is not None:
+            log_event(self.logger, "miner_stop_skipped", level=logging.DEBUG, miner_id=self.miner_id)
+            return
+        log_event(self.logger, "miner_stopping", miner_id=self.miner_id, pid=process.pid)
+        terminate_process_group(
+            process,
+            name=f"miner{self.miner_id}",
+            term_timeout=term_timeout,
+            kill_timeout=kill_timeout,
+            logger=self.logger,
+        )
+        log_event(self.logger, "miner_stopped", miner_id=self.miner_id, returncode=process.returncode)
+
+    def is_alive(self) -> bool:
+        return self.process is not None and self.process.poll() is None
+
+    def shares_submitted(self) -> int:
+        """Parse miner logs and return the number of accepted shares."""
+        count = 0
+        for path in (self.stdout_path, self.stderr_path):
+            if not path.exists():
+                continue
+            with path.open("r", encoding="utf8", errors="replace") as log_file:
+                for line in log_file:
+                    if ACCEPTED_SHARE_RE.search(line):
+                        count += 1
+        log_event(self.logger, "miner_share_count", level=logging.DEBUG, miner_id=self.miner_id, accepted_shares=count)
+        return count
+
+
+class MinerManager:
+    """Factory and lifecycle manager for CpuMiner instances."""
+
+    def __init__(
+        self,
+        config: NetworkConfig,
+        log_manager: LogManager,
+        cleanup: _Registerable | None = None,  # when the test case runs, it registers the cleanup maanger with the test framework, so we can register miner stop functions to be called on test cleanup
+    ) -> None:
+        self.config = config
+        self.log_manager = log_manager
+        self.cleanup = cleanup
+        self.miners: list[CpuMiner] = []
+        self.logger = log_manager.logger
+
+    def spawn_miner(self, node: Any) -> CpuMiner:
+        """Create and start a miner attached to *node*'s stratum port."""
+        stratum_port = getattr(node, "stratum_port", None)
+        if stratum_port is None:
+            raise TypeError(
+                f"spawn_miner: node {node!r} has no 'stratum_port' attribute. "
+                "Pass a BraidpoolNode instance."
+            )
+        miner_id = len(self.miners)
+        minerd_path = self._resolve_minerd_path()
+        log_event(self.logger, "miner_spawn_requested", miner_id=miner_id, stratum_port=stratum_port)
+        run_dir = self.log_manager.subdir(f"miner{miner_id}")
+        miner = CpuMiner(
+            stratum_port,
+            run_dir,
+            minerd_path=minerd_path,
+            miner_id=miner_id,
+            miner_logger=self.logger,
+        )
+        miner.start()
+        self.miners.append(miner)
+        if self.cleanup is not None:
+            self.cleanup.register(miner.stop)
+        return miner
+
+    def stop_all(self) -> None:
+        log_event(self.logger, "miner_stop_all_started", miner_count=len(self.miners))
+        for miner in reversed(self.miners):
+            miner.stop()
+        log_event(self.logger, "miner_stop_all_finished", miner_count=len(self.miners))
+
+    def _resolve_minerd_path(self) -> Path:
+        if self.config.minerd_bin_path is not None:
+            path = Path(self.config.minerd_bin_path)
+            if path.exists():
+                return path
+        return find_minerd()
+
+
+def find_minerd(repo_root: Path | None = None) -> Path:
+    """Find the minerd binary using the standard functional-test search order."""
+    return find_binary(
+        "minerd",
+        "MINERD_PATH",
+        ["node/src/cpuminer/minerd"],
+        repo_root=repo_root,
+    )

--- a/tests/functional/test_framework/rpc_client.py
+++ b/tests/functional/test_framework/rpc_client.py
@@ -91,7 +91,7 @@ class JsonRpcClient:
             self._auth_header = f"Basic {encoded_auth}"
 
     def _call(self, method: str, params: Any = None) -> Any:
-        started = time.monotonic()
+        started = time.monotonic() # ensures that even if system time changed, actual time is maintained
         request_id = next(self._ids)
         payload_obj = {"jsonrpc": "2.0", "id": request_id, "method": method}
         if params is not None:
@@ -268,6 +268,15 @@ class RpcClient(JsonRpcClient):
 
     def get_ipc_stats(self) -> dict:
         return self._call("getipcstats")
+
+    def get_node_info(self, bead_hash: str) -> dict:
+        return self._call("getnodeinfo", [bead_hash])
+
+    def staged_transactions(self) -> list[dict]:
+        return self._call("stagedtransactions")
+
+    def unstage_transactions(self, txid: str) -> bool:
+        return self._call("unstagetransactions", [txid])
 
     def bitcoin_proxy(self, method: str, params: Any = None) -> Any:
         return self._call("bitcoinproxy", [method, params or []])

--- a/tests/functional/test_framework/rpc_client.py
+++ b/tests/functional/test_framework/rpc_client.py
@@ -56,11 +56,11 @@ def _default_transport(url: str, payload: bytes, timeout: float, auth_header: st
         method="POST",
     )
     with urllib.request.urlopen(request, timeout=timeout) as response:
-        return response.read()
+        return response.read(_MAX_HTTP_BODY_BYTES)
 
 
-class RpcClient:
-    """Synchronous JSON-RPC 2.0 client for a Braidpool node."""
+class JsonRpcClient:
+    """Synchronous JSON-RPC 2.0 client."""
 
     def __init__(
         self,
@@ -98,8 +98,10 @@ class RpcClient:
             payload_obj["params"] = params
         payload = json.dumps(payload_obj, separators=(",", ":")).encode("utf8")
 
+        safe_params = "<redacted_positional_args>" if isinstance(params, (list, tuple)) else params
+
         if self.trace:
-            log_event(self.logger, "rpc_request", level=logging.DEBUG, method=method, request_id=request_id, params=params)
+            log_event(self.logger, "rpc_request", level=logging.DEBUG, method=method, request_id=request_id, params=safe_params)
 
         try:
             raw = self._send_with_retries(method, payload)
@@ -126,7 +128,7 @@ class RpcClient:
                 time.monotonic() - started,
                 status="error",
                 request_id=request_id,
-                params=params if self.trace else None,
+                params=safe_params if self.trace else None,
                 error=error.message,
             )
             raise error from exc
@@ -137,7 +139,7 @@ class RpcClient:
                 time.monotonic() - started,
                 status="error",
                 request_id=request_id,
-                params=params if self.trace else None,
+                params=safe_params if self.trace else None,
                 error=exc.message,
             )
             raise
@@ -148,7 +150,7 @@ class RpcClient:
             time.monotonic() - started,
             status="ok",
             request_id=request_id,
-            params=params if self.trace else None,
+            params=safe_params if self.trace else None,
         )
         return response["result"]
 
@@ -204,6 +206,23 @@ class RpcClient:
             delay = min(delay * 2, 2.0)
 
         raise RpcTransportError(None, f"RPC {method} failed: {last_error!r}")
+
+    def __getattr__(self, name: str) -> Callable[..., Any]:
+        """Dynamically handle RPC methods not explicitly defined."""
+        if name.startswith("_"):
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+        
+        def rpc_method(*args: Any, **kwargs: Any) -> Any:
+            if args and kwargs:
+                raise ValueError(f"Cannot pass both positional and keyword arguments to RPC method {name}")
+            params = kwargs if kwargs else list(args)
+            return self._call(name, params)
+            
+        return rpc_method
+
+
+class RpcClient(JsonRpcClient):
+    """Braidpool-specific JSON-RPC client."""
 
     def get_bead(self, bead_hash: str) -> dict:
         return self._call("getbead", [bead_hash])
@@ -286,19 +305,6 @@ class RpcClient:
             timeout=timeout,
             message=f"Peer count never reached {minimum}",
         )
-
-    def __getattr__(self, name: str) -> Callable[..., Any]:
-        """Dynamically handle RPC methods not explicitly defined."""
-        if name.startswith("_"):
-            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
-        
-        def rpc_method(*args: Any, **kwargs: Any) -> Any:
-            if args and kwargs:
-                raise ValueError(f"Cannot pass both positional and keyword arguments to RPC method {name}")
-            params = kwargs if kwargs else list(args)
-            return self._call(name, params)
-            
-        return rpc_method
 
 
 def _is_connection_refused(exc: urllib.error.URLError) -> bool:

--- a/tests/functional/test_framework/rpc_client.py
+++ b/tests/functional/test_framework/rpc_client.py
@@ -1,0 +1,304 @@
+"""JSON-RPC client for Braidpool functional tests."""
+
+from __future__ import annotations
+
+import base64
+import json
+import logging
+import time
+import urllib.error
+import urllib.request
+from itertools import count
+from typing import Any, Callable
+
+from test_framework.logging_utils import log_event, log_rpc_call
+from test_framework.util import wait_until
+
+
+logger = logging.getLogger(__name__)
+
+Transport = Callable[[str, bytes, float, str | None], bytes]
+
+
+class RpcError(Exception):
+    """Base exception for JSON-RPC failures."""
+
+    def __init__(self, code: int | None, message: str, data: Any = None) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.data = data
+
+
+class RpcTransportError(RpcError):
+    """Raised when the RPC endpoint cannot be reached."""
+
+
+class RpcTimeoutError(RpcError):
+    """Raised when an RPC call times out."""
+
+
+class RpcInvalidResponseError(RpcError):
+    """Raised when the server returns malformed JSON-RPC data."""
+
+
+def _default_transport(url: str, payload: bytes, timeout: float, auth_header: str | None = None) -> bytes:
+    headers = {"Content-Type": "application/json"}
+    if auth_header:
+        headers["Authorization"] = auth_header
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers=headers,
+        method="POST",
+    )
+    with urllib.request.urlopen(request, timeout=timeout) as response:
+        return response.read()
+
+
+class RpcClient:
+    """Synchronous JSON-RPC 2.0 client for a Braidpool node."""
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        timeout: float = 10.0,
+        *,
+        rpc_user: str | None = None,
+        rpc_password: str | None = None,
+        trace: bool = False,
+        max_retries: int = 5,
+        retry_delay: float = 0.5,
+        transport: Transport | None = None,
+        rpc_logger: logging.Logger | None = None,
+    ) -> None:
+        self.url = f"http://{host}:{port}"
+        self.timeout = timeout
+        self.trace = trace
+        self.max_retries = max_retries
+        self.retry_delay = retry_delay
+        self._transport = transport or _default_transport
+        self._ids = count(1)
+        self.logger = rpc_logger or logger
+        self._auth_header = None
+        if rpc_user is not None and rpc_password is not None:
+            auth_str = f"{rpc_user}:{rpc_password}"
+            encoded_auth = base64.b64encode(auth_str.encode("utf8")).decode("utf8")
+            self._auth_header = f"Basic {encoded_auth}"
+
+    def _call(self, method: str, params: Any = None) -> Any:
+        started = time.monotonic()
+        request_id = next(self._ids)
+        payload_obj = {"jsonrpc": "2.0", "id": request_id, "method": method}
+        if params is not None:
+            payload_obj["params"] = params
+        payload = json.dumps(payload_obj, separators=(",", ":")).encode("utf8")
+
+        if self.trace:
+            log_event(self.logger, "rpc_request", level=logging.DEBUG, method=method, request_id=request_id, params=params)
+
+        try:
+            raw = self._send_with_retries(method, payload)
+            response = json.loads(raw.decode("utf8"))
+            if not isinstance(response, dict):
+                raise RpcInvalidResponseError(None, f"JSON-RPC response for {method} is not an object")
+
+            error = response.get("error")
+            if error is not None:
+                if not isinstance(error, dict):
+                    raise RpcInvalidResponseError(None, f"Malformed JSON-RPC error for {method}")
+                raise RpcError(error.get("code"), error.get("message", "JSON-RPC error"), error.get("data"))
+
+            if response.get("id") != request_id:
+                raise RpcInvalidResponseError(None, f"JSON-RPC response id mismatch for {method}")
+
+            if "result" not in response:
+                raise RpcInvalidResponseError(None, f"JSON-RPC response for {method} missing result")
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            error = RpcInvalidResponseError(None, f"Invalid JSON-RPC response for {method}")
+            log_rpc_call(
+                self.logger,
+                method,
+                time.monotonic() - started,
+                status="error",
+                request_id=request_id,
+                params=params if self.trace else None,
+                error=error.message,
+            )
+            raise error from exc
+        except RpcError as exc:
+            log_rpc_call(
+                self.logger,
+                method,
+                time.monotonic() - started,
+                status="error",
+                request_id=request_id,
+                params=params if self.trace else None,
+                error=exc.message,
+            )
+            raise
+
+        log_rpc_call(
+            self.logger,
+            method,
+            time.monotonic() - started,
+            status="ok",
+            request_id=request_id,
+            params=params if self.trace else None,
+        )
+        return response["result"]
+
+    def _send_with_retries(self, method: str, payload: bytes) -> bytes:
+        delay = self.retry_delay
+        attempts = self.max_retries + 1
+        last_error: BaseException | None = None
+
+        for attempt in range(attempts):
+            try:
+                return self._transport(self.url, payload, self.timeout, self._auth_header)
+            except TimeoutError as exc:
+                log_event(self.logger, "rpc_timeout", level=logging.WARNING, method=method, attempt=attempt + 1)
+                raise RpcTimeoutError(None, f"RPC {method} timed out") from exc
+            except urllib.error.HTTPError as exc:
+                if exc.code == 401:
+                    raise RpcTransportError(None, f"RPC {method} authentication failed (401 Unauthorized)") from exc
+                if exc.code == 500:
+                    try:
+                        return exc.read()
+                    except Exception:
+                        pass
+                last_error = exc
+                if exc.code != 503 or attempt == attempts - 1:
+                    log_event(self.logger, "rpc_http_error", level=logging.WARNING, method=method, attempt=attempt + 1, error=str(exc))
+                    raise RpcTransportError(None, f"RPC {method} HTTP error {exc.code}: {exc.reason}") from exc
+            except urllib.error.URLError as exc:
+                last_error = exc
+                if not _is_connection_refused(exc) or attempt == attempts - 1:
+                    log_event(self.logger, "rpc_transport_failed", level=logging.WARNING, method=method, attempt=attempt + 1, error=str(exc))
+                    raise RpcTransportError(None, f"RPC {method} transport error: {exc}") from exc
+            except ConnectionRefusedError as exc:
+                last_error = exc
+                if attempt == attempts - 1:
+                    log_event(self.logger, "rpc_connection_refused", level=logging.WARNING, method=method, attempt=attempt + 1)
+                    raise RpcTransportError(None, f"RPC {method} connection refused") from exc
+            except OSError as exc:
+                _RETRYABLE_OSERRORS = (ConnectionResetError, BrokenPipeError)
+                if not isinstance(exc, _RETRYABLE_OSERRORS) or attempt == attempts - 1:
+                    log_event(self.logger, "rpc_transport_failed", level=logging.WARNING, method=method, attempt=attempt + 1, error=str(exc))
+                    raise RpcTransportError(None, f"RPC {method} transport error: {exc}") from exc
+                last_error = exc
+
+            log_event(
+                self.logger,
+                "rpc_retry",
+                level=logging.DEBUG,
+                method=method,
+                attempt=attempt + 1,
+                next_delay_seconds=delay,
+            )
+            if delay > 0:
+                time.sleep(delay)
+            delay = min(delay * 2, 2.0)
+
+        raise RpcTransportError(None, f"RPC {method} failed: {last_error!r}")
+
+    def get_bead(self, bead_hash: str) -> dict:
+        return self._call("getbead", [bead_hash])
+
+    def add_bead(self, bead_data: str) -> str:
+        return self._call("addbead", [bead_data])
+
+    def get_tips(self) -> list[str]:
+        return self._call("gettips")
+
+    def get_bead_count(self) -> int:
+        return self._call("getbeadcount")
+
+    def get_cohort_count(self) -> int:
+        return self._call("getcohortcount")
+
+    def get_cohort_by_id(self, cohort_id: int) -> list[str]:
+        return self._call("getcohortbyid", [cohort_id])
+
+    def get_genesis(self) -> str:
+        return self._call("getgenesis")
+
+    def get_braid_info(self) -> dict:
+        return self._call("getbraidinfo")
+
+    def get_mining_info(self, **kwargs) -> dict:
+        return self._call("getmininginfo", kwargs or {})
+
+    def get_miner_info(self) -> list[str]:
+        return self._call("getminerinfo")
+
+    def get_parents(self, bead_hash: str) -> list[str]:
+        return self._call("getparents", [bead_hash])
+
+    def get_children(self, bead_hash: str) -> list[str]:
+        return self._call("getchildren", [bead_hash])
+
+    def get_highest_work_path_by_count(self, limit: int) -> list[str]:
+        return self._call("gethighestworkpathbycount", [limit])
+
+    def get_peer_info(self) -> dict:
+        return self._call("getpeerinfo")
+
+    def get_ipc_stats(self) -> dict:
+        return self._call("getipcstats")
+
+    def bitcoin_proxy(self, method: str, params: Any = None) -> Any:
+        return self._call("bitcoinproxy", [method, params or []])
+
+    def wait_for_ready(self, timeout: float = 30.0) -> None:
+        """Poll get_braid_info until the node responds."""
+        wait_until(
+            lambda: self._try_get_braid_info(),
+            timeout=timeout,
+            interval=0.5,
+            message=f"Node at {self.url} did not become ready",
+        )
+
+    def _try_get_braid_info(self) -> bool:
+        try:
+            self.get_braid_info()
+            return True
+        except (RpcTransportError, RpcTimeoutError):
+            return False
+
+    def wait_for_bead_count(self, minimum: int, timeout: float = 60.0) -> int:
+        """Poll get_bead_count until >= minimum. Returns the count."""
+        result: list[int] = []
+        def check() -> bool:
+            count = self.get_bead_count()
+            result[:] = [count]
+            return count >= minimum
+        wait_until(check, timeout=timeout, message=f"Bead count never reached {minimum}")
+        return result[0]
+
+    def wait_for_peers(self, minimum: int, timeout: float = 30.0) -> None:
+        """Poll get_peer_info until peer count >= minimum."""
+        wait_until(
+            lambda: len(self.get_peer_info()) >= minimum,
+            timeout=timeout,
+            message=f"Peer count never reached {minimum}",
+        )
+
+    def __getattr__(self, name: str) -> Callable[..., Any]:
+        """Dynamically handle RPC methods not explicitly defined."""
+        if name.startswith("_"):
+            raise AttributeError(f"'{self.__class__.__name__}' object has no attribute '{name}'")
+        
+        def rpc_method(*args: Any, **kwargs: Any) -> Any:
+            if args and kwargs:
+                raise ValueError(f"Cannot pass both positional and keyword arguments to RPC method {name}")
+            params = kwargs if kwargs else list(args)
+            return self._call(name, params)
+            
+        return rpc_method
+
+
+def _is_connection_refused(exc: urllib.error.URLError) -> bool:
+    reason = getattr(exc, "reason", None)
+    return isinstance(reason, ConnectionRefusedError)

--- a/tests/functional/test_framework/rpc_client.py
+++ b/tests/functional/test_framework/rpc_client.py
@@ -19,6 +19,9 @@ logger = logging.getLogger(__name__)
 
 Transport = Callable[[str, bytes, float, str | None], bytes]
 
+_MAX_HTTP_BODY_BYTES = 10 * 1024 * 1024  # 10 MiB cap on HTTP error body reads
+_RETRYABLE_OSERRORS = (ConnectionResetError, BrokenPipeError)
+
 
 class RpcError(Exception):
     """Base exception for JSON-RPC failures."""
@@ -165,7 +168,7 @@ class RpcClient:
                     raise RpcTransportError(None, f"RPC {method} authentication failed (401 Unauthorized)") from exc
                 if exc.code == 500:
                     try:
-                        return exc.read()
+                        return exc.read(_MAX_HTTP_BODY_BYTES)
                     except Exception:
                         pass
                 last_error = exc
@@ -183,7 +186,6 @@ class RpcClient:
                     log_event(self.logger, "rpc_connection_refused", level=logging.WARNING, method=method, attempt=attempt + 1)
                     raise RpcTransportError(None, f"RPC {method} connection refused") from exc
             except OSError as exc:
-                _RETRYABLE_OSERRORS = (ConnectionResetError, BrokenPipeError)
                 if not isinstance(exc, _RETRYABLE_OSERRORS) or attempt == attempts - 1:
                     log_event(self.logger, "rpc_transport_failed", level=logging.WARNING, method=method, attempt=attempt + 1, error=str(exc))
                     raise RpcTransportError(None, f"RPC {method} transport error: {exc}") from exc

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -11,7 +11,6 @@ import os
 import re
 import shlex
 import shutil
-import signal
 import subprocess
 import sys
 import tempfile
@@ -20,6 +19,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Sequence
 
+from test_framework.cleanup_manager import terminate_process_group
 from test_framework.constants import STDERR_LOG_NAME, STDOUT_LOG_NAME, TEST_EXIT_PASSED, TEST_EXIT_SKIPPED
 from test_framework.logging_utils import configure_stream_logger, log_duration, log_event, log_exception
 
@@ -96,7 +96,13 @@ class RunningJob:
         return timeout is not None and now - self.start_time > timeout
 
     def terminate(self) -> None:
-        terminate_process_group(self.process)
+        terminate_process_group(
+            self.process,
+            name=self.scheduled.script_name,
+            term_timeout=2.0,
+            kill_timeout=1.0,
+            logger=logger,
+        )
 
     def to_result(self) -> TestResult:
         if self.timed_out:
@@ -247,30 +253,6 @@ class TestHandler:
             )
         )
         log_event(logger, "runner_test_started", test=scheduled.display_name, pid=proc.pid, port_seed=scheduled.port_seed)
-
-# Function to terminate a process group, firstly with SIGTERM and a wait, then with SIGKILL if it does not exit.
-# Ignoring cases where the process is already gone. This is used for cleaning up test subprocesses on timeout or interrupt.
-def terminate_process_group(proc: subprocess.Popen) -> None:
-    """Terminate a process group robustly."""
-    if proc.poll() is not None:
-        return
-    try:
-        pgid = os.getpgid(proc.pid)
-    except OSError:
-        return
-    for sig, wait_time in ((signal.SIGTERM, 2.0), (signal.SIGTERM, 1.0), (signal.SIGKILL, 1.0)):
-        if proc.poll() is not None:
-            return
-        try:
-            log_event(logger, "runner_signal_sent", level=logging.DEBUG, pid=proc.pid, signal=sig.name)
-            os.killpg(pgid, sig)
-        except ProcessLookupError:
-            return
-        try:
-            proc.wait(timeout=wait_time)
-            return
-        except subprocess.TimeoutExpired:
-            continue
 
 
 def build_test_list(tests: list[str], *, extended: bool, exclude: str | None, pattern: str | None) -> list[str]:


### PR DESCRIPTION
This PR advances #463. 
Three main modules are implemented in this PR:
- rpc_client: for handling and providing RPCs of braidpool nodes to the test framework
- miner_manager: starting and handling the lifecycle of the CPU miner
- cleanup_manager: for handling cleanup of all the processes run by the tests, ensuring memory safety.

This PR is a follow up pr for #468 