### PR TITLE
Removing `futures::Mutex` for `tokio::sync::Mutex`

### DIFF
--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -10,13 +10,15 @@ use bitcoin::{
     absolute::MedianTimePast, ecdsa::Signature, BlockHash, BlockTime, BlockVersion, CompactTarget,
     PublicKey, TxMerkleNode, Txid,
 };
-use futures::lock::Mutex;
 use num::ToPrimitive;
 use serde_json::json;
 use sqlx::{Pool, Row, Sqlite};
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
-use tokio::sync::mpsc::{Receiver, Sender};
+use tokio::sync::{
+    mpsc::{Receiver, Sender},
+    Mutex,
+};
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 const DB_CHANNEL_CAPACITY: usize = 1024;

--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -12,8 +12,10 @@ use std::{
     time::UNIX_EPOCH,
 };
 
-use futures::lock::Mutex;
-use tokio::sync::mpsc::{self, Receiver, Sender};
+use tokio::sync::{
+    mpsc::{self, Receiver, Sender},
+    Mutex,
+};
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
 

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -1,7 +1,6 @@
 use bitcoin::consensus::encode::deserialize;
 use bitcoin::Network;
 use clap::Parser;
-use futures::lock::Mutex;
 use futures::StreamExt;
 use libp2p::kad::BootstrapOk;
 use libp2p::{
@@ -57,7 +56,7 @@ const ADDR_REFRENCE: &str =
     "/dnsaddr/french.braidpool.net/p2p/12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3";
 use tokio::sync::{
     mpsc::{self},
-    RwLock,
+    Mutex, RwLock,
 };
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn Error>> {

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -10,7 +10,6 @@ use crate::stratum::BlockTemplate;
 use crate::utils::BeadHash;
 use bitcoin::block::HeaderExt;
 use bitcoin::Transaction;
-use futures::lock::Mutex;
 use jsonrpsee::core::async_trait;
 use jsonrpsee::core::middleware::Batch;
 use jsonrpsee::core::middleware::Notification;
@@ -30,7 +29,7 @@ use std::collections::HashSet;
 use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
-use tokio::sync::{mpsc, oneshot, watch, RwLock};
+use tokio::sync::{mpsc, oneshot, watch, Mutex, RwLock};
 use tracing::{error, info, warn};
 
 #[cfg(test)]

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -6,7 +6,7 @@ use bitcoin::consensus::serialize;
 use bitcoin::io::Cursor;
 use bitcoin::{absolute::Decodable, Transaction};
 use bitcoin::{BlockHash, BlockHeader, BlockTime, TxMerkleNode, Txid, Witness};
-use futures::{lock::Mutex, FutureExt};
+use futures::FutureExt;
 use num::ToPrimitive;
 use rand::random;
 use serde::{Deserialize, Serialize};
@@ -20,7 +20,7 @@ use tokio::{
         tcp::{OwnedReadHalf, OwnedWriteHalf},
         TcpListener,
     },
-    sync::{mpsc, oneshot, RwLock},
+    sync::{mpsc, oneshot, Mutex, RwLock},
 };
 use tokio_stream::StreamExt;
 use tokio_util::codec::{FramedRead, LinesCodec};
@@ -2068,11 +2068,10 @@ mod test {
         absolute::LockTime, pow::CompactTargetExt, script::ScriptBufExt, Amount, BlockHash,
         BlockVersion, OutPoint, ScriptBuf, Sequence, TxIn, TxOut,
     };
-    use futures::lock::Mutex;
     use tokio::{
         io::{AsyncBufReadExt, AsyncWriteExt, BufReader},
         net::TcpStream,
-        sync::{mpsc, oneshot, RwLock},
+        sync::{mpsc, oneshot, Mutex, RwLock},
     };
 
     #[tokio::test]


### PR DESCRIPTION
Replace all `futures::lock::Mutex` imports and usages across the node crate with `tokio::sync::Mutex` so every async lock comes from a single, runtime-integrated primitive.

