### PR TITLE
Fix(tests): replace hardcoded stratum ports with OS-assigned port 0

### DIFF
--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -254,6 +254,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                 notification_tx_clone,
                 swarm_handler_arc.clone(),
                 spin_lock_ref,
+                None,
             )
             .await;
     });

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -19,7 +19,7 @@ use tokio::{
         tcp::{OwnedReadHalf, OwnedWriteHalf},
         TcpListener,
     },
-    sync::{mpsc, RwLock},
+    sync::{mpsc, oneshot, RwLock},
 };
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -1783,6 +1783,7 @@ impl Server {
         notification_sender: mpsc::Sender<NotifyCmd>,
         swarm_handler: Arc<Mutex<SwarmHandler>>,
         ibd_or_not: Arc<AtomicBool>,
+        bound_addr_tx: Option<oneshot::Sender<SocketAddr>>,
     ) -> Result<(), Box<std::io::Error>> {
         debug!("Starting stratum server");
         let bind_address = format!(
@@ -1796,6 +1797,9 @@ impl Server {
                 return Err(Box::new(e));
             }
         };
+        if let Some(tx) = bound_addr_tx {
+            let _ = tx.send(listener.local_addr()?);
+        }
 
         let endpoints = crate::utils::server_endpoints(
             &self.stratum_config.hostname,
@@ -2066,7 +2070,7 @@ mod test {
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
         net::TcpStream,
-        sync::{mpsc, RwLock},
+        sync::{mpsc, oneshot, RwLock},
     };
 
     #[tokio::test]
@@ -2085,11 +2089,12 @@ mod test {
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
         let config = StratumServerConfig {
             hostname: "127.0.0.1".to_string(),
-            port: 3353,
+            port: 0,
             ..Default::default()
         };
 
         let mut server = Server::new(config.clone(), connection_mapping.clone(), None);
+        let (addr_tx, addr_rx) = oneshot::channel();
 
         let server_task = tokio::spawn(async move {
             let _ = server
@@ -2098,13 +2103,13 @@ mod test {
                     notify_tx,
                     swarm_handler_arc,
                     test_ibd_spinlock.clone(),
+                    Some(addr_tx),
                 )
                 .await;
         });
 
-        tokio::time::sleep(Duration::from_millis(300)).await;
-
-        let addr = format!("{}:{}", config.hostname, config.port);
+        let bound_addr = addr_rx.await.unwrap();
+        let addr = bound_addr.to_string();
         let mut mock_connection_handles = Vec::new();
         for i in 0..3 {
             let addr_clone = addr.clone();
@@ -2151,11 +2156,12 @@ mod test {
 
         let config = StratumServerConfig {
             hostname: "127.0.0.1".to_string(),
-            port: 3356,
+            port: 0,
             ..Default::default()
         };
 
         let mut server = Server::new(config.clone(), connection_mapping.clone(), None);
+        let (addr_tx, addr_rx) = oneshot::channel();
 
         let server_task = tokio::spawn(async move {
             let _ = server
@@ -2164,14 +2170,13 @@ mod test {
                     notify_tx,
                     swarm_handler_arc,
                     test_ibd_spinlock,
+                    Some(addr_tx),
                 )
                 .await;
         });
 
-        tokio::time::sleep(Duration::from_millis(300)).await;
-
-        let addr = format!("{}:{}", config.hostname, config.port);
-        let mut stream = TcpStream::connect(&addr).await.unwrap();
+        let bound_addr = addr_rx.await.unwrap();
+        let mut stream = TcpStream::connect(bound_addr).await.unwrap();
 
         let msg = r#"{"id":1,"method":"mining.subscribe","params":[]}"#;
         stream.write_all(msg.as_bytes()).await.unwrap();
@@ -2200,12 +2205,12 @@ mod test {
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
         let config = StratumServerConfig {
             hostname: "127.0.0.1".to_string(),
-            port: 3357,
+            port: 0,
             ..Default::default()
         };
 
-        let port = config.port;
         let mut server = Server::new(config, connection_mapping, None);
+        let (addr_tx, addr_rx) = oneshot::channel();
         tokio::spawn(async move {
             let _ = server
                 .run_stratum_service(
@@ -2213,14 +2218,13 @@ mod test {
                     notify_tx,
                     swarm_handler_arc,
                     ibd_spinlock.clone(),
+                    Some(addr_tx),
                 )
                 .await;
         });
 
-        tokio::time::sleep(Duration::from_millis(300)).await;
-
-        let addr = format!("127.0.0.1:{}", port);
-        let mut stream = TcpStream::connect(&addr).await.unwrap();
+        let bound_addr = addr_rx.await.unwrap();
+        let mut stream = TcpStream::connect(bound_addr).await.unwrap();
 
         let request = r#"{"id":2,"method":"mining.authorize","params":["satoshi","braidpool"]}"#;
         stream.write_all(request.as_bytes()).await.unwrap();
@@ -2251,11 +2255,11 @@ mod test {
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
         let config = StratumServerConfig {
             hostname: "127.0.0.1".to_string(),
-            port: 3358,
+            port: 0,
             ..Default::default()
         };
-        let port = config.port;
         let mut server = Server::new(config, connection_mapping, None);
+        let (addr_tx, addr_rx) = oneshot::channel();
         tokio::spawn(async move {
             let _ = server
                 .run_stratum_service(
@@ -2263,12 +2267,12 @@ mod test {
                     notify_tx,
                     swarm_handler_arc,
                     ibd_spinlock.clone(),
+                    Some(addr_tx),
                 )
                 .await;
         });
-        tokio::time::sleep(Duration::from_millis(300)).await;
-        let addr = format!("127.0.0.1:{}", port);
-        let mut stream = TcpStream::connect(&addr).await.unwrap();
+        let bound_addr = addr_rx.await.unwrap();
+        let mut stream = TcpStream::connect(bound_addr).await.unwrap();
         let request = r#"{"id":3,"method":"mining.suggest_difficulty","params":[1000]}"#;
         stream.write_all(request.as_bytes()).await.unwrap();
         stream.write_all(b"\n").await.unwrap();
@@ -2295,28 +2299,28 @@ mod test {
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
         let config = StratumServerConfig {
             hostname: "127.0.0.1".to_string(),
-            port: 5050,
+            port: 0,
             ..Default::default()
         };
 
         let mut server = Server::new(config, connection_mapping.clone(), None);
         let mining_job_map_clone = mining_job_map.clone();
         let notify_tx_clone = notify_tx.clone();
+        let (addr_tx, addr_rx) = oneshot::channel();
         tokio::spawn(async move {
-            server
+            let _ = server
                 .run_stratum_service(
                     mining_job_map_clone,
                     notify_tx_clone,
                     swarm_handler_arc,
                     ibd_spinlock,
+                    Some(addr_tx),
                 )
-                .await
-                .unwrap();
+                .await;
         });
 
-        tokio::time::sleep(std::time::Duration::from_millis(200)).await;
-
-        let mut stream = TcpStream::connect("127.0.0.1:5050").await.unwrap();
+        let bound_addr = addr_rx.await.unwrap();
+        let mut stream = TcpStream::connect(bound_addr).await.unwrap();
 
         stream
             .write_all(b"{\"method\":\"mining.subscribe\", \"params\": [\"test\", 1]\n")

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1797,19 +1797,20 @@ impl Server {
                 return Err(Box::new(e));
             }
         };
+        let bound_addr = listener.local_addr()?;
         if let Some(tx) = bound_addr_tx {
-            let _ = tx.send(listener.local_addr()?);
+            let _ = tx.send(bound_addr);
         }
 
         let endpoints = crate::utils::server_endpoints(
             &self.stratum_config.hostname,
-            self.stratum_config.port,
+            bound_addr.port(),
             "stratum+tcp",
         );
         if endpoints.is_empty() {
             warn!(
                 host = %self.stratum_config.hostname,
-                port = %self.stratum_config.port,
+                port = %bound_addr.port(),
                 "Server listening but no interfaces were discovered"
             );
         } else {


### PR DESCRIPTION
While reviewing PRs #309 and #474, I kept seeing test_invalid_json fail with AddrInUse on port 5050. Looking into it, all five stratum tests bind fixed ports (3353, 3356, 3357, 3358, 5050), if a previous test leaves a 
server running or two tests race to bind the same port, the test fails with a misleading error that looks like a code bug rather than a port conflict.

The fix adds an optional oneshot channel parameter to run_stratum_service. After binding, the server sends its actual address back through the channel. Tests use port 0 so the OS assigns a free port, then await the receiver before connecting with no sleep, race windows, or hardcoded ports.

rpc_server.rs already uses the same pattern via server.local_addr(), so this is consistent with how the rest of the codebase handles this.

Production call in main.rs passes None, zero impact outside tests.