### PR TITLE
db: read parent_timestamp as u32 to avoid 2038 overflow

### DIFF
--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -422,7 +422,7 @@ pub async fn fetch_beads_in_batch(
             }
             if let (Ok(parent_hash), Ok(ts)) = (
                 row.try_get::<Vec<u8>, _>("parent_hash"),
-                row.try_get::<i32, _>("parent_timestamp"),
+                row.try_get::<u32, _>("parent_timestamp"),
             ) {
                 if parent_hash.is_empty() {
                     //Genesis bead case
@@ -439,7 +439,7 @@ pub async fn fetch_beads_in_batch(
                 bead.committed_metadata
                     .parent_bead_timestamps
                     .0
-                    .push(MedianTimePast::from_u32(ts as u32).unwrap());
+                    .push(MedianTimePast::from_u32(ts).unwrap());
             }
         }
     }


### PR DESCRIPTION
### What

In `fetch_beads_in_batch` (`node/src/db/db_handlers.rs`), `parent_timestamp` is read from the query result as `i32` and then cast back to unsigned with `ts as u32`:

```rust
row.try_get::<i32, _>("parent_timestamp"),
...
.push(MedianTimePast::from_u32(ts as u32).unwrap());
```

Since the column stores a Bitcoin block timestamp (unsigned seconds since the epoch), reading it as `i32` overflows for any timestamp at or after **2038-01-19 03:14:08**, which will panic or produce invalid parent timestamps.

### Change

Read the column as `u32` directly and drop the now-redundant `as u32` cast. This matches how the sibling timestamp columns in the same query are already read (`nTime`, `start_timestamp`, `broadcast_timestamp` all use `get::<u32, _>`).

### Notes

- Minimal, behavior-preserving for all in-range timestamps.
- I wasn't able to run the full build locally as I don't have the `capnp` toolchain set up on this machine; the change is a two-line type fix consistent with the surrounding code, so CI should cover the build/lint.

Fixes #449