### PR TITLE
fix(miner-api): update IP and MAC handling in miner device management

### DIFF
--- a/miner_api/db_models.py
+++ b/miner_api/db_models.py
@@ -10,7 +10,7 @@ class MinerDevice(Base):
     __tablename__ = "miner_devices"
     
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    ip = Column(String(45), nullable=False, index=True)  # IPv4 or IPv6
+    ip = Column(String(45), nullable=False, index=True)  # IPv4 or IPv6 — mutable, not unique
     name = Column(String(255), nullable=True)  # User-defined name for the miner
     
     # Device identification

--- a/miner_api/db_models.py
+++ b/miner_api/db_models.py
@@ -10,12 +10,12 @@ class MinerDevice(Base):
     __tablename__ = "miner_devices"
     
     id = Column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
-    ip = Column(String(45), unique=True, nullable=False, index=True)  # IPv4 or IPv6
+    ip = Column(String(45), nullable=False, index=True)  # IPv4 or IPv6
     name = Column(String(255), nullable=True)  # User-defined name for the miner
     
     # Device identification
     hostname = Column(String(255), nullable=True)
-    mac = Column(String(17), nullable=True)
+    mac = Column(String(17), nullable=True, unique=True, index=True) 
     make = Column(String(100), nullable=True)
     model = Column(String(100), nullable=True)
     firmware = Column(String(100), nullable=True)

--- a/miner_api/db_services.py
+++ b/miner_api/db_services.py
@@ -12,9 +12,15 @@ from .services import MinerService
 logger = logging.getLogger("miner_api")
 
 
+def _normalize_mac(mac: Optional[str]) -> Optional[str]:
+    if not mac:
+        return None
+    return mac.strip().lower().replace("-", ":")
+
+
 def _apply_device_fields(miner: MinerDevice, data: dict) -> None:
     miner.hostname = data.get("hostname")
-    miner.mac = data.get("mac")
+    miner.mac = _normalize_mac(data.get("mac"))
     miner.make = data.get("make")
     miner.model = data.get("model")
     miner.firmware = data.get("firmware")
@@ -57,6 +63,14 @@ class MinerDBService:
         """Add a new miner device to the database and fetch its initial data."""
         result = await MinerService.get_miner_data(ip)
         if not result.get("success"):
+            existing_by_ip = await MinerDBService.get_miner_by_ip(db, ip)
+            if existing_by_ip:
+                return {
+                    "success": False,
+                    "error": f"Miner with IP {ip} already exists",
+                    "already_exists": True,
+                    "miner": existing_by_ip.to_dict(),
+                }
             miner = MinerDevice(
                 ip=ip,
                 name=name,
@@ -66,15 +80,10 @@ class MinerDBService:
             db.add(miner)
             try:
                 await db.commit()
-            except IntegrityError:
+            except Exception as e:
                 await db.rollback()
-                existing = await MinerDBService.get_miner_by_ip(db, ip)
-                return {
-                    "success": False,
-                    "error": f"Miner with IP {ip} already exists",
-                    "already_exists": True,
-                    "miner": existing.to_dict() if existing else None,
-                }
+                logger.error(f"Database error adding offline miner {ip}: {e}")
+                return {"success": False, "error": "Database error adding miner", "db_error": True}
             await db.refresh(miner)
             logger.info(f"Added offline miner device: {ip}")
             return {
@@ -83,32 +92,30 @@ class MinerDBService:
                 "miner": miner.to_dict(),
             }
         data = result["data"]
-        mac = data.get("mac")
-        if mac:
-            # MAC lookup 
-            existing = await MinerDBService.get_miner_by_mac(db, mac)
-            if existing:
-                old_ip = existing.ip
-                existing.ip = ip
-                if name is not None:
-                    existing.name = name
-                _apply_device_fields(existing, data)
-                db.add(existing)
+        mac = _normalize_mac(data.get("mac"))
+        if not mac:
+            logger.error(f"Device at {ip} did not report a MAC address; cannot add miner.")
+            return {"success": False, "error": "Device did not report a MAC address"}
+
+        data["mac"] = mac
+        existing = await MinerDBService.get_miner_by_mac(db, mac)
+        if existing:
+            old_ip = existing.ip
+            existing.ip = ip
+            if name is not None:
+                existing.name = name
+            _apply_device_fields(existing, data)
+            db.add(existing)
+            try:
                 await db.commit()
                 await db.refresh(existing)
-                if old_ip != ip:
-                    logger.info(f"Miner MAC {mac} IP updated from {old_ip} to {ip}, record updated.")
-                return {"success": True, "miner": existing.to_dict()}
-
-        # No existing record by MAC (or device has no MAC) 
-        existing_by_ip = await MinerDBService.get_miner_by_ip(db, ip)
-        if existing_by_ip:
-            return {
-                "success": False,
-                "error": f"Miner with IP {ip} already exists",
-                "already_exists": True,
-                "miner": existing_by_ip.to_dict(),
-            }
+            except Exception as e:
+                await db.rollback()
+                logger.error(f"Database error updating miner MAC {mac}: {e}")
+                return {"success": False, "error": "Database error updating miner", "db_error": True}
+            if old_ip != ip:
+                logger.info(f"Miner MAC {mac} IP updated from {old_ip} to {ip}, record updated.")
+            return {"success": True, "miner": existing.to_dict()}
 
         miner = MinerDevice.from_miner_data(ip, data, name=name)
         db.add(miner)
@@ -116,12 +123,12 @@ class MinerDBService:
             await db.commit()
         except IntegrityError:
             await db.rollback()
-            existing_by_ip = await MinerDBService.get_miner_by_ip(db, ip)
+            existing = await MinerDBService.get_miner_by_mac(db, mac)
             return {
                 "success": False,
-                "error": f"Miner with IP {ip} already exists",
+                "error": f"Miner with MAC {mac} already exists",
                 "already_exists": True,
-                "miner": existing_by_ip.to_dict() if existing_by_ip else None,
+                "miner": existing.to_dict() if existing else None,
             }
         await db.refresh(miner)
 
@@ -131,17 +138,24 @@ class MinerDBService:
     
     @staticmethod
     async def get_miner_by_ip(db: AsyncSession, ip: str) -> Optional[MinerDevice]:
-        """Get a miner by IP address."""
+        """Get a miner by IP address. Returns the first match; IP is no longer unique."""
         result = await db.execute(
             select(MinerDevice).where(MinerDevice.ip == ip)
         )
-        return result.scalar_one_or_none()
+        return result.scalars().first()
     @staticmethod
     async def get_miner_by_mac(db: AsyncSession, mac: str) -> Optional[MinerDevice]:
         result = await db.execute(
             select(MinerDevice).where(MinerDevice.mac == mac)
         )
-        return result.scalar_one_or_none()
+        rows = result.scalars().all()
+        if not rows:
+            return None
+        if len(rows) > 1:
+            logger.warning(
+                f"Multiple rows found for MAC {mac}; returning first match to allow recovery"
+            )
+        return rows[0]
 
     @staticmethod
     async def get_miner_by_id(db: AsyncSession, miner_id: str) -> Optional[MinerDevice]:

--- a/miner_api/db_services.py
+++ b/miner_api/db_services.py
@@ -1,4 +1,3 @@
-
 import asyncio
 from typing import Optional, List
 from sqlalchemy import select
@@ -56,17 +55,7 @@ class MinerDBService:
     @staticmethod
     async def add_miner(db: AsyncSession, ip: str, name: Optional[str] = None) -> dict:
         """Add a new miner device to the database and fetch its initial data."""
-        existing = await MinerDBService.get_miner_by_ip(db, ip) # Check if miner already exists
-        if existing:
-            return {
-                "success": False,
-                "error": f"Miner with IP {ip} already exists",
-                "already_exists": True,
-                "miner": existing.to_dict()
-            }
-        
         result = await MinerService.get_miner_data(ip)
-        
         if not result.get("success"):
             miner = MinerDevice(
                 ip=ip,
@@ -76,7 +65,7 @@ class MinerDBService:
             )
             db.add(miner)
             try:
-                await db.commit()  
+                await db.commit()
             except IntegrityError:
                 await db.rollback()
                 existing = await MinerDBService.get_miner_by_ip(db, ip)
@@ -84,37 +73,61 @@ class MinerDBService:
                     "success": False,
                     "error": f"Miner with IP {ip} already exists",
                     "already_exists": True,
-                    "miner": existing.to_dict() if existing else None
+                    "miner": existing.to_dict() if existing else None,
                 }
             await db.refresh(miner)
-            
+            logger.info(f"Added offline miner device: {ip}")
             return {
                 "success": True,
                 "warning": "Miner added but currently offline",
-                "miner": miner.to_dict()
+                "miner": miner.to_dict(),
             }
-        
-        miner = MinerDevice.from_miner_data(ip, result["data"], name=name)
+        data = result["data"]
+        mac = data.get("mac")
+        if mac:
+            # MAC lookup 
+            existing = await MinerDBService.get_miner_by_mac(db, mac)
+            if existing:
+                old_ip = existing.ip
+                existing.ip = ip
+                if name is not None:
+                    existing.name = name
+                _apply_device_fields(existing, data)
+                db.add(existing)
+                await db.commit()
+                await db.refresh(existing)
+                if old_ip != ip:
+                    logger.info(f"Miner MAC {mac} IP updated from {old_ip} to {ip}, record updated.")
+                return {"success": True, "miner": existing.to_dict()}
+
+        # No existing record by MAC (or device has no MAC) 
+        existing_by_ip = await MinerDBService.get_miner_by_ip(db, ip)
+        if existing_by_ip:
+            return {
+                "success": False,
+                "error": f"Miner with IP {ip} already exists",
+                "already_exists": True,
+                "miner": existing_by_ip.to_dict(),
+            }
+
+        miner = MinerDevice.from_miner_data(ip, data, name=name)
         db.add(miner)
         try:
             await db.commit()
         except IntegrityError:
             await db.rollback()
-            existing = await MinerDBService.get_miner_by_ip(db, ip)
+            existing_by_ip = await MinerDBService.get_miner_by_ip(db, ip)
             return {
                 "success": False,
                 "error": f"Miner with IP {ip} already exists",
                 "already_exists": True,
-                "miner": existing.to_dict() if existing else None
+                "miner": existing_by_ip.to_dict() if existing_by_ip else None,
             }
         await db.refresh(miner)
-        
+
         logger.info(f"Added new miner device: {ip} (model: {miner.model})")
-        
-        return {
-            "success": True,
-            "miner": miner.to_dict()
-        }
+
+        return {"success": True, "miner": miner.to_dict()}
     
     @staticmethod
     async def get_miner_by_ip(db: AsyncSession, ip: str) -> Optional[MinerDevice]:
@@ -123,7 +136,13 @@ class MinerDBService:
             select(MinerDevice).where(MinerDevice.ip == ip)
         )
         return result.scalar_one_or_none()
-    
+    @staticmethod
+    async def get_miner_by_mac(db: AsyncSession, mac: str) -> Optional[MinerDevice]:
+        result = await db.execute(
+            select(MinerDevice).where(MinerDevice.mac == mac)
+        )
+        return result.scalar_one_or_none()
+
     @staticmethod
     async def get_miner_by_id(db: AsyncSession, miner_id: str) -> Optional[MinerDevice]:
         """Get a miner by ID."""


### PR DESCRIPTION
This PR improves miner device management by using the MAC address as the primary device identifier while treating the IP address as mutable. It resolves issues where miners receiving a new IP address (e.g., due to DHCP) were incorrectly treated as new devices, resulting in duplicate database entries.
### Workflow
add_miner(ip)
├── Device unreachable (offline)
│   ├── IP already in DB? → return already_exists
│   └── Create offline record (IP-only, no MAC yet)
│
└── Device online
    ├── No MAC returned → return error (hard stop)
    ├── MAC found in DB → update IP + fields on existing record
    └── MAC not in DB → create new record
        └── Race-condition duplicate MAC? → IntegrityError → return already_exists

fix #485 