### PR TITLE
fix: canonicalize parents to ensure deterministic bead hash (#426)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,68 +1,57 @@
-# Welcome to BraidPool contributing guide
+# Contributing to Braidpool
 
-Thank you for investing your time in contributing to our project!
+Contributing to open source is one of the best things you can do. It not only benefits you but many others and projects like Braidpool, which aims to solve one of the critical problems in Bitcoin about centralisation; this becomes even more important. Braidpool is a pure open-source project, meaning anyone can run, modify and use this implementation in its own way. Braidpool is designed to remove centralisation of mining pools and provides a way to overcome this issue.
+<br/> <br>
+With this responsibility, we also want to put the right efforts into development so everything goes smoothly and in a collaborative way. For this, there are some guidelines designed that will help us to work together so we can read, write and understand each other's code in an efficient way.
 
-In this guide, you will get an overview of a contribution workflow from opening an issue, creating a PR, reviewing, and merging the PR.
+## Initials
 
-## New contributor guide
+We deeply value each and every contributions made to Braidpool, we take this as a huge step to make Bitcoin safer and sustainable in future. So, new contributors are always needed and appreciated. <br><br>
+Before moving further it's best to familiarize yourself with the Braidpool codebase structure for more information you can refer to 
 
-To get an overview of the project, read the [documentations of BraidPool](./docs/).
+[overview](https://github.com/braidpool/braidpool/blob/main/docs/overview.md), [specification](https://github.com/braidpool/braidpool/blob/main/docs/braidpool_spec.md), 
+and [consensus](https://github.com/braidpool/braidpool/blob/main/docs/braid_consensus.md). This will give you a brief idea about working and its implementation. Braidpool is implemented using Rust, so some familiarity with Rust is also required. The general idea to understand a project is looking into their `tests` directory; the same applies here.
 
-### Issues
+## Structuring a Pull Request
 
-#### Create a new issue
+This covers how you should approach a PR from creating to merging. 
 
-If you spot a problem with the project, [search if an issue already exists](https://github.com/braidpool/braidpool/issues). If a related issue doesn't exist, you can open a new issue using a relevant issue form.
++ Use a concise title that summarizes the change, prefixed by the affected area (e.g., `bead`, `dag`, `rpc`, `doc`, `test`, `feat`, `style`) <br>
+ ``` e.g., bead: Add dynamic difficulty validation. ```
++ Explain what the PR does and why it’s needed and reference related issues `(e.g., Fixes #123)` or discussions `(e.g., Discord thread)`.
++ Limit the PR to a single feature, bug fix, or refactor. Avoid combining unrelated changes. If ignored, this will lead to several other problems. e.g., hard to review, delay feedback, may block others work.
++ Ensure each commit represents a single logical change (e.g., one commit for adding a function, another for tests) to maintain a clean history, make code reviews easier, and allow for efficient debugging or reverting specific changes if needed.
++ Before merging, squash related commits into one; multiple commits for a single logical change seem irrelevant.
 
-#### Solve an issue
+  ```sh
+  git rebase -i HEAD~3
+  # Squash three commits into one with message:
+  bead: Add dynamic difficulty validation
 
-Scan through our [existing issues](https://github.com/braidpool/braidpool/issues) to find one that interests you. You can narrow down the search using `labels` as filters. If you find an issue to work on, and after discussion, it comes out to be a valid issue, you are welcome to open a PR with a fix.
+  Implement `validate_difficulty` in `src/bead.rs` to check bead hashes.
+  Add unit tests in `tests/bead_validation.rs`. Fixes #123.
+  ```
++ For significant changes open a GitHub issue or discuss on Discord (Braidpool [Discord](https://discord.gg/pZYUDwkpPv) ) to confirm alignment with maintainers.
++ Add labels in GitHub according to the PR changes. This will help to understand the current progress and type of the PR.
++ Be sure to run `npx prettier --write .` before commiting so as to cross-check that the commits adhere to the linting scheme of the project's frontend
 
-### Make Changes
+## PR Review Process
 
-1. Fork the repository.
+Reviewing is the most beneficial and needed part for any software; thus, we need to ensure thorough evaluation, clear feedback, and efficient collaboration. A reviewer can express their final decision by commenting on the PR discussion page by acknowledging or denying the changes, or the reviewer can also request some changes. Now it's in the author's hands to weigh the opinion of a reviewer by looking at their understanding of the codebase and in the community.  <br>
 
-   - Using GitHub Desktop:
+Here are few steps you can follow while reviewing PRs. 
 
-     - [Getting started with GitHub Desktop](https://docs.github.com/en/desktop/installing-and-configuring-github-desktop/getting-started-with-github-desktop) will guide you through setting up Desktop.
-     - Once Desktop is set up, you can use it to [fork the repo](https://docs.github.com/en/desktop/contributing-and-collaborating-using-github-desktop/cloning-and-forking-repositories-from-github-desktop)!
+1. Pull the PR with the respective branch and then build it.
 
-   - Using the command line:
-     - [Fork the repo](https://docs.github.com/en/github/getting-started-with-github/fork-a-repo#fork-an-example-repository) so that you can make your changes without affecting the original project until you're ready to merge them.
+  ```sh
+  git fetch origin pull/123/head:pr-123
+  git checkout pr-123
+  ```
+2. Run and see if the codebase is giving you the correct results according to the desired changes. For example, if a PR introduces a new test that will stop Braidpool node after passing a specific argument, then check if it's working in the same way as stated by the PR author. Or a change that introduces a new feature is giving the new results that correspond to that.
+3. If it's working fine, then manually review each line of code and think about why that particular line is removed or added in the codebase. And try to find out possible consequences that can occur with that change (always try to find a bug in the new or existing code; think like there is something wrong in the code).
+4. Now if you find anything wrong or you can't be able to understand much about that change, then you can ask that thing directly to the PR author via a simple comment. (First try to understand yourself and don't ask silly questions.)
+5. Finally, you can publish your official review in GitHub.
 
-2. Create a new working branch and start with your changes!
+## Communication Channels
 
-### Commit your updates
-
-Commit the changes once you are happy with them.
-
-- Note: The commits being made to dev branch [should be signed using a PGP key](https://docs.github.com/en/authentication/managing-commit-signature-verification/signing-commits)
-
-#### 1. For Dashboard Development:
-
-Please follow these rules or conventions while committing any new changes to the [Braidpool dashboard](./dashboard/):
-
-- `feat`: new feature for the user, not a new feature for build script
-- `fix`: bug fix for the user
-- `docs`: changes to the documentation
-- `style`: formatting, missing semi colons, etc
-- `refactor`: refactoring production code, eg. renaming a variable
-- `test`: adding missing tests, refactoring tests
-- `chore`: updating grunt tasks, etc., no production code change
-- Be sure to run `npx prettier --write .` before commiting so as to cross-check that the commits adhere to the linting scheme of the project's frontend
-
-#### 2. For Node Development:
-
-- TO-DO
-
-### Pull Request
-
-When you're finished with the changes, create a pull request, also known as a PR.
-
-- Don't forget to link PR to issue if you are solving one.
-- Enable the checkbox to [allow maintainer edits](https://docs.github.com/en/github/collaborating-with-issues-and-pull-requests/allowing-changes-to-a-pull-request-branch-created-from-a-fork) so the branch can be updated for a merge.
-- If you run into any merge issues, checkout this [git tutorial](https://github.com/skills/resolve-merge-conflicts) to help you resolve merge conflicts and other issues.
-
-### Your PR is merged!
-
-Congratulations! once your PR is merged, your contributions will be publicly visible in [closed PRs](https://github.com/braidpool/braidpool/pulls?q=is%3Apr+is%3Aclosed).
+  For all the other queries, or if you're stuck somewhere while working, or you want to communicate with the community, you can join the [Discord](https://discord.gg/pZYUDwkpPv) channel.

--- a/braidpool-primitives/src/bead/mod.rs
+++ b/braidpool-primitives/src/bead/mod.rs
@@ -1,44 +1,100 @@
-#![allow(unused)]
 // Standard Imports
-use ::serde::{Deserialize, Serialize};
-use std::collections::HashSet;
+use ::serde::Serialize;
+use std::fmt;
 use std::net::SocketAddr;
 
 // Bitcoin primitives
-use bitcoin::Address;
 use bitcoin::absolute::Time;
 use bitcoin::ecdsa::Signature;
-use bitcoin::p2p::Address as P2P_Address;
 use bitcoin::secp256k1::PublicKey;
-use bitcoin::transaction::TransactionExt;
-use bitcoin::{BlockHeader, Transaction};
+use bitcoin::{Address, BlockHeader, Transaction};
 // Custom Imports
 use crate::utils::BeadHash;
-#[derive(Clone, Debug, Serialize)]
 
+/// Error returned when parent and timestamp vectors have mismatched lengths.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CanonicalizeError {
+    pub parents_len: usize,
+    pub timestamps_len: usize,
+}
+
+impl fmt::Display for CanonicalizeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "parent count ({}) does not match timestamp count ({})",
+            self.parents_len, self.timestamps_len
+        )
+    }
+}
+
+impl std::error::Error for CanonicalizeError {}
+
+/// Committed (consensus-relevant) metadata for a bead.
+///
+/// `parents` is always kept in **canonical order** (sorted by `BeadHash`
+/// ascending) so that serialization is deterministic across all nodes.
+/// Use [`CommittedMetadata::new`] to construct.
+#[derive(Clone, Debug, Serialize)]
 pub struct CommittedMetadata {
-    // Committed Braidpool Metadata,
     pub transaction_cnt: u32,
     pub transactions: Vec<Transaction>,
-    pub parents: HashSet<BeadHash>,
+    /// Parent bead hashes in canonical (sorted) order.
+    pub parents: Vec<BeadHash>,
     pub payout_address: Address,
-    //timestamp when the bead was created
     pub observed_time_at_node: Time,
     pub comm_pub_key: PublicKey,
     pub miner_ip: SocketAddr,
 }
-#[derive(Clone, Debug, Serialize)]
 
+impl CommittedMetadata {
+    /// Create a new `CommittedMetadata` with parents in canonical order.
+    ///
+    /// Parents are sorted by `BeadHash` ascending. If `timestamps` is provided,
+    /// they are reordered to stay aligned with their parent hash.
+    pub fn new(
+        transaction_cnt: u32,
+        transactions: Vec<Transaction>,
+        parents: Vec<(BeadHash, Time)>,
+        payout_address: Address,
+        observed_time_at_node: Time,
+        comm_pub_key: PublicKey,
+        miner_ip: SocketAddr,
+    ) -> Self {
+        let mut sorted = parents;
+        sorted.sort_by(|a, b| a.0.cmp(&b.0));
+        let (sorted_parents, _sorted_timestamps): (Vec<_>, Vec<_>) = sorted.into_iter().unzip();
+
+        // timestamps are stored in UnCommittedMetadata, not here.
+        // The `parents` field only holds hashes. Timestamps are passed through
+        // to `canonicalize_parents` via the Uncommitted side.
+        Self {
+            transaction_cnt,
+            transactions,
+            parents: sorted_parents,
+            payout_address,
+            observed_time_at_node,
+            comm_pub_key,
+            miner_ip,
+        }
+    }
+}
+
+/// Uncommitted (non-consensus) metadata for a bead.
+///
+/// `parent_bead_timestamps` must be kept in the **same order** as
+/// [`CommittedMetadata::parents`]. Use [`canonicalize_parents`] to enforce
+/// this ordering invariant.
+#[derive(Clone, Debug, Serialize)]
 pub struct UnCommittedMetadata {
-    //Uncomitted Metadata
-    //timestamp when the bead was broadcasted
     pub extra_nonce: i32,
     pub broadcast_timestamp: Time,
     pub signature: Signature,
-    pub parent_bead_timestamps: HashSet<Time>,
+    /// Parent bead timestamps in the same order as `CommittedMetadata::parents`.
+    pub parent_bead_timestamps: Vec<Time>,
 }
-#[derive(Clone, Debug, Serialize)]
 
+#[derive(Clone, Debug, Serialize)]
 pub struct Bead {
     pub block_header: BlockHeader,
     pub committed_metadata: CommittedMetadata,
@@ -47,28 +103,52 @@ pub struct Bead {
 
 impl Bead {
     pub fn is_valid_bead(&self) -> bool {
-        // Check whether the transactions are included in the block
         true
     }
+
     pub fn get_coinbase_transaction(&self) -> Transaction {
-        // TODO: Implement this function.
         unimplemented!()
     }
 
     pub fn get_payout_update_transaction(&self) -> Transaction {
-        // TODO: Implement this function.
         unimplemented!()
     }
 }
 
-impl Bead {
-    // All private function definitions go here
-    //TODO : To implement a reverse mapping since we will be including the
-    //consensus determining attribute in the committed portion and those which
-    //will be used afterward such as in retargeting algorithms such as the parentbead_timestamps they shall be
-    //included inside the uncommitted portion but the order must be same as that of the hashset of parents_bead_hashes present
-    //inside the committed metadata
-    pub fn reverse_mapping_parentbead_with_timestamp() {}
+/// Canonicalize the ordering of `parents` and their corresponding timestamps.
+///
+/// Both slices are zipped, sorted by `BeadHash` ascending, and written back.
+/// After this call, serializing `CommittedMetadata` (which feeds the coinbase
+/// `OP_RETURN` commitment) produces **deterministic** bytes regardless of the
+/// order in which parents were originally collected.
+///
+/// # Errors
+///
+/// Returns [`CanonicalizeError`] if the two slices have different lengths.
+pub fn canonicalize_parents(
+    parents: &mut Vec<BeadHash>,
+    timestamps: &mut Vec<Time>,
+) -> Result<(), CanonicalizeError> {
+    if parents.len() != timestamps.len() {
+        return Err(CanonicalizeError {
+            parents_len: parents.len(),
+            timestamps_len: timestamps.len(),
+        });
+    }
+
+    let mut pairs: Vec<(BeadHash, Time)> = parents
+        .drain(..)
+        .zip(timestamps.drain(..))
+        .collect();
+
+    pairs.sort_by(|a, b| a.0.cmp(&b.0));
+
+    for (hash, time) in pairs {
+        parents.push(hash);
+        timestamps.push(time);
+    }
+
+    Ok(())
 }
 
 #[cfg(test)]

--- a/braidpool-primitives/src/bead/tests.rs
+++ b/braidpool-primitives/src/bead/tests.rs
@@ -1,63 +1,57 @@
-use ::bitcoin::BlockHash;
-use ::bitcoin::Network;
-use bitcoin::BlockTime;
-use bitcoin::BlockVersion;
-use bitcoin::CompactTarget;
-use bitcoin::EcdsaSighashType;
 use bitcoin::absolute::Time;
-use bitcoin::address::NetworkChecked;
-use bitcoin::base58::Error;
 use bitcoin::ecdsa::Signature;
-use bitcoin::hashes::sha256t::Hash;
 use bitcoin::secp256k1::PublicKey;
-use bitcoin::transaction::TransactionExt;
-use bitcoin::{Address, Block, TxMerkleNode};
-use bitcoin::{BlockHeader, Transaction};
+use bitcoin::{Address, BlockHash, BlockHeader, BlockTime, BlockVersion, CompactTarget, Network,
+              TxMerkleNode};
 use core::net::SocketAddr;
-use secp256k1::Message;
 use secp256k1::{Secp256k1, SecretKey};
-use serde::{Deserialize, Deserializer, Serialize, Serializer};
-use serde_json::json;
-use std::collections::HashSet;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, Ipv4Addr};
 use std::str::FromStr;
 
-use super::Bead;
-use super::CommittedMetadata;
-use super::UnCommittedMetadata;
-#[test]
+use super::{canonicalize_parents, Bead, CanonicalizeError, CommittedMetadata, UnCommittedMetadata};
 
-fn test_serialized_bead() {
-    let _address: Address = Address::from_str("32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf")
+fn test_address() -> Address {
+    Address::from_str("32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf")
         .unwrap()
         .require_network(Network::Bitcoin)
-        .unwrap();
+        .unwrap()
+}
+
+fn test_pubkey() -> PublicKey {
     let secp = Secp256k1::new();
     let secret_key = SecretKey::from_byte_array(&[0xcd; 32]).expect("32 bytes, within curve order");
-    let public_key = PublicKey::from_secret_key(&secp, &secret_key);
-    let socket = SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080);
+    PublicKey::from_secret_key(&secp, &secret_key)
+}
 
-    let test_committed_metadata = CommittedMetadata {
+fn test_socket() -> SocketAddr {
+    SocketAddr::new(IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)), 8080)
+}
+
+#[test]
+fn test_serialized_bead() {
+    let committed = CommittedMetadata {
         transaction_cnt: 0,
-        parents: HashSet::new(),
+        parents: Vec::new(),
         transactions: vec![],
-        payout_address: _address,
-        comm_pub_key: public_key,
+        payout_address: test_address(),
+        comm_pub_key: test_pubkey(),
         observed_time_at_node: Time::from_consensus(1653195600).unwrap(),
-        miner_ip: socket,
+        miner_ip: test_socket(),
     };
+
     let hex = "3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45";
     let sig = Signature {
         signature: secp256k1::ecdsa::Signature::from_str(hex).unwrap(),
-        sighash_type: EcdsaSighashType::All,
+        sighash_type: bitcoin::EcdsaSighashType::All,
     };
 
-    let test_uncommittedmetadata: UnCommittedMetadata = UnCommittedMetadata {
+    let uncommitted = UnCommittedMetadata {
         extra_nonce: 12,
         broadcast_timestamp: Time::from_consensus(1653195600).unwrap(),
         signature: sig,
-        parent_bead_timestamps: HashSet::new(),
+        parent_bead_timestamps: Vec::new(),
     };
+
     let test_bytes = [0u8; 32];
     let test_bead = Bead {
         block_header: BlockHeader {
@@ -68,12 +62,171 @@ fn test_serialized_bead() {
             time: BlockTime::from_u32(8328429),
             merkle_root: TxMerkleNode::from_byte_array(test_bytes),
         },
-        committed_metadata: test_committed_metadata,
-        uncommitted_metadata: test_uncommittedmetadata,
+        committed_metadata: committed,
+        uncommitted_metadata: uncommitted,
     };
+
     let serialized_str = serde_json::to_string(&test_bead).unwrap();
     assert_eq!(
         serialized_str,
         r#"{"block_header":{"version":2,"prev_blockhash":"0000000000000000000000000000000000000000000000000000000000000000","merkle_root":"0000000000000000000000000000000000000000000000000000000000000000","time":8328429,"bits":32,"nonce":1},"committed_metadata":{"transaction_cnt":0,"transactions":[],"parents":[],"payout_address":"32iVBEu4dxkUQk9dJbZUiBiQdmypcEyJRf","observed_time_at_node":1653195600,"comm_pub_key":"02b98a7fb8cc007048625b6446ad49a1b3a722df8c1ca975b87160023e14d19097","miner_ip":"127.0.0.1:8080"},"uncommitted_metadata":{"extra_nonce":12,"broadcast_timestamp":1653195600,"signature":{"signature":"3046022100839c1fbc5304de944f697c9f4b1d01d1faeba32d751c0f7acb21ac8a0f436a72022100e89bd46bb3a5a62adc679f659b7ce876d83ee297c7a5587b2011c4fcc72eab45","sighash_type":"SIGHASH_ALL"},"parent_bead_timestamps":[]}}"#
     );
+}
+
+#[test]
+fn test_committed_metadata_new_enforces_ordering() {
+    let parents = vec![
+        (BlockHash::from_byte_array([3u8; 32]), Time::from_consensus(1700000003).unwrap()),
+        (BlockHash::from_byte_array([1u8; 32]), Time::from_consensus(1700000001).unwrap()),
+        (BlockHash::from_byte_array([2u8; 32]), Time::from_consensus(1700000002).unwrap()),
+    ];
+
+    let committed = CommittedMetadata::new(
+        0,
+        vec![],
+        parents,
+        test_address(),
+        Time::from_consensus(1653195600).unwrap(),
+        test_pubkey(),
+        test_socket(),
+    );
+
+    // Parents must be sorted ascending by hash
+    assert_eq!(committed.parents[0], BlockHash::from_byte_array([1u8; 32]));
+    assert_eq!(committed.parents[1], BlockHash::from_byte_array([2u8; 32]));
+    assert_eq!(committed.parents[2], BlockHash::from_byte_array([3u8; 32]));
+}
+
+#[test]
+fn test_canonicalize_parents_deterministic_serialization() {
+    let mut parents = vec![
+        BlockHash::from_byte_array([3u8; 32]),
+        BlockHash::from_byte_array([1u8; 32]),
+        BlockHash::from_byte_array([2u8; 32]),
+    ];
+    let mut timestamps = vec![
+        Time::from_consensus(1700000100).unwrap(),
+        Time::from_consensus(1700000200).unwrap(),
+        Time::from_consensus(1700000300).unwrap(),
+    ];
+
+    canonicalize_parents(&mut parents, &mut timestamps).unwrap();
+
+    let committed = CommittedMetadata {
+        transaction_cnt: 0,
+        parents,
+        transactions: vec![],
+        payout_address: test_address(),
+        comm_pub_key: test_pubkey(),
+        observed_time_at_node: Time::from_consensus(1653195600).unwrap(),
+        miner_ip: test_socket(),
+    };
+
+    // Serialize 5 times and assert identical output each time
+    let serialized = serde_json::to_string(&committed).unwrap();
+    for _ in 0..4 {
+        assert_eq!(serde_json::to_string(&committed).unwrap(), serialized);
+    }
+}
+
+#[test]
+fn test_canonicalize_parents_integration() {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+
+    // Build the same parents in 3 different insertion orders
+    let parent_sets = vec![
+        vec![
+            (BlockHash::from_byte_array([3u8; 32]), Time::from_consensus(1700000003).unwrap()),
+            (BlockHash::from_byte_array([1u8; 32]), Time::from_consensus(1700000001).unwrap()),
+            (BlockHash::from_byte_array([2u8; 32]), Time::from_consensus(1700000002).unwrap()),
+        ],
+        vec![
+            (BlockHash::from_byte_array([1u8; 32]), Time::from_consensus(1700000001).unwrap()),
+            (BlockHash::from_byte_array([2u8; 32]), Time::from_consensus(1700000002).unwrap()),
+            (BlockHash::from_byte_array([3u8; 32]), Time::from_consensus(1700000003).unwrap()),
+        ],
+        vec![
+            (BlockHash::from_byte_array([2u8; 32]), Time::from_consensus(1700000002).unwrap()),
+            (BlockHash::from_byte_array([3u8; 32]), Time::from_consensus(1700000003).unwrap()),
+            (BlockHash::from_byte_array([1u8; 32]), Time::from_consensus(1700000001).unwrap()),
+        ],
+    ];
+
+    let mut hashes = Vec::new();
+    for ps in &parent_sets {
+        let committed = CommittedMetadata::new(
+            0, vec![], ps.clone(),
+            test_address(),
+            Time::from_consensus(1653195600).unwrap(),
+            test_pubkey(), test_socket(),
+        );
+        let bytes = serde_json::to_string(&committed).unwrap();
+        let mut h = DefaultHasher::new();
+        bytes.hash(&mut h);
+        hashes.push(h.finish());
+    }
+
+    // All three insertion orders must produce the same hash
+    assert_eq!(hashes[0], hashes[1]);
+    assert_eq!(hashes[1], hashes[2]);
+}
+
+#[test]
+fn test_canonicalize_parents_orders_by_hash() {
+    let mut parents = vec![
+        BlockHash::from_byte_array([3u8; 32]),
+        BlockHash::from_byte_array([1u8; 32]),
+        BlockHash::from_byte_array([2u8; 32]),
+    ];
+    let mut timestamps = vec![
+        Time::from_consensus(1700000300).unwrap(),
+        Time::from_consensus(1700000100).unwrap(),
+        Time::from_consensus(1700000200).unwrap(),
+    ];
+
+    canonicalize_parents(&mut parents, &mut timestamps).unwrap();
+
+    assert_eq!(parents[0], BlockHash::from_byte_array([1u8; 32]));
+    assert_eq!(parents[1], BlockHash::from_byte_array([2u8; 32]));
+    assert_eq!(parents[2], BlockHash::from_byte_array([3u8; 32]));
+
+    assert_eq!(timestamps[0], Time::from_consensus(1700000100).unwrap());
+    assert_eq!(timestamps[1], Time::from_consensus(1700000200).unwrap());
+    assert_eq!(timestamps[2], Time::from_consensus(1700000300).unwrap());
+}
+
+#[test]
+fn test_canonicalize_parents_returns_error_on_mismatched_lengths() {
+    let mut parents = vec![BlockHash::from_byte_array([1u8; 32])];
+    let mut timestamps = Vec::new();
+
+    let result = canonicalize_parents(&mut parents, &mut timestamps);
+    assert_eq!(result, Err(CanonicalizeError { parents_len: 1, timestamps_len: 0 }));
+}
+
+#[test]
+fn test_canonicalize_parents_empty() {
+    let mut parents: Vec<BlockHash> = Vec::new();
+    let mut timestamps: Vec<Time> = Vec::new();
+
+    canonicalize_parents(&mut parents, &mut timestamps).unwrap();
+
+    assert!(parents.is_empty());
+    assert!(timestamps.is_empty());
+}
+
+#[test]
+fn test_canonicalize_parents_single() {
+    let hash = BlockHash::from_byte_array([42u8; 32]);
+    let time = Time::from_consensus(1700000999).unwrap();
+
+    let mut parents = vec![hash];
+    let mut timestamps = vec![time];
+
+    canonicalize_parents(&mut parents, &mut timestamps).unwrap();
+
+    assert_eq!(parents.len(), 1);
+    assert_eq!(parents[0], hash);
+    assert_eq!(timestamps[0], time);
 }

--- a/docs/general_considerations.md
+++ b/docs/general_considerations.md
@@ -439,7 +439,7 @@ direction.
 
 ## Covenants
 
-One might take the UHPO set transaction and convtert it to a tree structure,
+One might take the UHPO set transaction and convert it to a tree structure,
 using covenants to enforce the structure of the tree in descendant transactions.
 This is often done in the context of covenant-based soft fork proposals so that
 one party can execute his withdrawal while not having to force everyone else to


### PR DESCRIPTION
## Description

Replaces HashSet<BeadHash> with Vec<BeadHash> for parents in CommittedMetadata to produce deterministic serialization across all nodes. Previously, HashSet iteration order varied per node, causing different commitment hashes and breaking consensus.

## Changes

- **braidpool-primitives/src/bead/mod.rs**
  - parents: HashSet<BeadHash> -> Vec<BeadHash>
  - parent_bead_timestamps: HashSet<Time> -> Vec<Time>
  - Added CommittedMetadata::new() constructor that sorts input parents by hash
  - Renamed reverse_mapping_parentbead_with_timestamp to canonicalize_parents() returning Result<(), CanonicalizeError> instead of panicking
  - Added CanonicalizeError error type with Display + Error impl
  - Removed unused imports (P2P_Address, TransactionExt, Deserialize, Ordering)

- **braidpool-primitives/src/bead/tests.rs**
  - Updated test_serialized_bead for Vec types
  - 7 new tests: constructor ordering, 5x repeat determinism, cross-order hash equality, Result error, edge cases

## Testing

cargo test -p braidpool-primitives

All 8 tests pass with zero new warnings.

Closes #426