### PR TITLE
Updating db handlers for orphan insertions and batched queries 

### DIFF
--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -1,4 +1,5 @@
 use crate::bead::Bead;
+use crate::error::BraidError;
 use crate::utils::BeadHash;
 use num::BigUint;
 use serde::{Deserialize, Serialize};
@@ -241,23 +242,25 @@ impl Braid {
         }
         promoted
     }
-
-    pub fn resolve_parents(&self, bead: &Bead) -> Vec<(u64, u32)> {
+    pub fn resolve_parents(&self, bead: &Bead) -> Result<Vec<(u64, u32)>, BraidError> {
         bead.committed_metadata
             .parents
             .iter()
-            .filter_map(|parent_hash| {
-                self.bead_index_mapping
-                    .get(parent_hash)
-                    .map(|&parent_index| {
-                        (
-                            parent_index as u64,
-                            self.beads[parent_index]
-                                .committed_metadata
-                                .start_timestamp
-                                .to_u32(),
-                        )
-                    })
+            .map(|parent_hash| {
+                let &parent_index =
+                    self.bead_index_mapping
+                        .get(parent_hash)
+                        .ok_or(BraidError::MissingParent {
+                            bead: bead.block_header.block_hash(),
+                            parent: *parent_hash,
+                        })?;
+                Ok((
+                    parent_index as u64,
+                    self.beads[parent_index]
+                        .committed_metadata
+                        .start_timestamp
+                        .to_u32(),
+                ))
             })
             .collect()
     }

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -242,6 +242,26 @@ impl Braid {
         promoted
     }
 
+    pub fn resolve_parents(&self, bead: &Bead) -> Vec<(u64, u32)> {
+        bead.committed_metadata
+            .parents
+            .iter()
+            .filter_map(|parent_hash| {
+                self.bead_index_mapping
+                    .get(parent_hash)
+                    .map(|&parent_index| {
+                        (
+                            parent_index as u64,
+                            self.beads[parent_index]
+                                .committed_metadata
+                                .start_timestamp
+                                .to_u32(),
+                        )
+                    })
+            })
+            .collect()
+    }
+
     pub fn check_genesis_beads(&self, genesis_beads: &Vec<BeadHash>) -> GenesisCheckStatus {
         if (genesis_beads.len() != self.genesis_beads.len()) {
             return GenesisCheckStatus::GenesisBeadsCountMismatch;
@@ -249,7 +269,7 @@ impl Braid {
         for bead_hash in genesis_beads {
             let index = self.bead_index_mapping.get(bead_hash);
             let bead_exists = match index {
-                Some(idx) => self.genesis_beads.contains(idx),
+                Some(&idx) => self.genesis_beads.contains(&idx),
                 None => false,
             };
             if !bead_exists {

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -84,8 +84,9 @@ impl DBHandler {
             db_handler_tx,
         ))
     }
+    /// Builds the `(transactions, relatives, parent_timestamps)` JSON value tuples for a single
+    /// bead.
     fn prepare_bead_tuple_values(
-        &self,
         data: &BeadInsertData,
     ) -> (
         Vec<serde_json::Value>,
@@ -131,7 +132,7 @@ impl DBHandler {
             let bead = &data.bead;
             let bead_id = data.bead_id;
 
-            let (txs, relatives, parent_ts) = self.prepare_bead_tuple_values(data);
+            let (txs, relatives, parent_ts) = Self::prepare_bead_tuple_values(data);
 
             all_bead_data.push(json!({
                 "id": bead_id as i64,
@@ -275,7 +276,12 @@ impl DBHandler {
                     inserted_count = inserted_count,
                     "Bulk insert chunk failed, rolling back"
                 );
-                local_transaction.rollback().await.ok();
+                if let Err(rollback_err) = local_transaction.rollback().await {
+                    error!(
+                        error = ?rollback_err,
+                        "Failed to roll back batch transaction after chunk insert failure"
+                    );
+                }
                 return Err(e);
             }
             inserted_count += chunk.len() as u32;
@@ -758,162 +764,86 @@ pub mod test {
         let (current_file_braid, _file_braid) =
             loading_braid_from_file(file_path.to_str().unwrap());
 
-        let mut all_bead_data = Vec::new();
-        let mut all_txs_json_parts = Vec::new();
-        let mut all_relatives_json_parts = Vec::new();
-        let mut all_parent_ts_json_parts = Vec::new();
+        let mut bead_insert_data =
+            BeadInsertData::resolve_many(&current_file_braid, current_file_braid.beads.iter())
+                .expect("resolve_many failed: a bead or parent was missing from the braid index");
+        assert_eq!(
+            bead_insert_data.len(),
+            current_file_braid.beads.len(),
+            "resolve_many dropped beads"
+        );
+        // Splitting a dummy orphan bead from all the beads in the existing braid test file
+        // for testing the orphan insertions as well .
+        let split_at = bead_insert_data.len().saturating_sub(1);
+        let orphans = bead_insert_data.split_off(split_at);
+        println!("{orphans:?}");
+        let beads = bead_insert_data;
 
-        for bead in current_file_braid.beads.iter() {
-            let bead_id = *current_file_braid
-                .bead_index_mapping
-                .get(&bead.block_header.block_hash())
-                .unwrap();
-
-            all_bead_data.push(json!({
-                "id": bead_id as i64,
-                "hash": hex::encode(bead.block_header.block_hash().to_byte_array()),
-                "nVersion": bead.block_header.version.to_consensus(),
-                "hashPrevBlock": hex::encode(bead.block_header.prev_blockhash.to_byte_array()),
-                "hashMerkleRoot": hex::encode(bead.block_header.merkle_root.to_byte_array()),
-                "nTime": bead.block_header.time.to_u32(),
-                "nBits": bead.block_header.bits.to_consensus(),
-                "nNonce": bead.block_header.nonce,
-                "payout_address": hex::encode(bead.committed_metadata.payout_address.as_bytes()),
-                "start_timestamp": bead.committed_metadata.start_timestamp.to_u32(),
-                "comm_pub_key": hex::encode(bead.committed_metadata.comm_pub_key.to_bytes()),
-                "min_target": bead.committed_metadata.min_target.to_consensus(),
-                "weak_target": bead.committed_metadata.weak_target.to_consensus(),
-                "miner_ip": bead.committed_metadata.miner_ip.clone(),
-                "extranonce1": hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes()),
-                "extranonce2": hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes()),
-                "broadcast_timestamp": bead.uncommitted_metadata.broadcast_timestamp.to_u32(),
-                "signature": hex::encode(bead.uncommitted_metadata.signature.to_vec()),
-            }));
-
-            for bead_tx in bead.committed_metadata.transaction_ids.0.iter() {
-                all_txs_json_parts.push(json!({
-                    "txid": hex::encode(bead_tx.to_byte_array()),
-                    "bead_id": bead_id as u64
-                }));
-            }
-            // Add dummy tx for testing
-            all_txs_json_parts.push(json!({
-                "txid": "b1a6cecc2e40e89e9e943c3c010c1f6ca6dd1530361ead7289254d929ee4eb2a",
-                "bead_id": bead_id as u64
-            }));
-
-            for parent_hash in &bead.committed_metadata.parents {
-                let parent_index = *current_file_braid
-                    .bead_index_mapping
-                    .get(parent_hash)
-                    .unwrap();
-                let parent_timestamp = current_file_braid.beads[parent_index]
-                    .committed_metadata
-                    .start_timestamp
-                    .to_u32();
-
-                all_relatives_json_parts.push(json!({
-                    "parent": parent_index as u64,
-                    "child": bead_id as u64
-                }));
-
-                all_parent_ts_json_parts.push(json!({
-                    "parent": parent_index as u64,
-                    "child": bead_id as u64,
-                    "timestamp": parent_timestamp
-                }));
-            }
-        }
-
-        let beads_json = serde_json::to_string(&all_bead_data).unwrap();
-        let txs_json = serde_json::to_string(&all_txs_json_parts).unwrap();
-        let relatives_json = serde_json::to_string(&all_relatives_json_parts).unwrap();
-        let parent_ts_json = serde_json::to_string(&all_parent_ts_json_parts).unwrap();
-
-        // Execute bulk inserts separately (as the fix does)
-        let mut test_insertion_tx = test_pool.begin().await.unwrap();
-
-        if let Err(e) = sqlx::query(BULK_INSERT_BEADS)
-            .bind(&beads_json)
-            .execute(&mut *test_insertion_tx)
+        // Drive the real batched-insert code path over the in-memory test pool.
+        let (_db_tx, db_rx) = tokio::sync::mpsc::channel::<BraidpoolDBTypes>(DB_CHANNEL_CAPACITY);
+        let handler = DBHandler {
+            receiver: db_rx,
+            db_connection_pool: test_pool.clone(),
+        };
+        handler
+            .insert_beads_batch(beads, orphans)
             .await
-        {
-            panic!("Bulk insert beads failed: {:?}", e);
-        }
+            .expect("Batch insertion via production path failed");
 
-        if let Err(e) = sqlx::query(BULK_INSERT_TRANSACTIONS)
-            .bind(&txs_json)
-            .execute(&mut *test_insertion_tx)
-            .await
-        {
-            panic!("Bulk insert transactions failed: {:?}", e);
-        }
+        // Expected row counts derived directly from the braid.
+        let expected_beads = current_file_braid.beads.len();
+        let expected_txs: usize = current_file_braid
+            .beads
+            .iter()
+            .map(|b| b.committed_metadata.transaction_ids.0.len())
+            .sum();
+        // Relatives and ParentTimestamps are both produced from `resolve_parents`,
+        // so they share the same expected cardinality.
+        let expected_relatives: usize = current_file_braid
+            .beads
+            .iter()
+            .map(|b| current_file_braid.resolve_parents(b).unwrap().len())
+            .sum();
 
-        if let Err(e) = sqlx::query(BULK_INSERT_RELATIVES)
-            .bind(&relatives_json)
-            .execute(&mut *test_insertion_tx)
-            .await
-        {
-            panic!("Bulk insert relatives failed: {:?}", e);
-        }
-
-        if let Err(e) = sqlx::query(BULK_INSERT_PARENT_TIMESTAMPS)
-            .bind(&parent_ts_json)
-            .execute(&mut *test_insertion_tx)
-            .await
-        {
-            panic!("Bulk insert parent timestamps failed: {:?}", e);
-        }
-
-        test_insertion_tx.commit().await.unwrap();
-
-        // Verify bead table has correct count
         let bead_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bead")
             .fetch_one(&test_pool)
             .await
             .unwrap();
-        assert_eq!(
-            bead_count as usize,
-            current_file_braid.beads.len(),
-            "Bead count mismatch"
-        );
+        assert_eq!(bead_count as usize, expected_beads, "Bead count mismatch");
 
         let tx_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Transactions")
             .fetch_one(&test_pool)
             .await
             .unwrap();
+        assert_eq!(
+            tx_count as usize, expected_txs,
+            "Transactions count mismatch"
+        );
 
         let relatives_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Relatives")
             .fetch_one(&test_pool)
             .await
             .unwrap();
+        assert_eq!(
+            relatives_count as usize, expected_relatives,
+            "Relatives count mismatch"
+        );
 
         let parent_ts_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ParentTimestamps")
             .fetch_one(&test_pool)
             .await
             .unwrap();
-        let expected_parent_ts = all_parent_ts_json_parts.len();
-
-        if expected_parent_ts > 0 {
-            assert_eq!(
-                parent_ts_count as usize, expected_parent_ts,
-                "ParentTimestamps count mismatch"
-            );
-        }
+        assert_eq!(
+            parent_ts_count as usize, expected_relatives,
+            "ParentTimestamps count mismatch"
+        );
 
         for bead in current_file_braid.beads.iter() {
-            let fetched_test_bead =
-                fetch_bead_by_bead_hash(&test_pool, bead.block_header.block_hash())
-                    .await
-                    .unwrap();
+            let fetched = fetch_bead_by_bead_hash(&test_pool, bead.block_header.block_hash())
+                .await
+                .unwrap()
+                .unwrap_or_else(|| panic!("Bead not found: {}", bead.block_header.block_hash()));
 
-            assert!(
-                fetched_test_bead.is_some(),
-                "Bead not found: {}",
-                bead.block_header.block_hash()
-            );
-
-            let fetched = fetched_test_bead.unwrap();
             assert_eq!(
                 fetched.block_header.block_hash().to_string(),
                 bead.block_header.block_hash().to_string()

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -1,62 +1,72 @@
-#[cfg(test)]
-use crate::braid::consensus_functions;
 use crate::{
     bead::Bead,
-    db::{init_db::init_db, BraidpoolDBTypes, InsertTupleTypes},
+    db::{init_db::init_db, BeadInsertData, BraidpoolDBTypes, InsertTupleTypes},
     error::DBErrors,
-    utils::BeadHash,
 };
 use bitcoin::{
     absolute::MedianTimePast, ecdsa::Signature, BlockHash, BlockTime, BlockVersion, CompactTarget,
     PublicKey, TxMerkleNode, Txid,
 };
-use futures::lock::Mutex;
-use num::ToPrimitive;
 use serde_json::json;
 use sqlx::{Pool, Row, Sqlite};
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::collections::HashMap;
 use tokio::sync::mpsc::{Receiver, Sender};
-#[allow(unused_imports)]
-use tracing::{debug, error, info, trace, warn};
-const DB_CHANNEL_CAPACITY: usize = 1024;
-const INSERT_QUERY: &'static str = "
-INSERT INTO bead (
-    id, hash, nVersion, hashPrevBlock, hashMerkleRoot, nTime,
-    nBits, nNonce, payout_address, start_timestamp, comm_pub_key,
-    min_target, weak_target, miner_ip, extranonce1, extranonce2,
-    broadcast_timestamp, signature
-)
-VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,?);
+#[cfg(test)]
+use tracing::info;
+use tracing::{debug, error, trace};
+pub const DB_CHANNEL_CAPACITY: usize = 1024;
+/// Maximum number of beads (including orphans) to insert in a single bulk query to limit the memory consumption
+pub const BATCH_INSERT_THRESHOLD: usize = 500;
+//Bulk insertion sub-queries
+const BULK_INSERT_BEADS: &'static str =
+    "INSERT INTO bead (id, hash, nVersion, hashPrevBlock, hashMerkleRoot, nTime, 
+        nBits, nNonce, payout_address, start_timestamp, comm_pub_key, min_target, 
+        weak_target, miner_ip, extranonce1, extranonce2, broadcast_timestamp, signature) 
+    SELECT 
+        json_extract(value, '$.id'), 
+        unhex(json_extract(value, '$.hash')), 
+        json_extract(value, '$.nVersion'), 
+        unhex(json_extract(value, '$.hashPrevBlock')), 
+        unhex(json_extract(value, '$.hashMerkleRoot')), 
+        json_extract(value, '$.nTime'), 
+        json_extract(value, '$.nBits'), 
+        json_extract(value, '$.nNonce'),
+        unhex(json_extract(value, '$.payout_address')),
+        json_extract(value, '$.start_timestamp'),
+        unhex(json_extract(value, '$.comm_pub_key')), 
+        json_extract(value, '$.min_target'), 
+        json_extract(value, '$.weak_target'), 
+        json_extract(value, '$.miner_ip'), 
+        json_extract(value, '$.extranonce1'), 
+        json_extract(value, '$.extranonce2'), 
+        json_extract(value, '$.broadcast_timestamp'), 
+        unhex(json_extract(value, '$.signature')) 
+    FROM json_each(?);";
+//Separating into sub-queries
+const BULK_INSERT_TRANSACTIONS: &'static str = "INSERT INTO Transactions (bead_id, txid) 
+    SELECT json_extract(value, '$.bead_id'), unhex(json_extract(value, '$.txid')) 
+    FROM json_each(?);";
 
-INSERT INTO Transactions (bead_id, txid)
-SELECT
-    json_extract(value, '$.bead_id') AS bead_id,
-    unhex(json_extract(value, '$.txid')) AS txid
-FROM json_each(?);
+const BULK_INSERT_RELATIVES: &'static str = "INSERT INTO Relatives (child, parent) 
+    SELECT json_extract(value, '$.child'), json_extract(value, '$.parent') 
+    FROM json_each(?);";
 
-INSERT INTO Relatives (child, parent)
-SELECT json_extract(value,'$.child') AS child,
-    json_extract(value,'$.parent') AS PARENT
-FROM json_each(?);
-
-INSERT INTO ParentTimestamps (parent, child, timestamp)
-SELECT json_extract(value,'$.parent') AS parent,
-    json_extract(value,'$.child') AS child,
-    json_extract(value,'$.timestamp') AS timestamp
-FROM json_each(?);
-";
+const BULK_INSERT_PARENT_TIMESTAMPS: &'static str =
+    "INSERT INTO ParentTimestamps (parent, child, timestamp) 
+    SELECT json_extract(value, '$.parent'), json_extract(value, '$.child'), 
+        json_extract(value, '$.timestamp') 
+    FROM json_each(?);";
 #[derive(Debug)]
 pub struct DBHandler {
     //Query receiver inherit to handler only
     receiver: Receiver<BraidpoolDBTypes>,
     //Shared across tasks for accessing DB after contention using `Mutex`
-    pub db_connection_pool: Arc<Mutex<Pool<Sqlite>>>,
+    pub db_connection_pool: Pool<Sqlite>,
 }
 impl DBHandler {
     pub async fn new() -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
         debug!("Initializing schema for persistent database");
-        let connection = match init_db().await {
+        let db_connection_pool = match init_db().await {
             Ok(conn) => conn,
             Err(error) => {
                 error!(error = ?error, "Failed to initialize database connection");
@@ -69,96 +79,225 @@ impl DBHandler {
         Ok((
             Self {
                 receiver: db_handler_rx,
-                db_connection_pool: Arc::new(Mutex::new(connection)),
+                db_connection_pool,
             },
             db_handler_tx,
         ))
     }
-    //Insertion handlers private
-    pub async fn insert_bead(
+    fn prepare_bead_tuple_values(
         &self,
-        bead: Bead,
-        txs_json: String,
-        relative_json: String,
-        parent_timestamp_json: String,
-        bead_id: &usize,
+        data: &BeadInsertData,
+    ) -> (
+        Vec<serde_json::Value>,
+        Vec<serde_json::Value>,
+        Vec<serde_json::Value>,
+    ) {
+        let bead_id = data.bead_id as u64;
+        let mut relatives_values = Vec::with_capacity(data.parent_refs.len());
+        let mut parent_ts_values = Vec::with_capacity(data.parent_refs.len());
+        for (parent_id, parent_timestamp) in &data.parent_refs {
+            relatives_values.push(json!({ "parent": *parent_id, "child": bead_id }));
+            parent_ts_values.push(json!({
+                "child": bead_id,
+                "parent": *parent_id,
+                "timestamp": *parent_timestamp,
+            }));
+            debug!("Parent found with id - {:?}", parent_id);
+        }
+        let mut txs_values =
+            Vec::with_capacity(data.bead.committed_metadata.transaction_ids.0.len());
+        for tx in &data.bead.committed_metadata.transaction_ids.0 {
+            txs_values.push(json!({
+                "txid": hex::encode(tx.to_byte_array()),
+                "bead_id": bead_id,
+            }));
+        }
+        (txs_values, relatives_values, parent_ts_values)
+    }
+
+    /// Inserting chunks for bulk insertions
+    async fn bulk_insert_chunk(
+        &self,
+        local_transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
+        chunk: &[BeadInsertData],
     ) -> Result<(), DBErrors> {
-        trace!("Sequential insertion query received");
-        let hex_converted_extranonce_1 =
-            hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes());
-        let hex_converted_extranonce_2 =
-            hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes());
-        let block_header_bytes = bead.block_header.block_hash().to_byte_array().to_vec();
-        let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
-        let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
-        let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
-        let public_key_bytes = bead.committed_metadata.comm_pub_key.to_vec();
-        let signature_bytes = bead.uncommitted_metadata.signature.to_vec();
-        let mut conn = match self.db_connection_pool.lock().await.begin().await {
-            Ok(conn) => conn,
+        let mut all_bead_data = Vec::with_capacity(chunk.len());
+        let mut all_txs_json_parts = Vec::new();
+        let mut all_relatives_json_parts = Vec::new();
+        let mut all_parent_ts_json_parts = Vec::new();
+
+        for data in chunk {
+            // For each chunk constructing the query placeholders
+            let bead = &data.bead;
+            let bead_id = data.bead_id;
+
+            let (txs, relatives, parent_ts) = self.prepare_bead_tuple_values(data);
+
+            all_bead_data.push(json!({
+                "id": bead_id as i64,
+                "hash": hex::encode(bead.block_header.block_hash().to_byte_array()),
+                "nVersion": bead.block_header.version.to_consensus(),
+                "hashPrevBlock": hex::encode(bead.block_header.prev_blockhash.to_byte_array()),
+                "hashMerkleRoot": hex::encode(bead.block_header.merkle_root.to_byte_array()),
+                "nTime": bead.block_header.time.to_u32(),
+                "nBits": bead.block_header.bits.to_consensus(),
+                "nNonce": bead.block_header.nonce,
+                "payout_address": hex::encode(bead.committed_metadata.payout_address.as_bytes()),
+                "start_timestamp": bead.committed_metadata.start_timestamp.to_u32(),
+                "comm_pub_key": hex::encode(bead.committed_metadata.comm_pub_key.to_bytes()),
+                "min_target": bead.committed_metadata.min_target.to_consensus(),
+                "weak_target": bead.committed_metadata.weak_target.to_consensus(),
+                "miner_ip": bead.committed_metadata.miner_ip.clone(),
+                "extranonce1": hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes()),
+                "extranonce2": hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes()),
+                "broadcast_timestamp": bead.uncommitted_metadata.broadcast_timestamp.to_u32(),
+                "signature": hex::encode(bead.uncommitted_metadata.signature.to_vec()),
+            }));
+            all_txs_json_parts.extend(txs);
+            all_relatives_json_parts.extend(relatives);
+            all_parent_ts_json_parts.extend(parent_ts);
+        }
+
+        let beads_json = serde_json::to_string(&all_bead_data).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "bulk_beads".to_string(),
+            }
+        })?;
+        let txs_json = serde_json::to_string(&all_txs_json_parts).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "bulk_transactions".to_string(),
+            }
+        })?;
+        let relatives_json = serde_json::to_string(&all_relatives_json_parts).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "bulk_relatives".to_string(),
+            }
+        })?;
+        let parent_ts_json = serde_json::to_string(&all_parent_ts_json_parts).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "bulk_parent_timestamps".to_string(),
+            }
+        })?;
+
+        // Execute each bulk insert separately within the same transaction
+        sqlx::query(BULK_INSERT_BEADS)
+            .bind(&beads_json)
+            .execute(&mut **local_transaction)
+            .await
+            .map_err(|e| {
+                error!(error = ?e, "Bulk insert beads failed");
+                DBErrors::InsertionTransactionNotCommitted {
+                    error: e.to_string(),
+                    query_name: "Bulk insert beads".to_string(),
+                }
+            })?;
+
+        sqlx::query(BULK_INSERT_TRANSACTIONS)
+            .bind(&txs_json)
+            .execute(&mut **local_transaction)
+            .await
+            .map_err(|e| {
+                error!(error = ?e, "Bulk insert transactions failed");
+                DBErrors::InsertionTransactionNotCommitted {
+                    error: e.to_string(),
+                    query_name: "Bulk insert transactions".to_string(),
+                }
+            })?;
+
+        sqlx::query(BULK_INSERT_RELATIVES)
+            .bind(&relatives_json)
+            .execute(&mut **local_transaction)
+            .await
+            .map_err(|e| {
+                error!(error = ?e, "Bulk insert relatives failed");
+                DBErrors::InsertionTransactionNotCommitted {
+                    error: e.to_string(),
+                    query_name: "Bulk insert relatives".to_string(),
+                }
+            })?;
+
+        sqlx::query(BULK_INSERT_PARENT_TIMESTAMPS)
+            .bind(&parent_ts_json)
+            .execute(&mut **local_transaction)
+            .await
+            .map_err(|e| {
+                error!(error = ?e, "Bulk insert parent timestamps failed");
+                DBErrors::InsertionTransactionNotCommitted {
+                    error: e.to_string(),
+                    query_name: "Bulk insert parent timestamps".to_string(),
+                }
+            })?;
+
+        Ok(())
+    }
+
+    /// Inserts a batch of beads, batches that are larger than BATCH_INSERT_THRESHOLD are split into bulk chunks of that size .
+    async fn insert_beads_batch(
+        &self,
+        beads: Vec<BeadInsertData>,
+        orphans: Vec<BeadInsertData>,
+    ) -> Result<(), DBErrors> {
+        let total_count = beads.len() + orphans.len();
+        // Dividing into number of chunks
+        let chunk_count = total_count.div_ceil(BATCH_INSERT_THRESHOLD).max(1);
+
+        debug!(
+            bead_count = beads.len(),
+            orphan_count = orphans.len(),
+            total = total_count,
+            chunk_size = BATCH_INSERT_THRESHOLD,
+            chunk_count = chunk_count,
+            "Batch insertion query received"
+        );
+
+        let mut local_transaction = match self.db_connection_pool.begin().await {
+            Ok(local_transaction) => local_transaction,
             Err(err) => {
-                error!("Failed to begin DB transaction: {}", err);
+                error!("Failed to begin DB batch transaction: {}", err);
                 return Err(DBErrors::ConnectionToSQlitePoolFailed {
                     error: err.to_string(),
                 });
             }
         };
-        //All fields are in be format
-        if let Err(e) = sqlx::query(&INSERT_QUERY)
-            .bind(*bead_id as i64)
-            .bind(block_header_bytes)
-            .bind(bead.block_header.version.to_consensus())
-            .bind(prev_block_hash_bytes)
-            .bind(merkle_root_bytes)
-            .bind(bead.block_header.time.to_u32())
-            .bind(bead.block_header.bits.to_consensus())
-            .bind(bead.block_header.nonce)
-            .bind(payout_addr_bytes)
-            .bind(bead.committed_metadata.start_timestamp.to_u32())
-            .bind(public_key_bytes)
-            .bind(bead.committed_metadata.min_target.to_consensus())
-            .bind(bead.committed_metadata.weak_target.to_consensus())
-            .bind(bead.committed_metadata.miner_ip)
-            .bind(hex_converted_extranonce_1.to_string())
-            .bind(hex_converted_extranonce_2.to_string())
-            .bind(bead.uncommitted_metadata.broadcast_timestamp.to_u32())
-            .bind(signature_bytes)
-            .bind(txs_json)
-            .bind(relative_json)
-            .bind(parent_timestamp_json)
-            .execute(&mut *conn)
-            .await
-        {
-            error!(error = ?e, "Transaction failed, rolling back");
-            match conn.rollback().await {
-                Ok(_) => {
-                    info!("Transaction rollbacked successfully and not committed");
-                    return Err(DBErrors::InsertionTransactionNotCommitted {
-                        error: e.to_string(),
-                        query_name: "Combined insert transaction".to_string(),
-                    });
-                }
-                Err(error) => {
-                    error!(error = ?error, "Failed to rollback transaction");
-                    return Err(DBErrors::TransactionNotRolledBack {
-                        error: error.to_string(),
-                        query: "Insertion of Bead".to_string(),
-                    });
-                }
+
+        let all_beads: Vec<BeadInsertData> = beads.into_iter().chain(orphans).collect();
+        let mut inserted_count = 0u32;
+        // Iterating through each chunk and inserting the corrsponding chunk
+        for chunk in all_beads.chunks(BATCH_INSERT_THRESHOLD) {
+            if let Err(e) = self.bulk_insert_chunk(&mut local_transaction, chunk).await {
+                error!(
+                    error = ?e,
+                    chunk_size = chunk.len(),
+                    inserted_count = inserted_count,
+                    "Bulk insert chunk failed, rolling back"
+                );
+                local_transaction.rollback().await.ok();
+                return Err(e);
             }
+            inserted_count += chunk.len() as u32;
         }
-        match conn.commit().await {
+
+        match local_transaction.commit().await {
             Ok(_) => {
-                debug!("Transaction committed and not rolledback successfully");
+                debug!(
+                    bead_count = inserted_count,
+                    chunk_count = chunk_count,
+                    "Batch transaction committed successfully"
+                );
             }
             Err(error) => {
-                error!(error = ?error, "Failed to commit transaction");
+                error!(error = ?error, "Failed to commit batch transaction");
                 return Err(DBErrors::InsertionTransactionNotCommitted {
                     error: error.to_string(),
-                    query_name: "Combined insert transaction".to_string(),
+                    query_name: "Batch insert transaction".to_string(),
                 });
             }
         };
+
         Ok(())
     }
     //Individual insertion operations
@@ -166,117 +305,39 @@ impl DBHandler {
         debug!("Query handler task started");
         while let Some(query_request) = self.receiver.recv().await {
             match query_request {
-                BraidpoolDBTypes::InsertTupleTypes { query } => match query {
-                    InsertTupleTypes::InsertBeadSequentially {
-                        bead_to_insert,
-                        txs_json,
-                        relative_json,
-                        parent_timestamp_json,
-                        bead_id,
-                    } => {
-                        let bead_hash = bead_to_insert.block_header.block_hash();
-                        match self
-                            .insert_bead(
-                                bead_to_insert,
-                                txs_json,
-                                relative_json,
-                                parent_timestamp_json,
-                                &bead_id,
-                            )
-                            .await
-                        {
-                            Ok(_) => {
-                                debug!(
-                                    bead_id = bead_id,
-                                    bead_hash = %bead_hash,
-                                    "Bead inserted successfully"
-                                );
-                            }
-                            Err(error) => {
-                                error!(
-                                    error = ?error,
-                                    bead_id = bead_id,
-                                    bead_hash = %bead_hash,
-                                    "Failed to insert bead"
-                                );
-                                continue;
-                            }
-                        };
+                BraidpoolDBTypes::InsertTupleTypes {
+                    query:
+                        InsertTupleTypes::InsertBeadsBatch {
+                            beads,
+                            removed_orphans,
+                        },
+                } => {
+                    debug!(
+                        bead_count = beads.len(),
+                        orphan_count = removed_orphans.len(),
+                        "Received batch insert request"
+                    );
+                    match self.insert_beads_batch(beads, removed_orphans).await {
+                        Ok(_) => {
+                            debug!("Batch insertion completed successfully");
+                        }
+                        Err(error) => {
+                            error!(
+                                error = ?error,
+                                "Failed to insert beads in batch"
+                            );
+                        }
                     }
-                },
+                }
             }
         }
     }
 }
-pub fn prepare_bead_tuple_data(
-    beads: &Vec<Bead>,
-    bead_index_mapping: &HashMap<BeadHash, usize>,
-    bead: &Bead,
-) -> anyhow::Result<(String, String, String)> {
-    let mut parent_set: HashMap<usize, HashSet<usize>> = HashMap::new();
-
-    for (idx, b) in beads.iter().enumerate() {
-        let mut set = HashSet::new();
-        for p in &b.committed_metadata.parents {
-            let parent_idx = *bead_index_mapping.get(p).unwrap();
-            set.insert(parent_idx);
-        }
-        parent_set.insert(idx, set);
-    }
-
-    let bead_id = *bead_index_mapping
-        .get(&bead.block_header.block_hash())
-        .unwrap();
-    let current_parents = parent_set.get(&bead_id).cloned().unwrap_or_default();
-
-    let mut relatives = Vec::new();
-    let mut parent_ts = Vec::new();
-    let mut txs = Vec::new();
-
-    for parent in current_parents {
-        let ts = beads[parent]
-            .committed_metadata
-            .start_timestamp
-            .to_u32()
-            .to_u64()
-            .expect("An error occurred while casting u32 to u64");
-
-        relatives.push((parent as u64, bead_id as u64));
-        parent_ts.push((parent as u64, bead_id as u64, ts));
-    }
-
-    for tx in &bead.committed_metadata.transaction_ids.0 {
-        txs.push((bead_id as u64, hex::encode(tx.to_byte_array())));
-    }
-
-    let txs_json = serde_json::to_string(
-        &txs.iter()
-            .map(|t| json!({ "txid": t.1, "bead_id": t.0 }))
-            .collect::<Vec<_>>(),
-    )?;
-
-    let relatives_json = serde_json::to_string(
-        &relatives
-            .iter()
-            .map(|r| json!({ "parent": r.0, "child": r.1 }))
-            .collect::<Vec<_>>(),
-    )?;
-
-    let parent_ts_json = serde_json::to_string(
-        &parent_ts
-            .iter()
-            .map(|p| json!({ "child": p.1, "parent": p.0, "timestamp": p.2 }))
-            .collect::<Vec<_>>(),
-    )?;
-
-    Ok((txs_json, relatives_json, parent_ts_json))
-}
 //Fetching beads in batch
 pub async fn fetch_beads_in_batch(
-    db_pool: Arc<Mutex<Pool<Sqlite>>>,
+    db_pool: &Pool<Sqlite>,
     batch_size: u32,
 ) -> Result<Vec<Bead>, DBErrors> {
-    let conn = db_pool.lock().await.clone();
     let total_rows: u32 = sqlx::query(
         "  SELECT
             COUNT(*) AS row_cnt
@@ -285,7 +346,7 @@ pub async fn fetch_beads_in_batch(
             LEFT JOIN ParentTimestamps pt ON pt.child = b.id
             LEFT JOIN BEAD pb ON pb.id = pt.parent",
     )
-    .fetch_one(&conn)
+    .fetch_one(db_pool)
     .await
     .map_err(|e| DBErrors::TupleNotFetched {
         error: e.to_string(),
@@ -338,7 +399,7 @@ pub async fn fetch_beads_in_batch(
         )
         .bind(batch_size)
         .bind(offset)
-        .fetch_all(&conn)
+        .fetch_all(db_pool)
         .await
         .map_err(|e| DBErrors::TupleNotFetched {
             error: e.to_string(),
@@ -453,7 +514,7 @@ pub async fn fetch_beads_in_batch(
 }
 //Fetching single bead
 pub async fn fetch_bead_by_bead_hash(
-    db_connection_arc: Arc<Mutex<Pool<Sqlite>>>,
+    db_connection_arc: &Pool<Sqlite>,
     bead_hash: BlockHash,
 ) -> Result<Option<Bead>, DBErrors> {
     let mut fetched_bead: Bead = Bead::default();
@@ -484,12 +545,27 @@ pub async fn fetch_bead_by_bead_hash(
             let ntime = BlockTime::from_u32(row.get::<u32, _>("nTime"));
             let nbits = CompactTarget::from_consensus(row.get::<u32, _>("nBits"));
             let nonce = row.get::<u32, _>("nNonce");
-            let payout_address = std::str::from_utf8(&row.get::<Vec<u8>, _>("payout_address"))
-                .unwrap()
+            let payout_address_bytes = row.get::<Vec<u8>, _>("payout_address");
+            let payout_address = std::str::from_utf8(&payout_address_bytes)
+                .map_err(|_| DBErrors::TupleAttributeParsingError {
+                    error: "Invalid UTF-8 in payout_address".to_string(),
+                    attribute: "payout_address".to_string(),
+                })?
                 .to_string();
-            let start_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("start_timestamp")).unwrap();
-            let pub_key = PublicKey::from_slice(&row.get::<Vec<u8>, _>("comm_pub_key")).unwrap();
+            let start_ts_val = row.get::<u32, _>("start_timestamp");
+            let start_timestamp = MedianTimePast::from_u32(start_ts_val).map_err(|e| {
+                DBErrors::TupleAttributeParsingError {
+                    error: format!("Invalid timestamp value {}: {}", start_ts_val, e),
+                    attribute: "start_timestamp".to_string(),
+                }
+            })?;
+            let pub_key =
+                PublicKey::from_slice(&row.get::<Vec<u8>, _>("comm_pub_key")).map_err(|e| {
+                    DBErrors::TupleAttributeParsingError {
+                        error: format!("Invalid public key: {}", e),
+                        attribute: "comm_pub_key".to_string(),
+                    }
+                })?;
             let min_target = CompactTarget::from_consensus(row.get::<u32, _>("min_target"));
             let weak_target = CompactTarget::from_consensus(row.get::<u32, _>("weak_target"));
             let miner_ip = row.get::<String, _>("miner_ip");
@@ -525,7 +601,7 @@ pub async fn fetch_bead_by_bead_hash(
             fetched_bead.uncommitted_metadata.signature = signature;
             Ok(())
         })
-        .fetch_optional(&db_connection_arc.lock().await.clone())
+        .fetch_optional(&*db_connection_arc)
         .await
     {
         Ok(_rows) => {
@@ -544,7 +620,7 @@ pub async fn fetch_bead_by_bead_hash(
     let rows =
         match sqlx::query("SELECT  txid as txid, bead_id FROM Transactions WHERE bead_id = ?")
             .bind(bead_id)
-            .fetch_all(&db_connection_arc.lock().await.clone())
+            .fetch_all(&*db_connection_arc)
             .await
         {
             Ok(rows) => rows,
@@ -558,7 +634,7 @@ pub async fn fetch_bead_by_bead_hash(
     let parent_timestamp_rows =
         match sqlx::query("SELECT  parent,child,timestamp FROM ParentTimestamps WHERE child = ?")
             .bind(bead_id)
-            .fetch_all(&db_connection_arc.lock().await.clone())
+            .fetch_all(&*db_connection_arc)
             .await
         {
             Ok(rows) => rows,
@@ -574,7 +650,7 @@ pub async fn fetch_bead_by_bead_hash(
         //Fetching parent_bead from DB
         let parent_bead_hash_raw_bytes = match sqlx::query("SELECT  hash FROM Bead WHERE id = ?")
             .bind(parent_bead_id)
-            .fetch_one(&db_connection_arc.lock().await.clone())
+            .fetch_one(&*db_connection_arc)
             .await
         {
             Ok(bead_tuple) => bead_tuple.get::<Vec<u8>, _>("hash"),
@@ -595,11 +671,17 @@ pub async fn fetch_bead_by_bead_hash(
             }
         };
         //Extending parent bead timestamp
+        let parent_ts = MedianTimePast::from_u32(parent_timestamp as u32).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: format!("Invalid parent timestamp value {}: {}", parent_timestamp, e),
+                attribute: "parent_bead_timestamps".to_string(),
+            }
+        })?;
         fetched_bead
             .committed_metadata
             .parent_bead_timestamps
             .0
-            .push(MedianTimePast::from_u32(parent_timestamp as u32).unwrap());
+            .push(parent_ts);
         //Extending parent committment by parent hash
         fetched_bead
             .committed_metadata
@@ -632,6 +714,7 @@ pub mod test {
     use super::*;
     use serde_json::json;
     use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
+    use std::collections::HashSet;
     use std::{fs, path::Path, str::FromStr};
     const TEST_DB_URL: &str = "sqlite::memory:";
     use crate::{
@@ -665,171 +748,185 @@ pub mod test {
     }
 
     #[tokio::test]
-    async fn test_insertion_beads() {
+    async fn test_batch_insertion_beads() {
         let test_pool = test_db_initializer().await;
         let ancestors = std::env::current_dir().unwrap();
         let ancestors_directory: Vec<&Path> = ancestors.ancestors().collect();
         let parent_directory = ancestors_directory[1];
         let test_absolute_path = parent_directory.join(BRAIDTESTDIRECTORY);
         let file_path = test_absolute_path.join("random2.json");
-        let (current_file_braid, file_braid) = loading_braid_from_file(file_path.to_str().unwrap());
+        let (current_file_braid, _file_braid) =
+            loading_braid_from_file(file_path.to_str().unwrap());
+
+        let mut all_bead_data = Vec::new();
+        let mut all_txs_json_parts = Vec::new();
+        let mut all_relatives_json_parts = Vec::new();
+        let mut all_parent_ts_json_parts = Vec::new();
+
         for bead in current_file_braid.beads.iter() {
-            let mut braid_parent_set: HashMap<usize, HashSet<usize>> = HashMap::new();
-            for bead in current_file_braid.beads.iter().enumerate() {
-                let parent_beads = &bead.1.committed_metadata.parents;
-                braid_parent_set.insert(bead.0, HashSet::new());
-                for parent_bead_hash in parent_beads.iter() {
-                    let current_parent_bead_index = current_file_braid
-                        .bead_index_mapping
-                        .get(&*parent_bead_hash)
-                        .unwrap();
-                    if let Some(value) = braid_parent_set.get_mut(&bead.0) {
-                        value.insert(*current_parent_bead_index);
-                    }
-                }
-            }
-            let mut ancestor_mapping: HashMap<usize, HashSet<usize>> = HashMap::new();
-            consensus_functions::updating_ancestors(
-                &current_file_braid,
-                bead.block_header.block_hash(),
-                &mut ancestor_mapping,
-                &braid_parent_set,
-            );
-            let bead_id = current_file_braid
+            let bead_id = *current_file_braid
                 .bead_index_mapping
                 .get(&bead.block_header.block_hash())
                 .unwrap();
-            let current_bead_parent_set = braid_parent_set.get(&(bead_id)).unwrap();
-            let mut relative_tuples: Vec<(u64, u64)> = Vec::new();
-            let mut parent_timestamp_tuples: Vec<(u64, u64, u64)> = Vec::new();
-            let mut transaction_tuples: Vec<(u64, String)> = Vec::new();
-            for parent_bead in current_bead_parent_set {
-                relative_tuples.push(((*parent_bead as u64), (*bead_id as u64)));
-                let current_parent_timestamp = current_file_braid
-                    .beads
-                    .get(*parent_bead)
-                    .unwrap()
-                    .committed_metadata
-                    .start_timestamp;
-                parent_timestamp_tuples.push((
-                    (*parent_bead as u64),
-                    (*bead_id as u64),
-                    current_parent_timestamp.to_u32().to_u64().unwrap(),
-                ));
-            }
-            for bead_tx in bead.committed_metadata.transaction_ids.0.iter() {
-                transaction_tuples.push(((*bead_id as u64), hex::encode(bead_tx.to_byte_array())));
-            }
-            //Adding dummy tx
-            transaction_tuples.push((
-                *bead_id as u64,
-                "b1a6cecc2e40e89e9e943c3c010c1f6ca6dd1530361ead7289254d929ee4eb2a".to_string(),
-            ));
-            let transactions_values = transaction_tuples
-                .iter()
-                .map(|t| {
-                    json!({
-                        "txid":t.1,
-                        "bead_id":t.0
-                    })
-                })
-                .collect::<Vec<_>>();
-            let parent_timestamps_values = parent_timestamp_tuples
-                .iter()
-                .map(|p| {
-                    json!({
-                        "child":p.1,
-                        "parent":p.0,
-                        "timestamp":p.2
-                    })
-                })
-                .collect::<Vec<_>>();
 
-            let relatives_values = relative_tuples
-                .iter()
-                .map(|r| {
-                    json!({
-                        "parent":r.0,
-                        "child":r.1
-                    })
-                })
-                .collect::<Vec<_>>();
-            let test_tx_json = serde_json::to_string(&transactions_values).unwrap();
-            let test_relative_json = serde_json::to_string(&relatives_values).unwrap();
-            let test_parent_timestamp_json =
-                serde_json::to_string(&parent_timestamps_values).unwrap();
-            let hex_converted_extranonce_1 =
-                hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes());
-            let hex_converted_extranonce_2 =
-                hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes());
-            let block_header_bytes = bead.block_header.block_hash().to_byte_array().to_vec();
-            let prev_block_hash_bytes = bead.block_header.prev_blockhash.to_byte_array().to_vec();
-            let merkle_root_bytes = bead.block_header.merkle_root.to_byte_array().to_vec();
-            let payout_addr_bytes = bead.committed_metadata.payout_address.as_bytes().to_vec();
-            let public_key_bytes = bead.committed_metadata.comm_pub_key.to_vec();
-            let signature_bytes = bead.uncommitted_metadata.signature.to_vec();
-            let mut test_insertion_tx = test_pool.begin().await.unwrap();
-            if let Err(e) = sqlx::query(&INSERT_QUERY)
-                .bind(*bead_id as i64)
-                .bind(block_header_bytes)
-                .bind(bead.block_header.version.to_consensus())
-                .bind(prev_block_hash_bytes)
-                .bind(merkle_root_bytes)
-                .bind(bead.block_header.time.to_u32())
-                .bind(bead.block_header.bits.to_consensus())
-                .bind(bead.block_header.nonce)
-                .bind(payout_addr_bytes)
-                .bind(bead.committed_metadata.start_timestamp.to_u32())
-                .bind(public_key_bytes)
-                .bind(bead.committed_metadata.min_target.to_consensus())
-                .bind(bead.committed_metadata.weak_target.to_consensus())
-                .bind(bead.committed_metadata.miner_ip.clone())
-                .bind(hex_converted_extranonce_1.to_string())
-                .bind(hex_converted_extranonce_2.to_string())
-                .bind(bead.uncommitted_metadata.broadcast_timestamp.to_u32())
-                .bind(signature_bytes)
-                .bind(test_tx_json)
-                .bind(test_relative_json)
-                .bind(test_parent_timestamp_json)
-                .execute(&mut *test_insertion_tx)
-                .await
-            {
-                println!("Transaction failed to commit rolling back due to - {:?}", e);
-                match test_insertion_tx.rollback().await {
-                    Ok(_) => {
-                        println!("Transaction rollbacked successfully");
-                        continue;
-                    }
-                    Err(error) => {
-                        panic!(
-                            "An error occurred while rolling back the transaction - {:?}",
-                            error
-                        )
-                    }
-                }
+            all_bead_data.push(json!({
+                "id": bead_id as i64,
+                "hash": hex::encode(bead.block_header.block_hash().to_byte_array()),
+                "nVersion": bead.block_header.version.to_consensus(),
+                "hashPrevBlock": hex::encode(bead.block_header.prev_blockhash.to_byte_array()),
+                "hashMerkleRoot": hex::encode(bead.block_header.merkle_root.to_byte_array()),
+                "nTime": bead.block_header.time.to_u32(),
+                "nBits": bead.block_header.bits.to_consensus(),
+                "nNonce": bead.block_header.nonce,
+                "payout_address": hex::encode(bead.committed_metadata.payout_address.as_bytes()),
+                "start_timestamp": bead.committed_metadata.start_timestamp.to_u32(),
+                "comm_pub_key": hex::encode(bead.committed_metadata.comm_pub_key.to_bytes()),
+                "min_target": bead.committed_metadata.min_target.to_consensus(),
+                "weak_target": bead.committed_metadata.weak_target.to_consensus(),
+                "miner_ip": bead.committed_metadata.miner_ip.clone(),
+                "extranonce1": hex::encode(bead.uncommitted_metadata.extra_nonce_1.to_be_bytes()),
+                "extranonce2": hex::encode(bead.uncommitted_metadata.extra_nonce_2.to_be_bytes()),
+                "broadcast_timestamp": bead.uncommitted_metadata.broadcast_timestamp.to_u32(),
+                "signature": hex::encode(bead.uncommitted_metadata.signature.to_vec()),
+            }));
+
+            for bead_tx in bead.committed_metadata.transaction_ids.0.iter() {
+                all_txs_json_parts.push(json!({
+                    "txid": hex::encode(bead_tx.to_byte_array()),
+                    "bead_id": bead_id as u64
+                }));
             }
-            match test_insertion_tx.commit().await {
-                Ok(_) => {
-                    println!("All related insertions committed successfully");
-                }
-                Err(error) => {
-                    panic!("An error occurred while committing transaction");
-                }
-            };
-            let fetched_test_bead = fetch_bead_by_bead_hash(
-                Arc::new(Mutex::new(test_pool.clone())),
-                bead.block_header.block_hash(),
-            )
+            // Add dummy tx for testing
+            all_txs_json_parts.push(json!({
+                "txid": "b1a6cecc2e40e89e9e943c3c010c1f6ca6dd1530361ead7289254d929ee4eb2a",
+                "bead_id": bead_id as u64
+            }));
+
+            for parent_hash in &bead.committed_metadata.parents {
+                let parent_index = *current_file_braid
+                    .bead_index_mapping
+                    .get(parent_hash)
+                    .unwrap();
+                let parent_timestamp = current_file_braid.beads[parent_index]
+                    .committed_metadata
+                    .start_timestamp
+                    .to_u32();
+
+                all_relatives_json_parts.push(json!({
+                    "parent": parent_index as u64,
+                    "child": bead_id as u64
+                }));
+
+                all_parent_ts_json_parts.push(json!({
+                    "parent": parent_index as u64,
+                    "child": bead_id as u64,
+                    "timestamp": parent_timestamp
+                }));
+            }
+        }
+
+        let beads_json = serde_json::to_string(&all_bead_data).unwrap();
+        let txs_json = serde_json::to_string(&all_txs_json_parts).unwrap();
+        let relatives_json = serde_json::to_string(&all_relatives_json_parts).unwrap();
+        let parent_ts_json = serde_json::to_string(&all_parent_ts_json_parts).unwrap();
+
+        // Execute bulk inserts separately (as the fix does)
+        let mut test_insertion_tx = test_pool.begin().await.unwrap();
+
+        if let Err(e) = sqlx::query(BULK_INSERT_BEADS)
+            .bind(&beads_json)
+            .execute(&mut *test_insertion_tx)
+            .await
+        {
+            panic!("Bulk insert beads failed: {:?}", e);
+        }
+
+        if let Err(e) = sqlx::query(BULK_INSERT_TRANSACTIONS)
+            .bind(&txs_json)
+            .execute(&mut *test_insertion_tx)
+            .await
+        {
+            panic!("Bulk insert transactions failed: {:?}", e);
+        }
+
+        if let Err(e) = sqlx::query(BULK_INSERT_RELATIVES)
+            .bind(&relatives_json)
+            .execute(&mut *test_insertion_tx)
+            .await
+        {
+            panic!("Bulk insert relatives failed: {:?}", e);
+        }
+
+        if let Err(e) = sqlx::query(BULK_INSERT_PARENT_TIMESTAMPS)
+            .bind(&parent_ts_json)
+            .execute(&mut *test_insertion_tx)
+            .await
+        {
+            panic!("Bulk insert parent timestamps failed: {:?}", e);
+        }
+
+        test_insertion_tx.commit().await.unwrap();
+
+        // Verify bead table has correct count
+        let bead_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM bead")
+            .fetch_one(&test_pool)
             .await
             .unwrap();
+        assert_eq!(
+            bead_count as usize,
+            current_file_braid.beads.len(),
+            "Bead count mismatch"
+        );
+
+        let tx_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Transactions")
+            .fetch_one(&test_pool)
+            .await
+            .unwrap();
+
+        let relatives_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM Relatives")
+            .fetch_one(&test_pool)
+            .await
+            .unwrap();
+
+        let parent_ts_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM ParentTimestamps")
+            .fetch_one(&test_pool)
+            .await
+            .unwrap();
+        let expected_parent_ts = all_parent_ts_json_parts.len();
+
+        if expected_parent_ts > 0 {
             assert_eq!(
-                fetched_test_bead
-                    .unwrap()
-                    .block_header
-                    .block_hash()
-                    .to_string(),
-                bead.block_header.block_hash().to_string()
+                parent_ts_count as usize, expected_parent_ts,
+                "ParentTimestamps count mismatch"
             );
         }
+
+        for bead in current_file_braid.beads.iter() {
+            let fetched_test_bead =
+                fetch_bead_by_bead_hash(&test_pool, bead.block_header.block_hash())
+                    .await
+                    .unwrap();
+
+            assert!(
+                fetched_test_bead.is_some(),
+                "Bead not found: {}",
+                bead.block_header.block_hash()
+            );
+
+            let fetched = fetched_test_bead.unwrap();
+            assert_eq!(
+                fetched.block_header.block_hash().to_string(),
+                bead.block_header.block_hash().to_string()
+            );
+
+            assert_eq!(
+                fetched.committed_metadata.parents.len(),
+                bead.committed_metadata.parents.len(),
+                "Parent count mismatch for bead {}",
+                bead.block_header.block_hash()
+            );
+        }
+
+        println!("Batch insertion test completed successfully!");
     }
 }

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -18,7 +18,7 @@ pub const DB_CHANNEL_CAPACITY: usize = 1024;
 pub const BATCH_INSERT_THRESHOLD: usize = 500;
 pub const FETCH_BEAD_BATCH_SIZE: u32 = 50;
 //Bulk insertion sub-queries
-const BULK_INSERT_BEADS: &'static str =
+const BULK_INSERT_BEADS: &str =
     "INSERT INTO bead (id, hash, nVersion, hashPrevBlock, hashMerkleRoot, nTime, 
         nBits, nNonce, payout_address, start_timestamp, comm_pub_key, min_target, 
         weak_target, miner_ip, extranonce1, extranonce2, broadcast_timestamp, signature) 
@@ -43,7 +43,7 @@ const BULK_INSERT_BEADS: &'static str =
         unhex(json_extract(value, '$.signature')) 
     FROM json_each(?);";
 //Separating into sub-queries
-const BULK_INSERT_TRANSACTIONS: &'static str = "INSERT INTO Transactions (bead_id, txid) 
+const BULK_INSERT_TRANSACTIONS: &str = "INSERT INTO Transactions (bead_id, txid) 
     SELECT json_extract(value, '$.bead_id'), unhex(json_extract(value, '$.txid')) 
     FROM json_each(?);";
 
@@ -588,38 +588,11 @@ fn build_bead_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Bead, DBErrors> 
             }
         })?;
 
-                bead.uncommitted_metadata.signature =
-                    Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).unwrap();
-                bead
-            });
-
-            if let Ok(tx_bytes) = row.try_get::<Vec<u8>, _>("txid") {
-                let arr: [u8; 32] = tx_bytes.try_into().unwrap();
-                bead.committed_metadata
-                    .transaction_ids
-                    .0
-                    .push(Txid::from_byte_array(arr));
-            }
-            if let (Ok(parent_hash), Ok(ts)) = (
-                row.try_get::<Vec<u8>, _>("parent_hash"),
-                row.try_get::<u32, _>("parent_timestamp"),
-            ) {
-                if parent_hash.is_empty() {
-                    //Genesis bead case
-                    continue;
-                }
-                let arr: [u8; 32] = parent_hash.try_into().unwrap();
-                bead.committed_metadata
-                    .parents
-                    .insert(BlockHash::from_byte_array(arr));
-                tracing::info!(
-                    parent_hash = %BlockHash::from_byte_array(arr),
-                    "Parent hash added to bead's parent set"
-                );
-                bead.committed_metadata
-                    .parent_bead_timestamps
-                    .0
-                    .push(MedianTimePast::from_u32(ts).unwrap());
+    bead.uncommitted_metadata.signature =
+        Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: format!("Invalid signature: {}", e),
+                attribute: "signature".into(),
             }
         })?;
 
@@ -692,9 +665,20 @@ pub async fn fetch_bead_by_bead_hash(
                     error: e.to_string(),
                     attribute: "extranonce2".to_string(),
                 })?;
-            let broadcast_timestamp =
-                MedianTimePast::from_u32(row.get::<u32, _>("broadcast_timestamp")).unwrap();
-            let signature = Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).unwrap();
+            let broadcast_timestamp = MedianTimePast::from_u32(
+                row.get::<u32, _>("broadcast_timestamp"),
+            )
+            .map_err(|e| DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "broadcast_timestamp".to_string(),
+            })?;
+            let signature =
+                Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).map_err(|e| {
+                    DBErrors::TupleAttributeParsingError {
+                        error: e.to_string(),
+                        attribute: "signature".to_string(),
+                    }
+                })?;
             bead_id = id;
             fetched_bead.block_header.version = version;
             fetched_bead.block_header.bits = nbits;

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -9,7 +9,6 @@ use bitcoin::{
 };
 use serde_json::json;
 use sqlx::{Pool, Row, Sqlite};
-use std::collections::HashMap;
 use tokio::sync::mpsc::{Receiver, Sender};
 #[cfg(test)]
 use tracing::info;
@@ -17,6 +16,7 @@ use tracing::{debug, error, trace};
 pub const DB_CHANNEL_CAPACITY: usize = 1024;
 /// Maximum number of beads (including orphans) to insert in a single bulk query to limit the memory consumption
 pub const BATCH_INSERT_THRESHOLD: usize = 500;
+pub const FETCH_BEAD_BATCH_SIZE: u32 = 50;
 //Bulk insertion sub-queries
 const BULK_INSERT_BEADS: &'static str =
     "INSERT INTO bead (id, hash, nVersion, hashPrevBlock, hashMerkleRoot, nTime, 
@@ -47,11 +47,11 @@ const BULK_INSERT_TRANSACTIONS: &'static str = "INSERT INTO Transactions (bead_i
     SELECT json_extract(value, '$.bead_id'), unhex(json_extract(value, '$.txid')) 
     FROM json_each(?);";
 
-const BULK_INSERT_RELATIVES: &'static str = "INSERT INTO Relatives (child, parent) 
+const BULK_INSERT_RELATIVES: &str = "INSERT INTO Relatives (child, parent) 
     SELECT json_extract(value, '$.child'), json_extract(value, '$.parent') 
     FROM json_each(?);";
 
-const BULK_INSERT_PARENT_TIMESTAMPS: &'static str =
+const BULK_INSERT_PARENT_TIMESTAMPS: &str =
     "INSERT INTO ParentTimestamps (parent, child, timestamp) 
     SELECT json_extract(value, '$.parent'), json_extract(value, '$.child'), 
         json_extract(value, '$.timestamp') 
@@ -118,7 +118,6 @@ impl DBHandler {
 
     /// Inserting chunks for bulk insertions
     async fn bulk_insert_chunk(
-        &self,
         local_transaction: &mut sqlx::Transaction<'_, sqlx::Sqlite>,
         chunk: &[BeadInsertData],
     ) -> Result<(), DBErrors> {
@@ -269,7 +268,7 @@ impl DBHandler {
         let mut inserted_count = 0u32;
         // Iterating through each chunk and inserting the corrsponding chunk
         for chunk in all_beads.chunks(BATCH_INSERT_THRESHOLD) {
-            if let Err(e) = self.bulk_insert_chunk(&mut local_transaction, chunk).await {
+            if let Err(e) = Self::bulk_insert_chunk(&mut local_transaction, chunk).await {
                 error!(
                     error = ?e,
                     chunk_size = chunk.len(),
@@ -344,136 +343,250 @@ pub async fn fetch_beads_in_batch(
     db_pool: &Pool<Sqlite>,
     batch_size: u32,
 ) -> Result<Vec<Bead>, DBErrors> {
-    let total_rows: u32 = sqlx::query(
-        "  SELECT
-            COUNT(*) AS row_cnt
-            FROM BEAD b
-            LEFT JOIN Transactions t ON t.bead_id = b.id
-            LEFT JOIN ParentTimestamps pt ON pt.child = b.id
-            LEFT JOIN BEAD pb ON pb.id = pt.parent",
-    )
-    .fetch_one(db_pool)
-    .await
-    .map_err(|e| DBErrors::TupleNotFetched {
-        error: e.to_string(),
-    })?
-    .get("row_cnt");
+    // Fetching total number of beads
+    let total_rows: i64 = sqlx::query("SELECT COUNT(*) AS row_cnt FROM Bead")
+        .fetch_one(db_pool)
+        .await
+        .map_err(|e| DBErrors::TupleNotFetched {
+            error: e.to_string(),
+        })?
+        .get("row_cnt");
 
     debug!(
-        total_rows = total_rows,
+        total_beads = total_rows,
         "Number of beads present locally in persistent DB"
     );
     if total_rows == 0 {
         return Ok(vec![]);
     }
 
-    let num_batches = (total_rows + batch_size - 1) / batch_size;
-    let mut beads: HashMap<i32, Bead> = HashMap::new();
-    for batch_num in 0..num_batches {
-        let offset = batch_num * batch_size;
-        let rows = sqlx::query(
-            "            
-                SELECT
-                b.nVersion        AS nVersion,
-                b.nBits           AS nBits,
-                b.nTime           AS nTime,
-                b.nNonce          AS nNonce,
-                b.hashPrevBlock   AS hashPrevBlock,
-                b.hashMerkleRoot  AS hashMerkleRoot,
-                b.payout_address  AS payout_address,
-                b.comm_pub_key    AS comm_pub_key,
-                b.min_target      AS min_target,
-                b.weak_target     AS weak_target,   
-                b.miner_ip        AS miner_ip,
-                b.start_timestamp AS start_timestamp,
+    let batch_size = batch_size.max(1) as i64;
+    let mut all_beads: Vec<Bead> = Vec::new();
+    // Bead ids are 0-indexed, so the cursor starts below the smallest possible.
+    let mut last_id: i64 = -1;
+
+    loop {
+        let bead_rows = sqlx::query(
+            "SELECT
+                b.nVersion            AS nVersion,
+                b.nBits               AS nBits,
+                b.nTime               AS nTime,
+                b.nNonce              AS nNonce,
+                b.hashPrevBlock       AS hashPrevBlock,
+                b.hashMerkleRoot      AS hashMerkleRoot,
+                b.payout_address      AS payout_address,
+                b.comm_pub_key        AS comm_pub_key,
+                b.min_target          AS min_target,
+                b.weak_target         AS weak_target,
+                b.miner_ip            AS miner_ip,
+                b.start_timestamp     AS start_timestamp,
                 b.broadcast_timestamp AS broadcast_timestamp,
-                b.extranonce1     AS extranonce1,
-                b.extranonce2     AS extranonce2,
-                b.signature       AS signature,
-                b.id               AS bead_id,
-                b.hash             AS bead_hash,
-                t.txid             AS txid,
-                pt.parent          AS parent_id,
-                pt.timestamp       AS parent_timestamp,
-                pb.hash            AS parent_hash
-            FROM BEAD b
-            LEFT JOIN Transactions t ON t.bead_id = b.id
-            LEFT JOIN ParentTimestamps pt ON pt.child = b.id
-            LEFT JOIN BEAD pb ON pb.id = pt.parent
-            order BY b.id
-            LIMIT ? OFFSET ?",
+                b.extranonce1         AS extranonce1,
+                b.extranonce2         AS extranonce2,
+                b.signature           AS signature,
+                b.id                  AS bead_id
+            FROM Bead b
+            WHERE b.id > ?
+            ORDER BY b.id
+            LIMIT ?",
         )
+        .bind(last_id)
         .bind(batch_size)
-        .bind(offset)
         .fetch_all(db_pool)
         .await
         .map_err(|e| DBErrors::TupleNotFetched {
             error: e.to_string(),
         })?;
-        for row in rows {
-            let bead_id: i32 = row.get("bead_id");
-            let bead = beads.entry(bead_id).or_insert_with(|| {
-                let mut bead = Bead::default();
-                bead.block_header.version =
-                    BlockVersion::from_consensus(row.get::<i32, _>("nVersion"));
-                bead.block_header.bits = CompactTarget::from_consensus(row.get::<u32, _>("nBits"));
-                bead.block_header.time = BlockTime::from_u32(row.get::<u32, _>("nTime"));
-                bead.block_header.nonce = row.get::<u32, _>("nNonce");
 
-                let prev_bytes: Vec<u8> = row.get("hashPrevBlock");
-                bead.block_header.prev_blockhash = BlockHash::from_byte_array(
-                    prev_bytes
-                        .try_into()
-                        .map_err(|_| DBErrors::TupleAttributeParsingError {
-                            error: "Invalid prev block hash length".into(),
-                            attribute: "hashPrevBlock".into(),
-                        })
-                        .unwrap(),
-                );
+        if bead_rows.is_empty() {
+            break;
+        }
 
-                let merkle_bytes: Vec<u8> = row.get("hashMerkleRoot");
-                bead.block_header.merkle_root = TxMerkleNode::from_byte_array(
-                    merkle_bytes
-                        .try_into()
-                        .map_err(|_| DBErrors::TupleAttributeParsingError {
-                            error: "Invalid merkle root length".into(),
-                            attribute: "hashMerkleRoot".into(),
-                        })
-                        .unwrap(),
-                );
+        let mut batch: Vec<Bead> = Vec::with_capacity(bead_rows.len());
+        let mut ids: Vec<i64> = Vec::with_capacity(bead_rows.len());
 
-                bead.committed_metadata.payout_address =
-                    String::from_utf8(row.get::<Vec<u8>, _>("payout_address"))
-                        .map_err(|_| DBErrors::TupleAttributeParsingError {
-                            error: "Invalid payout_address UTF-8".into(),
-                            attribute: "payout_address".into(),
-                        })
-                        .unwrap();
+        for row in &bead_rows {
+            let bead_id: i64 = row.get("bead_id");
+            let bead = build_bead_from_row(row)?;
+            batch.push(bead);
+            ids.push(bead_id);
+            last_id = last_id.max(bead_id);
+        }
 
-                bead.committed_metadata.comm_pub_key =
-                    PublicKey::from_slice(&row.get::<Vec<u8>, _>("comm_pub_key"))
-                        .map_err(|_| DBErrors::TupleAttributeParsingError {
-                            error: "Invalid comm_pub_key".into(),
-                            attribute: "comm_pub_key".into(),
-                        })
-                        .unwrap();
+        let placeholders = ids.iter().map(|_| "?").collect::<Vec<_>>().join(",");
 
-                bead.committed_metadata.min_target =
-                    CompactTarget::from_consensus(row.get::<u32, _>("min_target"));
-                bead.committed_metadata.weak_target =
-                    CompactTarget::from_consensus(row.get::<u32, _>("weak_target"));
-                bead.committed_metadata.miner_ip = row.get("miner_ip");
+        // Transactions for every bead in the batch.
+        let tx_sql =
+            format!("SELECT bead_id, txid FROM Transactions WHERE bead_id IN ({placeholders})");
+        let mut tx_query = sqlx::query(&tx_sql);
+        for id in &ids {
+            tx_query = tx_query.bind(id);
+        }
+        let tx_rows = tx_query
+            .fetch_all(db_pool)
+            .await
+            .map_err(|e| DBErrors::TupleNotFetched {
+                error: e.to_string(),
+            })?;
+        for row in tx_rows {
+            let bead_id: i64 = row.get("bead_id");
+            let idx = ids
+                .binary_search(&bead_id)
+                .map_err(|_| DBErrors::TupleNotFetched {
+                    error: format!("Transaction references unknown bead_id {bead_id}"),
+                })?;
+            let tx_bytes: Vec<u8> = row.get("txid");
+            let arr: [u8; 32] =
+                tx_bytes
+                    .try_into()
+                    .map_err(|_| DBErrors::TupleAttributeParsingError {
+                        error: "Invalid txid length".into(),
+                        attribute: "txid".into(),
+                    })?;
+            batch[idx]
+                .committed_metadata
+                .transaction_ids
+                .0
+                .push(Txid::from_byte_array(arr));
+        }
 
-                bead.committed_metadata.start_timestamp =
-                    MedianTimePast::from_u32(row.get::<u32, _>("start_timestamp")).unwrap();
+        let pt_sql = format!(
+            "SELECT pt.child AS child, pt.timestamp AS timestamp, pb.hash AS parent_hash
+             FROM ParentTimestamps pt
+             JOIN Bead pb ON pb.id = pt.parent
+             WHERE pt.child IN ({placeholders})
+             ORDER BY pt.child, pt.parent"
+        );
+        let mut pt_query = sqlx::query(&pt_sql);
+        for id in &ids {
+            pt_query = pt_query.bind(id);
+        }
+        let pt_rows = pt_query
+            .fetch_all(db_pool)
+            .await
+            .map_err(|e| DBErrors::TupleNotFetched {
+                error: e.to_string(),
+            })?;
+        for row in pt_rows {
+            let child_id: i64 = row.get("child");
+            let idx = ids
+                .binary_search(&child_id)
+                .map_err(|_| DBErrors::TupleNotFetched {
+                    error: format!("ParentTimestamp references unknown child bead_id {child_id}"),
+                })?;
+            let parent_hash: Vec<u8> = row.get("parent_hash");
+            let arr: [u8; 32] =
+                parent_hash
+                    .try_into()
+                    .map_err(|_| DBErrors::TupleAttributeParsingError {
+                        error: "Invalid parent hash length".into(),
+                        attribute: "parent_hash".into(),
+                    })?;
+            let ts: i64 = row.get("timestamp");
+            let parent_ts = MedianTimePast::from_u32(ts as u32).map_err(|e| {
+                DBErrors::TupleAttributeParsingError {
+                    error: format!("Invalid parent timestamp value {}: {}", ts, e),
+                    attribute: "parent_bead_timestamps".into(),
+                }
+            })?;
+            let bead = &mut batch[idx];
+            bead.committed_metadata
+                .parents
+                .insert(BlockHash::from_byte_array(arr));
+            bead.committed_metadata
+                .parent_bead_timestamps
+                .0
+                .push(parent_ts);
+        }
 
-                bead.uncommitted_metadata.broadcast_timestamp =
-                    MedianTimePast::from_u32(row.get::<u32, _>("broadcast_timestamp")).unwrap();
+        let batch_len = batch.len() as i64;
+        all_beads.extend(batch);
 
-                bead.uncommitted_metadata.extra_nonce_1 =
-                    u64::from_str_radix(&row.get::<String, _>("extranonce1"), 16).unwrap();
-                bead.uncommitted_metadata.extra_nonce_2 =
-                    u64::from_str_radix(&row.get::<String, _>("extranonce2"), 16).unwrap();
+        // A short page means that we have reached the end of the table.
+        if batch_len < batch_size {
+            break;
+        }
+    }
+
+    Ok(all_beads)
+}
+
+/// Reconstructs a [`Bead`] from a single `Bead` table row.
+fn build_bead_from_row(row: &sqlx::sqlite::SqliteRow) -> Result<Bead, DBErrors> {
+    let mut bead = Bead::default();
+    bead.block_header.version = BlockVersion::from_consensus(row.get::<i32, _>("nVersion"));
+    bead.block_header.bits = CompactTarget::from_consensus(row.get::<u32, _>("nBits"));
+    bead.block_header.time = BlockTime::from_u32(row.get::<u32, _>("nTime"));
+    bead.block_header.nonce = row.get::<u32, _>("nNonce");
+
+    let prev_bytes: Vec<u8> = row.get("hashPrevBlock");
+    bead.block_header.prev_blockhash =
+        BlockHash::from_byte_array(prev_bytes.try_into().map_err(|_| {
+            DBErrors::TupleAttributeParsingError {
+                error: "Invalid prev block hash length".into(),
+                attribute: "hashPrevBlock".into(),
+            }
+        })?);
+
+    let merkle_bytes: Vec<u8> = row.get("hashMerkleRoot");
+    bead.block_header.merkle_root =
+        TxMerkleNode::from_byte_array(merkle_bytes.try_into().map_err(|_| {
+            DBErrors::TupleAttributeParsingError {
+                error: "Invalid merkle root length".into(),
+                attribute: "hashMerkleRoot".into(),
+            }
+        })?);
+
+    bead.committed_metadata.payout_address =
+        String::from_utf8(row.get::<Vec<u8>, _>("payout_address")).map_err(|_| {
+            DBErrors::TupleAttributeParsingError {
+                error: "Invalid payout_address UTF-8".into(),
+                attribute: "payout_address".into(),
+            }
+        })?;
+
+    bead.committed_metadata.comm_pub_key =
+        PublicKey::from_slice(&row.get::<Vec<u8>, _>("comm_pub_key")).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: format!("Invalid comm_pub_key: {}", e),
+                attribute: "comm_pub_key".into(),
+            }
+        })?;
+
+    bead.committed_metadata.min_target =
+        CompactTarget::from_consensus(row.get::<u32, _>("min_target"));
+    bead.committed_metadata.weak_target =
+        CompactTarget::from_consensus(row.get::<u32, _>("weak_target"));
+    bead.committed_metadata.miner_ip = row.get("miner_ip");
+
+    let start_ts = row.get::<u32, _>("start_timestamp");
+    bead.committed_metadata.start_timestamp =
+        MedianTimePast::from_u32(start_ts).map_err(|e| DBErrors::TupleAttributeParsingError {
+            error: format!("Invalid start_timestamp value {}: {}", start_ts, e),
+            attribute: "start_timestamp".into(),
+        })?;
+
+    let broadcast_ts = row.get::<u32, _>("broadcast_timestamp");
+    bead.uncommitted_metadata.broadcast_timestamp = MedianTimePast::from_u32(broadcast_ts)
+        .map_err(|e| DBErrors::TupleAttributeParsingError {
+            error: format!("Invalid broadcast_timestamp value {}: {}", broadcast_ts, e),
+            attribute: "broadcast_timestamp".into(),
+        })?;
+
+    bead.uncommitted_metadata.extra_nonce_1 =
+        u64::from_str_radix(&row.get::<String, _>("extranonce1"), 16).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "extranonce1".into(),
+            }
+        })?;
+    bead.uncommitted_metadata.extra_nonce_2 =
+        u64::from_str_radix(&row.get::<String, _>("extranonce2"), 16).map_err(|e| {
+            DBErrors::TupleAttributeParsingError {
+                error: e.to_string(),
+                attribute: "extranonce2".into(),
+            }
+        })?;
 
                 bead.uncommitted_metadata.signature =
                     Signature::from_slice(&row.get::<Vec<u8>, _>("signature")).unwrap();
@@ -508,15 +621,9 @@ pub async fn fetch_beads_in_batch(
                     .0
                     .push(MedianTimePast::from_u32(ts).unwrap());
             }
-        }
-    }
-    let mut bead_vec: Vec<(i32, Bead)> = Vec::new();
-    for (bead_id, bead) in beads.iter() {
-        bead_vec.push((*bead_id, bead.clone()));
-    }
-    bead_vec.sort_by_key(|k| k.0);
-    let beads: Vec<Bead> = bead_vec.into_iter().map(|(_, bead)| bead).collect();
-    Ok(beads)
+        })?;
+
+    Ok(bead)
 }
 //Fetching single bead
 pub async fn fetch_bead_by_bead_hash(
@@ -720,7 +827,7 @@ pub mod test {
     use super::*;
     use serde_json::json;
     use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
-    use std::collections::HashSet;
+    use std::collections::{HashMap, HashSet};
     use std::{fs, path::Path, str::FromStr};
     const TEST_DB_URL: &str = "sqlite::memory:";
     use crate::{
@@ -776,7 +883,6 @@ pub mod test {
         // for testing the orphan insertions as well .
         let split_at = bead_insert_data.len().saturating_sub(1);
         let orphans = bead_insert_data.split_off(split_at);
-        println!("{orphans:?}");
         let beads = bead_insert_data;
 
         // Drive the real batched-insert code path over the in-memory test pool.
@@ -856,7 +962,5 @@ pub mod test {
                 bead.block_header.block_hash()
             );
         }
-
-        println!("Batch insertion test completed successfully!");
     }
 }

--- a/node/src/db/mod.rs
+++ b/node/src/db/mod.rs
@@ -1,17 +1,41 @@
 #![allow(non_snake_case)]
 use crate::bead::Bead;
+use crate::braid::Braid;
 pub mod db_handlers;
 pub mod init_db;
+#[derive(Debug, Clone)]
+pub struct BeadInsertData {
+    pub bead: Bead,
+    pub bead_id: usize,
+    pub parent_refs: Vec<(u64, u32)>,
+}
+
+impl BeadInsertData {
+    pub fn resolve(braid: &Braid, bead: &Bead) -> Option<Self> {
+        braid
+            .bead_index_mapping
+            .get(&bead.block_header.block_hash())
+            .map(|&bead_id| BeadInsertData {
+                parent_refs: braid.resolve_parents(bead),
+                bead: bead.clone(),
+                bead_id,
+            })
+    }
+
+    pub fn resolve_many<'a>(braid: &Braid, beads: impl IntoIterator<Item = &'a Bead>) -> Vec<Self> {
+        beads
+            .into_iter()
+            .filter_map(|bead| Self::resolve(braid, bead))
+            .collect()
+    }
+}
 
 #[derive(Debug, Clone)]
 
 pub enum InsertTupleTypes {
-    InsertBeadSequentially {
-        bead_to_insert: Bead,
-        txs_json: String,
-        relative_json: String,
-        parent_timestamp_json: String,
-        bead_id: usize,
+    InsertBeadsBatch {
+        beads: Vec<BeadInsertData>,
+        removed_orphans: Vec<BeadInsertData>,
     },
 }
 #[derive(Debug, Clone)]

--- a/node/src/db/mod.rs
+++ b/node/src/db/mod.rs
@@ -37,6 +37,29 @@ impl BeadInsertData {
     }
 }
 
+/// Resolves a newly-added bead and its promoted orphans against the braid index
+pub async fn persist_added_bead<'a>(
+    braid: &Braid,
+    bead: &Bead,
+    promoted_orphans: impl IntoIterator<Item = &'a Bead>,
+    db_tx: &tokio::sync::mpsc::Sender<BraidpoolDBTypes>,
+) -> Result<(), BraidError> {
+    let bead_data = BeadInsertData::resolve(braid, bead)?;
+    let removed_orphans = BeadInsertData::resolve_many(braid, promoted_orphans)?;
+    if let Err(error) = db_tx
+        .send(BraidpoolDBTypes::InsertTupleTypes {
+            query: InsertTupleTypes::InsertBeadsBatch {
+                beads: vec![bead_data],
+                removed_orphans,
+            },
+        })
+        .await
+    {
+        tracing::error!(err = ?error.0, "Failed to send InsertBeadsBatch to DB handler");
+    }
+    Ok(())
+}
+
 #[derive(Debug, Clone)]
 
 pub enum InsertTupleTypes {

--- a/node/src/db/mod.rs
+++ b/node/src/db/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case)]
 use crate::bead::Bead;
 use crate::braid::Braid;
+use crate::error::BraidError;
 pub mod db_handlers;
 pub mod init_db;
 #[derive(Debug, Clone)]
@@ -11,21 +12,27 @@ pub struct BeadInsertData {
 }
 
 impl BeadInsertData {
-    pub fn resolve(braid: &Braid, bead: &Bead) -> Option<Self> {
-        braid
+    /// Resolves a bead into a [`BeadInsertData`] using the braid's index mapping.
+    pub fn resolve(braid: &Braid, bead: &Bead) -> Result<Self, BraidError> {
+        let &bead_id = braid
             .bead_index_mapping
             .get(&bead.block_header.block_hash())
-            .map(|&bead_id| BeadInsertData {
-                parent_refs: braid.resolve_parents(bead),
-                bead: bead.clone(),
-                bead_id,
-            })
+            .ok_or(BraidError::BeadNotIndexed {
+                bead: bead.block_header.block_hash(),
+            })?;
+        Ok(BeadInsertData {
+            parent_refs: braid.resolve_parents(bead)?,
+            bead: bead.clone(),
+            bead_id,
+        })
     }
-
-    pub fn resolve_many<'a>(braid: &Braid, beads: impl IntoIterator<Item = &'a Bead>) -> Vec<Self> {
+    pub fn resolve_many<'a>(
+        braid: &Braid,
+        beads: impl IntoIterator<Item = &'a Bead>,
+    ) -> Result<Vec<Self>, BraidError> {
         beads
             .into_iter()
-            .filter_map(|bead| Self::resolve(braid, bead))
+            .map(|bead| Self::resolve(braid, bead))
             .collect()
     }
 }

--- a/node/src/db/mod.rs
+++ b/node/src/db/mod.rs
@@ -56,6 +56,9 @@ pub async fn persist_added_bead<'a>(
         .await
     {
         tracing::error!(err = ?error.0, "Failed to send InsertBeadsBatch to DB handler");
+        return Err(BraidError::PersistenceChannelClosed {
+            bead: bead.block_header.block_hash(),
+        });
     }
     Ok(())
 }

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -2,6 +2,7 @@
 use std::{fmt, path::PathBuf};
 
 use crate::stratum::{BlockTemplate, JobDetails};
+use crate::utils::BeadHash;
 use crate::TemplateId;
 use bitcoin::address::ParseError as AddressParseError;
 use tokio::sync::oneshot;
@@ -11,6 +12,18 @@ use tokio::sync::oneshot;
 pub enum BraidError {
     MissingAncestorWork,
     HighestWorkBeadFetchFailed,
+    /// A bead's committed parent hash is not present in the braid index. This is
+    /// a consensus/DAG invariant violation: a connected bead must have all of
+    /// its parents resolvable.
+    MissingParent {
+        bead: BeadHash,
+        parent: BeadHash,
+    },
+    /// A bead is not present in the braid index when persistence was attempted,
+    /// despite the braid reporting it as added. Indicates a consensus/logic bug.
+    BeadNotIndexed {
+        bead: BeadHash,
+    },
 }
 #[derive(Debug)]
 pub enum BraidRPCError {
@@ -435,6 +448,16 @@ impl fmt::Display for BraidError {
             BraidError::MissingAncestorWork => write!(f, "Missing ancestor work map"),
             BraidError::HighestWorkBeadFetchFailed => {
                 write!(f, "An error occurred while fetching the highest work bead")
+            }
+            BraidError::MissingParent { bead, parent } => {
+                write!(
+                    f,
+                    "Parent {} of bead {} not found in braid index",
+                    parent, bead
+                )
+            }
+            BraidError::BeadNotIndexed { bead } => {
+                write!(f, "Bead {} not found in braid index", bead)
             }
         }
     }

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -358,7 +358,7 @@ impl fmt::Display for StratumErrors {
         }
     }
 }
-
+impl std::error::Error for StratumErrors {}
 /// Determines if an error indicates a connection/communication failure
 ///
 /// This function classifies errors to distinguish between:

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -24,6 +24,10 @@ pub enum BraidError {
     BeadNotIndexed {
         bead: BeadHash,
     },
+    /// The bead was resolved but the db channel closed due to an error
+    PersistenceChannelClosed {
+        bead: BeadHash,
+    },
 }
 #[derive(Debug)]
 pub enum BraidRPCError {
@@ -228,6 +232,10 @@ pub enum StratumErrors {
     ErrorFetchingCurrentUNIXTimestamp {
         error: String,
     },
+    /// A bead received was not able to get persisted to DB locally
+    BeadPersistenceFailed {
+        error: String,
+    },
 }
 pub enum StratumResponseErrors {}
 impl fmt::Display for StratumErrors {
@@ -355,6 +363,13 @@ impl fmt::Display for StratumErrors {
             StratumErrors::MiningJobInsertError { mining_job } => {
                 write!(f,"An error occurred while inserting the following job into the mining map - {:?}",mining_job)
             }
+            StratumErrors::BeadPersistenceFailed { error } => {
+                write!(
+                    f,
+                    "Self-mined bead added to braid but not persisted to DB - {}",
+                    error
+                )
+            }
         }
     }
 }
@@ -458,6 +473,13 @@ impl fmt::Display for BraidError {
             }
             BraidError::BeadNotIndexed { bead } => {
                 write!(f, "Bead {} not found in braid index", bead)
+            }
+            BraidError::PersistenceChannelClosed { bead } => {
+                write!(
+                    f,
+                    "Persistence channel closed; bead {} was not persisted",
+                    bead
+                )
             }
         }
     }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -286,7 +286,7 @@ impl SwarmHandler {
         downstream_payout_addr: &str,
         //TODO: Will be used as seperate entity after altering `uncommitted_metadata`
         extranonce_1_raw_value: u64,
-    ) -> Result<(), StratumErrors> {
+    ) -> Result<(), Box<dyn std::error::Error>> {
         let (candidate_block_header, candidate_block_transactions) = candidate_block.into_parts();
         let ids: Vec<Txid> = candidate_block_transactions
             .iter()
@@ -342,9 +342,9 @@ impl SwarmHandler {
         let duration_since_epoch = match current_system_time.duration_since(UNIX_EPOCH) {
             Ok(duration) => duration,
             Err(error) => {
-                return Err(StratumErrors::ErrorFetchingCurrentUNIXTimestamp {
+                return Err(Box::new(StratumErrors::ErrorFetchingCurrentUNIXTimestamp {
                     error: error.to_string(),
-                })
+                }));
             }
         };
 
@@ -374,41 +374,22 @@ impl SwarmHandler {
                     new_tips = ?new_tips,
                     "Braid extended successfully"
                 );
-                match db::BeadInsertData::resolve(&braid_data, &weak_share) {
-                    Ok(bead) => {
-                        match db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter())
-                        {
-                            Ok(removed_orphans) => {
-                                match self
-                                    .db_command_sender
-                                    .send(BraidpoolDBTypes::InsertTupleTypes {
-                                        query: db::InsertTupleTypes::InsertBeadsBatch {
-                                            beads: vec![bead],
-                                            removed_orphans,
-                                        },
-                                    })
-                                    .await
-                                {
-                                    Ok(_) => {
-                                        debug!(
-                                            hash = %bead_hash,
-                                            "InsertBeadsBatch sent to DB thread"
-                                        );
-                                    }
-                                    Err(error) => {
-                                        error!(error = ?error, "Database insertion command failed");
-                                    }
-                                }
-                            }
-                            Err(error) => {
-                                error!(error = %error, hash = %bead_hash, "Failed to resolve promoted orphans for persistence");
-                            }
-                        }
-                    }
-                    Err(error) => {
-                        error!(error = %error, hash = %bead_hash, "Failed to resolve bead for persistence");
-                    }
-                }
+
+                db::persist_added_bead(
+                    &braid_data,
+                    &weak_share,
+                    promoted_orphans.iter(),
+                    &self.db_command_sender,
+                )
+                .await
+                .map_err(|error| {
+                    error!(error = %error, hash = %bead_hash, "Failed to persist bead");
+                    error
+                })?;
+                debug!(
+                    hash = %bead_hash,
+                    "InsertBeadsBatch sent to DB thread"
+                );
                 let serialized_weak_share_bytes = bitcoin::consensus::serialize(&weak_share);
                 let res = self
                     .dashboard_notification_sender
@@ -419,7 +400,7 @@ impl SwarmHandler {
                         debug!("Passing self mined bead to the dashboard notifier");
                     }
                     Err(error) => {
-                        error!("An error occurred while sending dashboard notification - {error}");
+                        debug!("No dashboard subscriber for new bead notification - {error}");
                     }
                 }
                 //After validation of the candidate block constructed by the downstream node sending it to swarm for further propogation
@@ -442,9 +423,9 @@ impl SwarmHandler {
                             error = %e,
                             "Failed to send candidate block to swarm"
                         );
-                        return Err(StratumErrors::CandidateBlockNotSent {
+                        return Err(Box::new(StratumErrors::CandidateBlockNotSent {
                             error: e.to_string(),
-                        });
+                        }));
                     }
                 };
             }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -286,7 +286,7 @@ impl SwarmHandler {
         downstream_payout_addr: &str,
         //TODO: Will be used as seperate entity after altering `uncommitted_metadata`
         extranonce_1_raw_value: u64,
-    ) -> Result<(), Box<dyn std::error::Error>> {
+    ) -> Result<(), StratumErrors> {
         let (candidate_block_header, candidate_block_transactions) = candidate_block.into_parts();
         let ids: Vec<Txid> = candidate_block_transactions
             .iter()
@@ -342,9 +342,9 @@ impl SwarmHandler {
         let duration_since_epoch = match current_system_time.duration_since(UNIX_EPOCH) {
             Ok(duration) => duration,
             Err(error) => {
-                return Err(Box::new(StratumErrors::ErrorFetchingCurrentUNIXTimestamp {
+                return Err(StratumErrors::ErrorFetchingCurrentUNIXTimestamp {
                     error: error.to_string(),
-                }));
+                });
             }
         };
 
@@ -384,7 +384,9 @@ impl SwarmHandler {
                 .await
                 .map_err(|error| {
                     error!(error = %error, hash = %bead_hash, "Failed to persist bead");
-                    error
+                    StratumErrors::BeadPersistenceFailed {
+                        error: error.to_string(),
+                    }
                 })?;
                 debug!(
                     hash = %bead_hash,
@@ -423,9 +425,9 @@ impl SwarmHandler {
                             error = %e,
                             "Failed to send candidate block to swarm"
                         );
-                        return Err(Box::new(StratumErrors::CandidateBlockNotSent {
+                        return Err(StratumErrors::CandidateBlockNotSent {
                             error: e.to_string(),
-                        }));
+                        });
                     }
                 };
             }

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -1,5 +1,5 @@
 //These implementations must be defined under lib.rs as they are required for intergration tests
-use crate::{db::db_handlers::prepare_bead_tuple_data, rpc_server::DashboardEvents};
+use crate::rpc_server::DashboardEvents;
 use bitcoin::{
     consensus::encode::deserialize, ecdsa::Signature, pow::CompactTargetExt, BlockHash,
     CompactTarget, EcdsaSighashType, Txid,
@@ -366,7 +366,7 @@ impl SwarmHandler {
         };
         let status = braid_data.extend(&weak_share);
         match status {
-            AddBeadStatus::BeadAdded { .. } => {
+            AddBeadStatus::BeadAdded { promoted_orphans } => {
                 let new_tips: Vec<_> = braid_data.tips.iter().map(|&idx| idx).collect();
                 let bead_hash = weak_share.block_header.block_hash();
                 info!(
@@ -374,37 +374,36 @@ impl SwarmHandler {
                     new_tips = ?new_tips,
                     "Braid extended successfully"
                 );
-                //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                let bead_id = braid_data.bead_index_mapping.get(&bead_hash).unwrap();
-                let (txs_json, relative_json, parent_timestamp_json) = prepare_bead_tuple_data(
-                    &braid_data.beads,
-                    &braid_data.bead_index_mapping,
-                    &weak_share,
-                )
-                .unwrap();
-                let _db_insertion_command = match self
-                    .db_command_sender
-                    .send(BraidpoolDBTypes::InsertTupleTypes {
-                        query: db::InsertTupleTypes::InsertBeadSequentially {
-                            bead_to_insert: weak_share.clone(),
-                            txs_json: txs_json,
-                            relative_json: relative_json,
-                            parent_timestamp_json: parent_timestamp_json,
-                            bead_id: *bead_id,
-                        },
-                    })
-                    .await
-                {
-                    Ok(_) => {
-                        debug!(
-                            hash = %bead_hash,
-                            "InsertBeadSequentially sent to DB thread"
-                        );
+                // Resolve parent ids/timestamps
+                match db::BeadInsertData::resolve(&braid_data, &weak_share) {
+                    Some(bead) => {
+                        let removed_orphans =
+                            db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
+                        match self
+                            .db_command_sender
+                            .send(BraidpoolDBTypes::InsertTupleTypes {
+                                query: db::InsertTupleTypes::InsertBeadsBatch {
+                                    beads: vec![bead],
+                                    removed_orphans,
+                                },
+                            })
+                            .await
+                        {
+                            Ok(_) => {
+                                debug!(
+                                    hash = %bead_hash,
+                                    "InsertBeadsBatch sent to DB thread"
+                                );
+                            }
+                            Err(error) => {
+                                error!(error = ?error, "Database insertion command failed");
+                            }
+                        }
                     }
-                    Err(error) => {
-                        error!(error = ?error, "Database insertion command failed");
+                    None => {
+                        error!(hash = %bead_hash, "Bead ID not found in index mapping");
                     }
-                };
+                }
                 let serialized_weak_share_bytes = bitcoin::consensus::serialize(&weak_share);
                 let res = self
                     .dashboard_notification_sender

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -374,34 +374,39 @@ impl SwarmHandler {
                     new_tips = ?new_tips,
                     "Braid extended successfully"
                 );
-                // Resolve parent ids/timestamps
                 match db::BeadInsertData::resolve(&braid_data, &weak_share) {
-                    Some(bead) => {
-                        let removed_orphans =
-                            db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
-                        match self
-                            .db_command_sender
-                            .send(BraidpoolDBTypes::InsertTupleTypes {
-                                query: db::InsertTupleTypes::InsertBeadsBatch {
-                                    beads: vec![bead],
-                                    removed_orphans,
-                                },
-                            })
-                            .await
+                    Ok(bead) => {
+                        match db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter())
                         {
-                            Ok(_) => {
-                                debug!(
-                                    hash = %bead_hash,
-                                    "InsertBeadsBatch sent to DB thread"
-                                );
+                            Ok(removed_orphans) => {
+                                match self
+                                    .db_command_sender
+                                    .send(BraidpoolDBTypes::InsertTupleTypes {
+                                        query: db::InsertTupleTypes::InsertBeadsBatch {
+                                            beads: vec![bead],
+                                            removed_orphans,
+                                        },
+                                    })
+                                    .await
+                                {
+                                    Ok(_) => {
+                                        debug!(
+                                            hash = %bead_hash,
+                                            "InsertBeadsBatch sent to DB thread"
+                                        );
+                                    }
+                                    Err(error) => {
+                                        error!(error = ?error, "Database insertion command failed");
+                                    }
+                                }
                             }
                             Err(error) => {
-                                error!(error = ?error, "Database insertion command failed");
+                                error!(error = %error, hash = %bead_hash, "Failed to resolve promoted orphans for persistence");
                             }
                         }
                     }
-                    None => {
-                        error!(hash = %bead_hash, "Bead ID not found in index mapping");
+                    Err(error) => {
+                        error!(error = %error, hash = %bead_hash, "Failed to resolve bead for persistence");
                     }
                 }
                 let serialized_weak_share_bytes = bitcoin::consensus::serialize(&weak_share);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -14,7 +14,7 @@ use libp2p::{
     swarm::SwarmEvent,
     PeerId,
 };
-use node::db::db_handlers::{fetch_beads_in_batch, prepare_bead_tuple_data};
+use node::db::db_handlers::fetch_beads_in_batch;
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
 use node::SwarmHandler;
@@ -90,7 +90,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // starting from that block as genesis
     let initial_bead_fetch_handle = tokio::spawn(async move {
         let mut guard = braid_ref.write().await;
-        let fetched_beads = fetch_beads_in_batch(db_connection_pool_ref, 50).await?;
+        let fetched_beads = fetch_beads_in_batch(&db_connection_pool_ref, 50).await?;
         info!(beads = fetched_beads.len(), "Beads loaded from DB");
         for bead in &fetched_beads {
             let curr_bead_status = guard.extend(&bead);
@@ -646,32 +646,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             let mut peer_manager = peer_manager_arc.write().await;
                                             peer_manager.penalize_for_invalid_bead(&message.source);
                                         }
-                                    } else if let braid::AddBeadStatus::BeadAdded { .. } = status {
-
-                                     //Considering the index of the beads in braid will be same as the (insertion ids-1)
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
+                                    } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
+                                        let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
+                                            Some(data) => data,
                                             None => {
                                                 error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
                                                 continue;
                                             }
                                         };
-                                        let bead_hash = bead.block_header.block_hash();
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
-                                            Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead_hash,error);
-                                                continue;
-                                            }
-                                        };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead.clone(),txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
+                                        let removed_orphans = node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
+                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
                                            Ok(_)=>{
                                                debug!("Insert command sent successfully to db handler after receiving bead from peer");
                                            },
@@ -773,29 +757,17 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             let mut peer_manager = peer_manager_arc.write().await;
                                             peer_manager.penalize_for_invalid_bead(&message.source);
                                         }
-                                    } else if let braid::AddBeadStatus::BeadAdded { .. } = status {
-                                        let bead_id = match braid_data
-                                            .bead_index_mapping
-                                            .get(&bead.block_header.block_hash()) {
-                                            Some(id) => id,
+                                    } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
+                                        let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
+                                            Some(data) => data,
                                             None => {
                                                 error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
                                                 continue;
                                             }
                                         };
-                                        let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                            &braid_data.beads,
-                                            &braid_data.bead_index_mapping,
-                                            &bead,
-                                        ){
-                                            Ok(received_tuples)=>received_tuples,
-                                            Err(error)=>{
-                                                error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",bead.block_header.block_hash(),error);
-                                                continue;
-                                            }
-                                        };
+                                        let removed_orphans = node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
                                         // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,relative_json:relative_json,parent_timestamp_json:parent_timestamp_json,bead_id:*bead_id } }).await{
+                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
                                             Ok(_)=>{
                                                debug!("Insert command sent successfully to db handler after receiving bead from peer");
                                            },
@@ -986,10 +958,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         {
                                             let braid_lock = braid.read().await;
                                             for hash in hashes.iter() {
-                                                if let Some(index) =
+                                                if let Some(&index) =
                                                     braid_lock.bead_index_mapping.get(hash)
                                                 {
-                                                    if let Some(bead) = braid_lock.beads.get(*index) {
+                                                    if let Some(bead) = braid_lock.beads.get(index) {
                                                         beads.push(bead.clone());
                                                     }
                                                 }
@@ -1110,28 +1082,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                 let mut peer_manager = peer_manager_arc.write().await;
                                                 peer_manager.penalize_for_invalid_bead(&peer);
                                             }
-                                        } else if let braid::AddBeadStatus::BeadAdded { .. } = status {
+                                        } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
 
-                                            let bead_id = match braid_data
-                                                .bead_index_mapping
-                                                .get(&curr_beadhash) {
-                                                Some(id) => id,
+                                            let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
+                                                Some(data) => data,
                                                 None => {
                                                     error!(bead_hash = ?curr_beadhash, "Bead ID not found in index mapping (GetBeadsAfter)");
                                                     continue;
                                                 }
                                             };
-                                            let (txs_json, relative_json, parent_timestamp_json) = match prepare_bead_tuple_data(
-                                                &braid_data.beads,
-                                                &braid_data.bead_index_mapping,
-                                                &bead,
-                                            ){
-                                                Ok(received_tuples)=>received_tuples,
-                                                Err(error)=>{
-                                                    error!("An error occurred while preparing bead tuple data for bead with beadhash - {:?} due to {:?}",curr_beadhash,error);
-                                                    continue;
-                                                }
-                                            };
+                                            let removed_orphans = node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
                                             // update score of the peer
                                             {
                                                 let mut peer_manager = peer_manager_arc.write().await;
@@ -1147,7 +1107,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     error!("An error occurred while sending dashboard notification - {error}");
                                                 }
                                             }
-                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadSequentially { bead_to_insert: bead,txs_json:txs_json,parent_timestamp_json:parent_timestamp_json,relative_json:relative_json,bead_id:*bead_id } }).await{
+                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
                                                 Ok(_)=>{
                                                     debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
                                                 },
@@ -1577,9 +1537,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     match shutdown_signal {
         Ok(_) => {
             info!(component = "database", "Closing connection pool");
-            let pool = db_connection_pool.lock().await;
             //Closing all the existing connections to pool and committing from .db-wal to .db
-            pool.close().await;
+            db_connection_pool.close().await;
             info!(component = "database", "Connections closed");
             info!(component = "swarm", "Shutting down network swarm");
             swarm_handle.abort();

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -649,32 +649,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             peer_manager.penalize_for_invalid_bead(&message.source);
                                         }
                                     } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
-                                        let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
-                                            Ok(data) => data,
-                                            Err(error) => {
-                                                error!(error = %error, bead_hash = ?bead.block_header.block_hash(), "Failed to resolve bead for persistence");
-                                                continue;
-                                            }
-                                        };
-                                        let removed_orphans = match node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter()) {
-                                            Ok(orphans) => orphans,
-                                            Err(error) => {
-                                                error!(error = %error, "Failed to resolve promoted orphans for persistence");
-                                                continue;
-                                            }
-                                        };
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
-                                           Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
+                                        if let Err(error) = node::db::persist_added_bead(&braid_data, &bead, promoted_orphans.iter(), &db_tx).await {
+                                            error!(error = %error, bead_hash = ?bead.block_header.block_hash(), "Failed to persist bead");
+                                            continue;
+                                        }
                                         {
                                             let mut peer_manager = peer_manager_arc.write().await;
                                             peer_manager.update_score(&message.source, 1.0);
@@ -685,7 +663,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                                     debug!("Notification sent to dashboard notification sender from peer");
                                                 }
                                                 Err(error) => {
-                                                    error!("An error occurred while sending dashboard notification - {error}");
+                                                    debug!("No dashboard subscriber for new bead notification - {error}");
                                             }
                                 }
                                     }
@@ -766,33 +744,11 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             peer_manager.penalize_for_invalid_bead(&message.source);
                                         }
                                     } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
-                                        let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
-                                            Ok(data) => data,
-                                            Err(error) => {
-                                                error!(error = %error, bead_hash = ?bead.block_header.block_hash(), "Failed to resolve bead for persistence (GetAllBeads)");
-                                                continue;
-                                            }
-                                        };
-                                        let removed_orphans = match node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter()) {
-                                            Ok(orphans) => orphans,
-                                            Err(error) => {
-                                                error!(error = %error, "Failed to resolve promoted orphans for persistence (GetAllBeads)");
-                                                continue;
-                                            }
-                                        };
-                                        // update score of the peer and adding to local db store
-                                        let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
-                                            Ok(_)=>{
-                                               debug!("Insert command sent successfully to db handler after receiving bead from peer");
-                                           },
-                                           Err(error)=>{
-                                               error!(
-                                                   source = ?message.source,
-                                                   err = ?error.0,
-                                                   "An error occurred while sending insert bead command received from peer"
-                                               );
-                                           }
-                                        };
+                                        if let Err(error) = node::db::persist_added_bead(&braid_data, &bead, promoted_orphans.iter(), &db_tx).await {
+                                            error!(error = %error, bead_hash = ?bead.block_header.block_hash(), "Failed to persist bead (GetAllBeads)");
+                                            continue;
+                                        }
+                                        // update score of the peer
                                         {
                                             let mut peer_manager = peer_manager_arc.write().await;
                                             peer_manager.update_score(&message.source, 1.0);
@@ -1098,47 +1054,25 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                             }
                                         } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
 
-                                            let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
-                                                Ok(data) => data,
-                                                Err(error) => {
-                                                    error!(error = %error, bead_hash = ?curr_beadhash, "Failed to resolve bead for persistence (GetBeadsAfter)");
-                                                    continue;
-                                                }
-                                            };
-                                            let removed_orphans = match node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter()) {
-                                                Ok(orphans) => orphans,
-                                                Err(error) => {
-                                                    error!(error = %error, bead_hash = ?curr_beadhash, "Failed to resolve promoted orphans for persistence (GetBeadsAfter)");
-                                                    continue;
-                                                }
-                                            };
+                                            //persisting the received beads from peer onto DB(disk)
+                                            if let Err(error) = node::db::persist_added_bead(&braid_data, &bead, promoted_orphans.iter(), &db_tx).await {
+                                                error!(error = %error, bead_hash = ?curr_beadhash, "Failed to persist bead (GetBeadsAfter)");
+                                                continue;
+                                            }
                                             // update score of the peer
                                             {
                                                 let mut peer_manager = peer_manager_arc.write().await;
                                                 peer_manager.update_score(&peer, 1.0);
                                             }
-                                            //persisting the received beads from peer onto DB(disk)
                                             let res =  dashboard_notifier.new_bead.send(Some(bead.clone()));
                                             match res {
                                                 Ok(_) => {
                                                     debug!("Notification sent to dashboard notification sender from IBD");
                                                 }
                                                 Err(error) => {
-                                                    error!("An error occurred while sending dashboard notification - {error}");
+                                                    debug!("No dashboard subscriber for new bead notification - {error}");
                                                 }
                                             }
-                                            match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
-                                                Ok(_)=>{
-                                                    debug!(beadhash=?curr_beadhash,"Bead received in IBD persisted over disk with beadhash and status BeadAdded");
-                                                },
-                                                Err(error)=>{
-                                                    tracing::error!(
-                                                        peer = %peer,
-                                                        err = ?error.0,
-                                                        "An error occurred while persisting received bead from peer"
-                                                    );
-                                                }
-                                            };
                                         }
                                     }
                                     //Preparing next batch request to be sent to the sync node

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -15,6 +15,7 @@ use libp2p::{
     PeerId,
 };
 use node::db::db_handlers::fetch_beads_in_batch;
+use node::db::db_handlers::FETCH_BEAD_BATCH_SIZE;
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::utils::BeadHash;
 use node::SwarmHandler;
@@ -90,7 +91,8 @@ async fn main() -> Result<(), Box<dyn Error>> {
     // starting from that block as genesis
     let initial_bead_fetch_handle = tokio::spawn(async move {
         let mut guard = braid_ref.write().await;
-        let fetched_beads = fetch_beads_in_batch(&db_connection_pool_ref, 50).await?;
+        let fetched_beads =
+            fetch_beads_in_batch(&db_connection_pool_ref, FETCH_BEAD_BATCH_SIZE).await?;
         info!(beads = fetched_beads.len(), "Beads loaded from DB");
         for bead in &fetched_beads {
             let curr_bead_status = guard.extend(&bead);

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -648,13 +648,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         }
                                     } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
                                         let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
-                                            Some(data) => data,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping");
+                                            Ok(data) => data,
+                                            Err(error) => {
+                                                error!(error = %error, bead_hash = ?bead.block_header.block_hash(), "Failed to resolve bead for persistence");
                                                 continue;
                                             }
                                         };
-                                        let removed_orphans = node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
+                                        let removed_orphans = match node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter()) {
+                                            Ok(orphans) => orphans,
+                                            Err(error) => {
+                                                error!(error = %error, "Failed to resolve promoted orphans for persistence");
+                                                continue;
+                                            }
+                                        };
                                         let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
                                            Ok(_)=>{
                                                debug!("Insert command sent successfully to db handler after receiving bead from peer");
@@ -759,13 +765,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         }
                                     } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
                                         let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
-                                            Some(data) => data,
-                                            None => {
-                                                error!(bead_hash = ?bead.block_header.block_hash(), "Bead ID not found in index mapping (GetAllBeads)");
+                                            Ok(data) => data,
+                                            Err(error) => {
+                                                error!(error = %error, bead_hash = ?bead.block_header.block_hash(), "Failed to resolve bead for persistence (GetAllBeads)");
                                                 continue;
                                             }
                                         };
-                                        let removed_orphans = node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
+                                        let removed_orphans = match node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter()) {
+                                            Ok(orphans) => orphans,
+                                            Err(error) => {
+                                                error!(error = %error, "Failed to resolve promoted orphans for persistence (GetAllBeads)");
+                                                continue;
+                                            }
+                                        };
                                         // update score of the peer and adding to local db store
                                         let _query_send_result = match db_tx.send(node::db::BraidpoolDBTypes::InsertTupleTypes { query: node::db::InsertTupleTypes::InsertBeadsBatch { beads: vec![bead_data], removed_orphans } }).await{
                                             Ok(_)=>{
@@ -1085,13 +1097,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                                         } else if let braid::AddBeadStatus::BeadAdded { promoted_orphans } = &status {
 
                                             let bead_data = match node::db::BeadInsertData::resolve(&braid_data, &bead) {
-                                                Some(data) => data,
-                                                None => {
-                                                    error!(bead_hash = ?curr_beadhash, "Bead ID not found in index mapping (GetBeadsAfter)");
+                                                Ok(data) => data,
+                                                Err(error) => {
+                                                    error!(error = %error, bead_hash = ?curr_beadhash, "Failed to resolve bead for persistence (GetBeadsAfter)");
                                                     continue;
                                                 }
                                             };
-                                            let removed_orphans = node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter());
+                                            let removed_orphans = match node::db::BeadInsertData::resolve_many(&braid_data, promoted_orphans.iter()) {
+                                                Ok(orphans) => orphans,
+                                                Err(error) => {
+                                                    error!(error = %error, bead_hash = ?curr_beadhash, "Failed to resolve promoted orphans for persistence (GetBeadsAfter)");
+                                                    continue;
+                                                }
+                                            };
                                             // update score of the peer
                                             {
                                                 let mut peer_manager = peer_manager_arc.write().await;

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -161,6 +161,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let rpc_peer_manager = peer_manager_arc.clone();
     let rpc_connection_mapping = connection_mapping_for_rpc.clone();
     let rpc_latest_template = latest_template.clone();
+    let rpc_db_tx = db_tx.clone();
     let server_join = tokio::spawn(async move {
         run_rpc_server(
             rpc_braid,
@@ -170,6 +171,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
             rpc_latest_template,
             rpc_proxy_tx,
             bitcoin_rpc_config,
+            rpc_db_tx,
         )
         .await
     });

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -669,7 +669,7 @@ impl RpcServer for RpcServerImpl {
         let braid_data = self.braid_arc.read().await;
 
         let parent_index = match braid_data.bead_index_mapping.get(&parent_hash) {
-            Some(index) => *index,
+            Some(&index) => index,
             None => return Err(ErrorObjectOwned::owned(3, "Bead not found", None::<()>)),
         };
 

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -3,6 +3,7 @@ use crate::braid::consensus_functions;
 use crate::braid::consensus_functions::highest_work_path;
 use crate::braid::AddBeadStatus;
 use crate::braid::Braid;
+use crate::db::BraidpoolDBTypes;
 use crate::ipc::client::QueueStats;
 use crate::peer_manager::PeerManager;
 use crate::stratum;
@@ -274,6 +275,7 @@ pub struct RpcServerImpl {
     rpc_proxy_tx: mpsc::UnboundedSender<RpcProxyCommand>,
     bitcoin_rpc_config: Option<BitcoinRpcConfig>,
     dashboard_events: Arc<DashboardEvents>,
+    db_tx: mpsc::Sender<BraidpoolDBTypes>,
 }
 
 impl RpcServerImpl {
@@ -284,6 +286,7 @@ impl RpcServerImpl {
         latest_block_template: Arc<Mutex<BlockTemplate>>,
         rpc_proxy_tx: mpsc::UnboundedSender<RpcProxyCommand>,
         bitcoin_rpc_config: Option<BitcoinRpcConfig>,
+        db_tx: mpsc::Sender<BraidpoolDBTypes>,
     ) -> Self {
         Self {
             braid_arc: braid_shared_pointer,
@@ -293,6 +296,7 @@ impl RpcServerImpl {
             rpc_proxy_tx,
             bitcoin_rpc_config,
             dashboard_events: DashboardEvents::new(),
+            db_tx,
         }
     }
 
@@ -329,10 +333,26 @@ impl RpcServer for RpcServerImpl {
         );
         let mut braid_data = self.braid_arc.write().await;
         let success_status = braid_data.extend(&bead);
-        drop(braid_data);
 
         match success_status {
-            AddBeadStatus::BeadAdded { .. } => {
+            AddBeadStatus::BeadAdded { promoted_orphans } => {
+                if let Err(error) = crate::db::persist_added_bead(
+                    &braid_data,
+                    &bead,
+                    promoted_orphans.iter(),
+                    &self.db_tx,
+                )
+                .await
+                {
+                    drop(braid_data);
+                    error!(error = %error, hash = %bead_hash, "Failed to persist bead added via RPC");
+                    return Err(ErrorObjectOwned::owned(
+                        5,
+                        format!("Failed to persist bead: {}", error),
+                        None::<()>,
+                    ));
+                }
+                drop(braid_data);
                 let _ = self.dashboard_events.new_bead.send(Some(bead));
                 Ok("Bead added successfully".to_string())
             }
@@ -1095,6 +1115,7 @@ pub async fn run_rpc_server(
     latest_block_template: Arc<Mutex<BlockTemplate>>,
     rpc_proxy_tx: mpsc::UnboundedSender<RpcProxyCommand>,
     bitcoin_rpc_config: Option<BitcoinRpcConfig>,
+    db_tx: mpsc::Sender<BraidpoolDBTypes>,
 ) -> Result<(SocketAddr, Arc<DashboardEvents>), ()> {
     //Initializing the middleware
     let rpc_middleware =
@@ -1119,6 +1140,7 @@ pub async fn run_rpc_server(
         latest_block_template,
         rpc_proxy_tx,
         bitcoin_rpc_config.clone(),
+        db_tx,
     );
     let dashboard_notification_ref = rpc_impl.dashboard_events();
     let handle = server.start(rpc_impl.into_rpc());
@@ -1204,7 +1226,16 @@ async fn call_bitcoin_rpc_direct(
         .result
         .ok_or_else(|| "RPC response missing result field".into())
 }
-
+/// Returns a DB command sender backed by a background task that drains the
+/// channel, so tests can construct an [`RpcServerImpl`] without a real DB
+/// handler while keeping `db_tx.send(..)` calls succeeding.
+#[cfg(test)]
+fn test_db_tx() -> mpsc::Sender<BraidpoolDBTypes> {
+    let (tx, mut rx) =
+        mpsc::channel::<BraidpoolDBTypes>(crate::db::db_handlers::DB_CHANNEL_CAPACITY);
+    tokio::spawn(async move { while rx.recv().await.is_some() {} });
+    tx
+}
 #[tokio::test]
 pub async fn test_extend_rpc() {
     let test_bead1 = create_test_bead(1, None);
@@ -1222,6 +1253,7 @@ pub async fn test_extend_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1274,6 +1306,7 @@ pub async fn test_same_bead_extend() {
             tx
         },
         None, // No Bitcoin RPC config for tests
+        test_db_tx(),
     );
     let _handle = server.start(rpc_impl.into_rpc());
 
@@ -1329,6 +1362,7 @@ pub async fn test_cohort_count_rpc() {
             tx
         },
         None, // No Bitcoin RPC config for tests
+        test_db_tx(),
     );
     let _handle = server.start(rpc_impl.into_rpc());
 
@@ -1395,6 +1429,7 @@ pub async fn test_get_bead_count_cli_flow() {
             tx
         },
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1436,6 +1471,7 @@ pub async fn test_get_tips_cli_flow() {
             tx
         },
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1473,6 +1509,7 @@ pub async fn test_get_bead_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1533,6 +1570,7 @@ pub async fn test_get_cohort_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1584,6 +1622,7 @@ pub async fn test_get_genesis_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1623,6 +1662,7 @@ pub async fn test_get_parents_and_children_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1691,6 +1731,7 @@ pub async fn test_get_hwpath_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1734,6 +1775,7 @@ pub async fn test_get_braid_info_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1772,6 +1814,7 @@ pub async fn test_get_node_info_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1831,6 +1874,7 @@ pub async fn test_get_peer_info_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx.clone(),
         None,
+        test_db_tx(),
     );
     let handle_empty = server_empty.start(rpc_impl_empty.into_rpc());
 
@@ -1873,6 +1917,7 @@ pub async fn test_get_peer_info_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     );
     let handle_with_peers = server_with_peers.start(rpc_impl_with_peers.into_rpc());
 
@@ -1932,6 +1977,7 @@ pub async fn test_get_miner_info_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -1969,6 +2015,7 @@ pub async fn test_staged_transactions_rpc() {
         Arc::clone(&latest_block),
         proxy_tx,
         None,
+        test_db_tx(),
     );
     let handle = server.start(rpc_impl.into_rpc());
 
@@ -2059,6 +2106,7 @@ pub async fn test_get_ipc_stats_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -2110,6 +2158,7 @@ pub async fn test_get_ipc_stats_rpc_simple() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -2161,6 +2210,7 @@ pub async fn test_unstage_transactions_rpc_simple() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -2219,6 +2269,7 @@ pub async fn test_get_mining_info_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();
@@ -2355,6 +2406,7 @@ pub async fn test_subscribe_bead_rpc() {
         Arc::new(Mutex::new(stratum::BlockTemplate::default())),
         proxy_tx,
         None,
+        test_db_tx(),
     )
     .await
     .unwrap();

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -750,7 +750,7 @@ impl DownstreamClient {
                 });
             }
         };
-        let _swarm_command_sent = match swarm_handler
+        match swarm_handler
             .lock()
             .await
             .propagate_valid_bead(
@@ -771,11 +771,16 @@ impl DownstreamClient {
                     peer = %self.downstream_ip,
                     "Candidate block submitted"
                 );
-                Ok(StratumResponses::StandardResponse {
-                    std_response: StandardResponse::new_ok(Some(client_request_id), json!(true)),
-                })
             }
-            Err(error) => Err(error),
+            Err(error) => {
+                error!(
+                    connection_id = %connection_id_hex,
+                    peer = %self.downstream_ip,
+                    error = %error,
+                    "Failed to propagate/persist self-mined bead"
+                );
+                return Err(error);
+            }
         };
         Ok(StratumResponses::StandardResponse {
             std_response: StandardResponse::new_ok(Some(client_request_id), json!(true)),


### PR DESCRIPTION
This is a continuation of PR #309 and PR #474 having scope :-  

- Updating db_handler with Batched query insertion and removing `SequentialQueryInsertion`.
- Removing the tests associated with sequential insertion method and updating the existent method wrt to orphan handling.
- Persisting orphan beads via db command handlers and adding helpers to `Braid` for constructing parents set and passing into `BeadInsertData` containing parent_bead_idx and timestamp as per schema for insertion,to be passed onto the db_handler .
- Adding appropriate error types for handling consensus failures.
