### PR TITLE
feat: add dynamic extranonce selection on upstream pool

### DIFF
--- a/node/src/audit.rs
+++ b/node/src/audit.rs
@@ -199,29 +199,35 @@ impl AuditCommitment {
         hex::encode(&self.commitment_bytes)
     }
 
-    pub fn verify_in_extranonce1(&self, extranonce1_bytes: &[u8], miner_prefix: &[u8]) -> bool {
-        if extranonce1_bytes.len() != TOTAL_EXTRANONCE1_BYTES {
+    pub fn verify_in_extranonce1(
+        &self,
+        extranonce1_bytes: &[u8],
+        miner_prefix: &[u8],
+        upstream_ext1_size: usize,
+    ) -> bool {
+        let expected_total = upstream_ext1_size + MINER_PREFIX_BYTES + COMMITMENT_BYTES;
+        if extranonce1_bytes.len() != expected_total {
             return false;
         }
-        if &extranonce1_bytes
-            [UPSTREAM_EXTRANONCE1_BYTES..UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES]
+        if &extranonce1_bytes[upstream_ext1_size..upstream_ext1_size + MINER_PREFIX_BYTES]
             != miner_prefix
         {
             return false;
         }
-        let commitment_start = UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES;
+        let commitment_start = upstream_ext1_size + MINER_PREFIX_BYTES;
         let commitment_end = commitment_start + COMMITMENT_BYTES;
         &extranonce1_bytes[commitment_start..commitment_end] == &self.commitment_bytes
     }
 
-    pub fn extract_miner_prefix_from_ext1(extranonce1_bytes: &[u8]) -> Option<Vec<u8>> {
-        if extranonce1_bytes.len() < UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES {
+    pub fn extract_miner_prefix_from_ext1(
+        extranonce1_bytes: &[u8],
+        upstream_ext1_size: usize,
+    ) -> Option<Vec<u8>> {
+        if extranonce1_bytes.len() < upstream_ext1_size + MINER_PREFIX_BYTES {
             return None;
         }
         Some(
-            extranonce1_bytes
-                [UPSTREAM_EXTRANONCE1_BYTES..UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES]
-                .to_vec(),
+            extranonce1_bytes[upstream_ext1_size..upstream_ext1_size + MINER_PREFIX_BYTES].to_vec(),
         )
     }
 }
@@ -233,15 +239,19 @@ pub struct MinerAuditState {
     pub miner_prefix: Vec<u8>,
     pub commitment_pending: bool,
     pub previous_commitment: Option<AuditCommitment>,
+    pub upstream_ext1_size: usize,
+    pub miner_roll_bytes: usize,
 }
 
 impl MinerAuditState {
-    pub fn new(miner_prefix: Vec<u8>) -> Self {
+    pub fn new(miner_prefix: Vec<u8>, upstream_ext1_size: usize, miner_roll_bytes: usize) -> Self {
         Self {
             current_commitment: AuditCommitment::genesis(),
             miner_prefix,
             commitment_pending: false,
             previous_commitment: None,
+            upstream_ext1_size,
+            miner_roll_bytes,
         }
     }
 
@@ -266,25 +276,29 @@ impl MinerAuditState {
         extranonce1_bytes: &[u8],
         extranonce2_hex: &str,
     ) -> AuditVerificationResult {
-        if extranonce1_bytes.len() != TOTAL_EXTRANONCE1_BYTES {
+        let expected_total = self.upstream_ext1_size + MINER_PREFIX_BYTES + COMMITMENT_BYTES;
+        if extranonce1_bytes.len() != expected_total {
             return AuditVerificationResult::Invalid {
                 reason: format!(
                     "Wrong extranonce1 length: expected {} bytes, got {}",
-                    TOTAL_EXTRANONCE1_BYTES,
+                    expected_total,
                     extranonce1_bytes.len()
                 ),
             };
         }
-        if extranonce2_hex.len() != MINER_ROLL_BYTES * 2 {
+        if extranonce2_hex.len() != self.miner_roll_bytes * 2 {
             return AuditVerificationResult::Invalid {
                 reason: format!(
                     "Wrong extranonce2 length: expected {} hex chars, got {}",
-                    MINER_ROLL_BYTES * 2,
+                    self.miner_roll_bytes * 2,
                     extranonce2_hex.len()
                 ),
             };
         }
-        if let Some(prefix) = AuditCommitment::extract_miner_prefix_from_ext1(extranonce1_bytes) {
+        if let Some(prefix) = AuditCommitment::extract_miner_prefix_from_ext1(
+            extranonce1_bytes,
+            self.upstream_ext1_size,
+        ) {
             if prefix != self.miner_prefix {
                 return AuditVerificationResult::Invalid {
                     reason: format!(
@@ -299,10 +313,11 @@ impl MinerAuditState {
                 reason: "Could not extract miner prefix from extranonce1".to_string(),
             };
         }
-        if self
-            .current_commitment
-            .verify_in_extranonce1(extranonce1_bytes, &self.miner_prefix)
-        {
+        if self.current_commitment.verify_in_extranonce1(
+            extranonce1_bytes,
+            &self.miner_prefix,
+            self.upstream_ext1_size,
+        ) {
             let miner_roll = hex::decode(extranonce2_hex)
                 .ok()
                 .and_then(|bytes| bytes.first().copied());
@@ -312,7 +327,7 @@ impl MinerAuditState {
                 miner_roll,
             }
         } else {
-            let commitment_start = UPSTREAM_EXTRANONCE1_BYTES + MINER_PREFIX_BYTES;
+            let commitment_start = self.upstream_ext1_size + MINER_PREFIX_BYTES;
             let commitment_end = commitment_start + COMMITMENT_BYTES;
             let actual = hex::encode(&extranonce1_bytes[commitment_start..commitment_end]);
 
@@ -335,7 +350,11 @@ impl MinerAuditState {
         let result = self.verify_share(extranonce1_bytes, extranonce2_hex);
         if matches!(result, AuditVerificationResult::Invalid { .. }) {
             if let Some(prev_commitment) = previous_commitment {
-                if prev_commitment.verify_in_extranonce1(extranonce1_bytes, &self.miner_prefix) {
+                if prev_commitment.verify_in_extranonce1(
+                    extranonce1_bytes,
+                    &self.miner_prefix,
+                    self.upstream_ext1_size,
+                ) {
                     warn!(
                         old = %prev_commitment.to_hex(),
                         current = %self.current_commitment.to_hex(),
@@ -741,9 +760,15 @@ impl AuditDAG {
         }
     }
 
-    pub fn register_miner(&mut self, miner_ip: String, prefix: Vec<u8>) {
+    pub fn register_miner(
+        &mut self,
+        miner_ip: String,
+        prefix: Vec<u8>,
+        upstream_ext1_size: usize,
+        miner_roll_bytes: usize,
+    ) {
         let prefix_hex = hex::encode(&prefix);
-        let state = MinerAuditState::new(prefix);
+        let state = MinerAuditState::new(prefix, upstream_ext1_size, miner_roll_bytes);
         self.miner_states.insert(miner_ip.clone(), state);
         info!(
             miner = %miner_ip,
@@ -929,7 +954,11 @@ mod tests {
             &commitment.commitment_bytes,
         );
 
-        assert!(commitment.verify_in_extranonce1(&extranonce1, &miner_prefix));
+        assert!(commitment.verify_in_extranonce1(
+            &extranonce1,
+            &miner_prefix,
+            UPSTREAM_EXTRANONCE1_BYTES
+        ));
     }
 
     #[test]
@@ -939,7 +968,11 @@ mod tests {
         let extranonce1 = vec![0xff; 5]; // Too short
         let miner_prefix = vec![0xaa, 0xbb];
 
-        assert!(!commitment.verify_in_extranonce1(&extranonce1, &miner_prefix));
+        assert!(!commitment.verify_in_extranonce1(
+            &extranonce1,
+            &miner_prefix,
+            UPSTREAM_EXTRANONCE1_BYTES
+        ));
     }
 
     #[test]
@@ -954,7 +987,11 @@ mod tests {
             &commitment.commitment_bytes,
         );
 
-        assert!(!commitment.verify_in_extranonce1(&extranonce1, &miner_prefix));
+        assert!(!commitment.verify_in_extranonce1(
+            &extranonce1,
+            &miner_prefix,
+            UPSTREAM_EXTRANONCE1_BYTES
+        ));
     }
 
     #[test]
@@ -970,7 +1007,11 @@ mod tests {
             &wrong_commitment,
         );
 
-        assert!(!commitment.verify_in_extranonce1(&extranonce1, &miner_prefix));
+        assert!(!commitment.verify_in_extranonce1(
+            &extranonce1,
+            &miner_prefix,
+            UPSTREAM_EXTRANONCE1_BYTES
+        ));
     }
 
     #[test]
@@ -983,7 +1024,10 @@ mod tests {
             &[0x11, 0x22, 0x33, 0x44, 0x55],
         );
 
-        let extracted = AuditCommitment::extract_miner_prefix_from_ext1(&extranonce1);
+        let extracted = AuditCommitment::extract_miner_prefix_from_ext1(
+            &extranonce1,
+            UPSTREAM_EXTRANONCE1_BYTES,
+        );
         assert_eq!(extracted, Some(miner_prefix));
     }
 
@@ -991,7 +1035,7 @@ mod tests {
     /// Verify that on a new job arrival, the old commitment and the new one update correctly.
     fn test_miner_audit_state_update_commitment() {
         let prefix = vec![0xaa, 0xbb];
-        let mut state = MinerAuditState::new(prefix);
+        let mut state = MinerAuditState::new(prefix, UPSTREAM_EXTRANONCE1_BYTES, MINER_ROLL_BYTES);
         let bead = create_test_bead(vec![]);
 
         let old_commitment = state.current_commitment.clone();
@@ -1009,7 +1053,7 @@ mod tests {
     /// Validate that the incoming share contains the unaltered and valid prefix.
     fn test_verify_share_prefix_mismatch() {
         let prefix = vec![0xaa, 0xbb];
-        let state = MinerAuditState::new(prefix);
+        let state = MinerAuditState::new(prefix, UPSTREAM_EXTRANONCE1_BYTES, MINER_ROLL_BYTES);
 
         let extranonce1 = build_extranonce1(
             &[0xff; UPSTREAM_EXTRANONCE1_BYTES],
@@ -1030,7 +1074,8 @@ mod tests {
     /// Verify that the correct share was successfully accepted and marked as valid.
     fn test_verify_share_valid() {
         let prefix = vec![0xaa, 0xbb];
-        let state = MinerAuditState::new(prefix.clone());
+        let state =
+            MinerAuditState::new(prefix.clone(), UPSTREAM_EXTRANONCE1_BYTES, MINER_ROLL_BYTES);
 
         let extranonce1 = build_extranonce1(
             &[0xff; UPSTREAM_EXTRANONCE1_BYTES],
@@ -1056,7 +1101,8 @@ mod tests {
     /// verify that a share built on the previous commitment is explicitly rejected as stale.
     fn test_verify_share_with_fallback_uses_previous() {
         let prefix = vec![0xaa, 0xbb];
-        let mut state = MinerAuditState::new(prefix.clone());
+        let mut state =
+            MinerAuditState::new(prefix.clone(), UPSTREAM_EXTRANONCE1_BYTES, MINER_ROLL_BYTES);
 
         let extranonce1 = build_extranonce1(
             &[0xff; UPSTREAM_EXTRANONCE1_BYTES],
@@ -1093,7 +1139,12 @@ mod tests {
         let miner_ip = "192.168.1.100".to_string();
         let prefix = vec![0xaa, 0xbb];
 
-        audit_dag.register_miner(miner_ip.clone(), prefix.clone());
+        audit_dag.register_miner(
+            miner_ip.clone(),
+            prefix.clone(),
+            UPSTREAM_EXTRANONCE1_BYTES,
+            MINER_ROLL_BYTES,
+        );
         assert_eq!(audit_dag.miner_states[&miner_ip].miner_prefix, prefix);
     }
 
@@ -1104,7 +1155,12 @@ mod tests {
         let mut audit_dag = AuditDAG::new(braid);
         let miner_ip = "192.168.1.100".to_string();
 
-        audit_dag.register_miner(miner_ip.clone(), vec![0x00, 0x01]);
+        audit_dag.register_miner(
+            miner_ip.clone(),
+            vec![0x00, 0x01],
+            UPSTREAM_EXTRANONCE1_BYTES,
+            MINER_ROLL_BYTES,
+        );
 
         // Insert exactly 10 test records with various states
         for i in 0..10 {

--- a/node/src/db/audit_db_handlers.rs
+++ b/node/src/db/audit_db_handlers.rs
@@ -55,8 +55,8 @@ impl AuditDBHandler {
             .unwrap_or_default()
             .as_secs() as i64;
 
-        let extranonce1 = format!("{:08x}", bead.uncommitted_metadata.extra_nonce_1);
-        let extranonce2 = format!("{:08x}", bead.uncommitted_metadata.extra_nonce_2);
+        let extranonce1 = format!("{:016x}", bead.uncommitted_metadata.extra_nonce_1);
+        let extranonce2 = format!("{:016x}", bead.uncommitted_metadata.extra_nonce_2);
 
         let result = sqlx::query(INSERT_BEAD_QUERY)
             .bind(composite_hash.as_byte_array().as_slice())

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1142,6 +1142,21 @@ impl DownstreamClient {
 
         if let (Some(header), Some(block_hash)) = (valid_header, valid_block_hash) {
             let share_id = block_hash;
+            let upstream_ext1_size = used_extranonce1
+                .len()
+                .checked_sub(PREFIX_BYTES_SIZE + COMMITMENT_SIZE)
+                .ok_or_else(|| StratumErrors::InvalidMethodParams {
+                    method: "mining.submit: extranonce1 too short for audit mode".to_string(),
+                })?;
+
+            if upstream_ext1_size != 4 && upstream_ext1_size != 8 {
+                return Err(StratumErrors::InvalidMethodParams {
+                    method: format!(
+                        "mining.submit: unsupported upstream ext1 size: {}",
+                        upstream_ext1_size
+                    ),
+                });
+            }
 
             let bead = {
                 let payout_address = self
@@ -1244,54 +1259,46 @@ impl DownstreamClient {
                         bitcoin::absolute::MedianTimePast::from_u32(d.as_secs() as u32).unwrap()
                     })
                     .unwrap();
+
                 let (extranonce_1_raw_value, extranonce_2_raw_value) = {
-                    if used_extranonce1.len() < UPSTREAM_EXTRANONCE1_SIZE {
-                        error!(
-                            worker = %worker_name,
-                            extranonce1_len = %used_extranonce1.len(),
-                            required = UPSTREAM_EXTRANONCE1_SIZE,
-                            "extranonce1 too short, expected at least 4 bytes, this upstream pool is not supported yet."
-                        );
-                        return Err(StratumErrors::InvalidMethodParams {
-                            method: "mining.submit: extranonce1 too short for audit mode"
-                                .to_string(),
-                        });
-                    }
-                    let upstream_bytes = &used_extranonce1[..UPSTREAM_EXTRANONCE1_SIZE];
-                    let upstream_u32 = u32::from_be_bytes([
-                        upstream_bytes[0],
-                        upstream_bytes[1],
-                        upstream_bytes[2],
-                        upstream_bytes[3],
-                    ]);
-                    const MAX_AUDIT_BYTES: usize = 64;
-                    let audit_bytes = &used_extranonce1[UPSTREAM_EXTRANONCE1_SIZE..];
-                    if audit_bytes.len() > MAX_AUDIT_BYTES {
-                        return Err(StratumErrors::InvalidMethodParams {
-                            method: "mining.submit: audit extranonce too long".to_string(),
-                        });
-                    }
-                    let audit_hash = bitcoin::hashes::sha256::Hash::hash(audit_bytes);
-                    let audit_hash_bytes = audit_hash.to_byte_array();
-                    let audit_hash_u32 = u32::from_be_bytes([
-                        audit_hash_bytes[0],
-                        audit_hash_bytes[1],
-                        audit_hash_bytes[2],
-                        audit_hash_bytes[3],
-                    ]);
+                    let upstream_bytes = &used_extranonce1[..upstream_ext1_size];
+
+                    let extra_nonce_1: u64 = if upstream_ext1_size == 8 {
+                        u64::from_be_bytes(upstream_bytes.try_into().unwrap())
+                    } else {
+                        u32::from_be_bytes(upstream_bytes.try_into().unwrap()) as u64
+                    };
+
+                    let audit_portion = &used_extranonce1[upstream_ext1_size..];
+                    let miner_roll_bytes = hex::decode(extranonce2).map_err(|e| {
+                        StratumErrors::InvalidMethodParams {
+                            method: format!("mining.submit: invalid extranonce2 hex: {}", e),
+                        }
+                    })?;
+                    let mut nonce2_buf = [0u8; 8];
+                    let audit_len = audit_portion.len().min(PREFIX_BYTES_SIZE + COMMITMENT_SIZE);
+                    nonce2_buf[..audit_len].copy_from_slice(&audit_portion[..audit_len]);
+                    let roll_len = miner_roll_bytes
+                        .len()
+                        .min(std::mem::size_of::<u64>() - audit_len);
+                    nonce2_buf[audit_len..audit_len + roll_len]
+                        .copy_from_slice(&miner_roll_bytes[..roll_len]);
+                    let extra_nonce_2 = u64::from_be_bytes(nonce2_buf);
+
                     debug!(
                         worker = %worker_name,
-                        extranonce1_len = %used_extranonce1.len(),
+                        upstream_ext1_size = %upstream_ext1_size,
                         upstream_ext1 = %hex::encode(upstream_bytes),
-                        upstream_ext1_u32 = %format!("{:08x}", upstream_u32),
-                        audit_portion_len = %audit_bytes.len(),
-                        audit_portion = %hex::encode(audit_bytes),
-                        audit_hash_u32 = %format!("{:08x}", audit_hash_u32),
-                        "Parsed extranonce values for bead metadata"
+                        extra_nonce_1 = %format!("{:016x}", extra_nonce_1),
+                        audit_portion = %hex::encode(audit_portion),
+                        miner_roll = %extranonce2,
+                        extra_nonce_2 = %format!("{:016x}", extra_nonce_2),
+                        "Packed extranonce values for bead metadata"
                     );
 
-                    (upstream_u32, audit_hash_u32)
+                    (extra_nonce_1, extra_nonce_2)
                 };
+
                 let placeholder_sig_bytes = [0u8; 64];
                 let sig = bitcoin::ecdsa::Signature {
                     signature: secp256k1::ecdsa::Signature::from_compact(&placeholder_sig_bytes)
@@ -1301,8 +1308,8 @@ impl DownstreamClient {
 
                 let uncommitted_metadata = crate::uncommitted_metadata::UnCommittedMetadata {
                     broadcast_timestamp: broadcast_time,
-                    extra_nonce_1: extranonce_1_raw_value as u64,
-                    extra_nonce_2: extranonce_2_raw_value as u64,
+                    extra_nonce_1: extranonce_1_raw_value,
+                    extra_nonce_2: extranonce_2_raw_value,
                     signature: sig,
                 };
 
@@ -1363,8 +1370,7 @@ impl DownstreamClient {
                                 let full_extranonce2 = if let Some(ref prefix) =
                                     self.extranonce2_prefix
                                 {
-                                    let commitment_start =
-                                        UPSTREAM_EXTRANONCE1_SIZE + PREFIX_BYTES_SIZE;
+                                    let commitment_start = upstream_ext1_size + PREFIX_BYTES_SIZE;
                                     let commitment_end = commitment_start + COMMITMENT_SIZE;
                                     if used_extranonce1.len() < commitment_end {
                                         error!(
@@ -3475,6 +3481,7 @@ impl Server {
                                             }
                                         };
 
+                                        let upstream_ext1_len = upstream_ext1_bytes.len();
                                         let mut extended_extranonce1 = upstream_ext1_bytes;
                                         extended_extranonce1.extend_from_slice(&prefix_bytes);
                                         let bead_hash_commitment = mapping.get_current_bead_commitment();
@@ -3503,7 +3510,7 @@ impl Server {
                                             );
                                             {
                                                 let mut dag_guard = dag.lock().await;
-                                                dag_guard.register_miner(peer_addr.to_string(), prefix_bytes.clone());
+                                                dag_guard.register_miner(peer_addr.to_string(), prefix_bytes.clone(), upstream_ext1_len, miner_ext2_size);
                                                 if let Some(miner_state) = dag_guard.miner_states.get_mut(&peer_addr.to_string()) {
                                                     let commitment = crate::audit::AuditCommitment::from_hash_prefix(&bead_hash_commitment);
                                                     miner_state.current_commitment = commitment;
@@ -3542,7 +3549,7 @@ impl Server {
                                     }
                                 } else {
                                     // Normal Braidpool mode, generate local extranonce
-                                    let mut bytes = [0u8; 4];
+                                    let mut bytes = [0u8; 8];
                                     rand::thread_rng().fill_bytes(&mut bytes);
                                     info!("New Braidpool connection using local extranonce: {}", hex::encode(&bytes));
                                     (bytes.to_vec(), EXTRANONCE2_SIZE, None, false)
@@ -4579,8 +4586,8 @@ mod test {
         assert_ne!(client1.extranonce1, client3.extranonce1);
 
         // extranonce1 must be exactly EXTRANONCE1_SIZE bytes
-        assert_eq!(client1.extranonce1.len(), EXTRANONCE1_SIZE);
-        assert_eq!(client2.extranonce1.len(), EXTRANONCE1_SIZE);
-        assert_eq!(client3.extranonce1.len(), EXTRANONCE1_SIZE);
+        assert_eq!(client1.extranonce1.len(), UPSTREAM_EXTRANONCE1_SIZE);
+        assert_eq!(client2.extranonce1.len(), UPSTREAM_EXTRANONCE1_SIZE);
+        assert_eq!(client3.extranonce1.len(), UPSTREAM_EXTRANONCE1_SIZE);
     }
 }


### PR DESCRIPTION
This PR adds the functionality to choose the dynamic upstream extranonce size. Which means now any upstream pool that either supports 4 bytes or 8 bytes as the extranonce1 size can connect with the Braidpool as an auditing layer. The Braidpool node will readjust itself and further call to the miner and submit the request back to the upstream pool internally with respect to the upstream extranonce size. As seen in many pools, the already defined ranges are the most common ones (e.g. 4 bytes of extranonce1 and 8 bytes of extranonce2 or 8 bytes of extranonce1 and 8 bytes of extranonce2); any other values or sizes are not common and maybe hardly used by any pool. Thus, users can treat it like the maximum cap bytes they can use is 16 bytes where `total_extranonce_bytes - extranonce1_bytes >= 8` to make it work. 