### PR TITLE
tests: fix mutable default argument in all_ancestors

### DIFF
--- a/tests/braid.py
+++ b/tests/braid.py
@@ -74,11 +74,13 @@ def generation(beads, children=None):
         retval |= children[b]
     return retval
 
-def all_ancestors_recursive(b, parents, ancestors={}):
+def all_ancestors_recursive(b, parents, ancestors=None):
     """ Gets all ancestors for a bead <b>, filling in ancestors of
         any other ancestors encountered, using a recursive
         algorithm.  Assumes b not in parents and b not in ancestors.
     """
+    if ancestors is None:
+        ancestors = {}
     ancestors[b] = set(copy(parents[b]))
     for p in parents[b]:
         if p not in ancestors:
@@ -86,11 +88,13 @@ def all_ancestors_recursive(b, parents, ancestors={}):
         ancestors[b].update(ancestors[p])
     return ancestors
 
-def all_ancestors(b, parents, ancestors={}):
+def all_ancestors(b, parents, ancestors=None):
     """ Gets all ancestors for a bead <b>, filling in ancestors of any other
         ancestors encountered, using an iterative algorithm. Assumes b not in
         parents and b not in ancestors.
     """
+    if ancestors is None:
+        ancestors = {}
     work_stack = [(b, False)]  # (bead, is_processed)
 
     while work_stack:

--- a/tests/test_braid_parametrized.py
+++ b/tests/test_braid_parametrized.py
@@ -150,6 +150,23 @@ class TestAllAncestors:
         # With distinct explicit dicts, bead 1 should only record bead 0.
         assert a2[1] == {0}
 
+    def test_default_ancestors_dict_is_isolated(self):
+        """Calls that omit the ancestors argument must not share state.
+
+        Regression test: all_ancestors/all_ancestors_recursive previously used a
+        mutable default argument (ancestors={}), so a single dict was reused
+        across every call. Repeated calls on different graphs then returned stale
+        ancestor sets cached from an earlier call.
+        """
+        graph_a = {0: set(), 1: {0}}    # bead 1's only ancestor is 0
+        graph_b = {0: set(), 1: set()}  # bead 1 is a genesis: no ancestors
+        for func in (all_ancestors, all_ancestors_recursive):
+            first = func(1, graph_a)    # no explicit ancestors dict
+            second = func(1, graph_b)   # no explicit ancestors dict, same bead index
+            assert first[1] == {0}, func.__name__
+            # Would be {0} (leaked from the first call) if the default were shared.
+            assert second[1] == set(), func.__name__
+
 
 # cohorts()
 class TestCohorts:


### PR DESCRIPTION
### What

`all_ancestors` and `all_ancestors_recursive` in `tests/braid.py` use a mutable default argument, `ancestors={}`. Python evaluates default arguments once at definition time, so every call that omits the argument shares one dict.

When callers reuse bead indices across different graphs — which `load_braid` does, since it renumbers every fixture's beads `0..n` — later calls find those indices already cached and return **stale ancestor sets** instead of recomputing. Concretely, `test_all_ancestors` in `test_braid.py` calls with the default dict; after the first fixture populates beads `0..49`, every later fixture finds those indices cached and skips recomputation, so most fixtures are no longer actually exercised.

### Change

- Switch both functions to the `ancestors=None` / `if ancestors is None: ancestors = {}` idiom so each defaulted call starts fresh. All internal callers already pass an explicit `ancestors` dict, so their behaviour is unchanged.
- Add a regression test (`test_default_ancestors_dict_is_isolated`) that calls both functions without an explicit dict on two different graphs and asserts no state leaks between calls. It fails on the shared-default behaviour and passes with the fix.

### Notes

- `tests/` unittest and pytest suites pass. (`test_simulator_api.py`'s websocket test errors on Windows due to signal handling — unrelated to this change.)
- I left `all_ancestors_recursive` delegating to the iterative traversal on purpose: `simulator.py` raises the recursion limit and notes that deep recursion can blow the stack on large cohorts, so making it genuinely recursive seemed like a separate, riskier decision better left to a maintainer.
