### PR TITLE
Test: fix shared DB path causing intermittent CI failures

### DIFF
--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -84,6 +84,45 @@ impl DBHandler {
             db_handler_tx,
         ))
     }
+
+    #[cfg(test)]
+    pub async fn new_in_memory() -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
+        use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
+        use std::str::FromStr;
+        const SCHEMA: &str = include_str!("schema.sql");
+
+        let pool_options = SqliteConnectOptions::from_str("sqlite::memory:")
+            .map_err(|e| DBErrors::ConnectionUrlNotParsed {
+                error: e.to_string(),
+                url: "sqlite::memory:".to_string(),
+            })?
+            .foreign_keys(true)
+            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
+
+        let db_connection_pool = SqlitePool::connect_with(pool_options).await.map_err(|e| {
+            DBErrors::ConnectionToSQlitePoolFailed {
+                error: e.to_string(),
+            }
+        })?;
+
+        sqlx::query(SCHEMA)
+            .execute(&db_connection_pool)
+            .await
+            .map_err(|e| DBErrors::SchemaNotInitialized {
+                error: e.to_string(),
+                db_path: std::path::PathBuf::from(":memory:"),
+            })?;
+
+        let (db_handler_tx, db_handler_rx) = tokio::sync::mpsc::channel(DB_CHANNEL_CAPACITY);
+        Ok((
+            Self {
+                receiver: db_handler_rx,
+                db_connection_pool,
+            },
+            db_handler_tx,
+        ))
+    }
+
     /// Builds the `(transactions, relatives, parent_timestamps)` JSON value tuples for a single
     /// bead.
     fn prepare_bead_tuple_values(

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -10,8 +10,6 @@ use bitcoin::{
 use serde_json::json;
 use sqlx::{Pool, Row, Sqlite};
 use tokio::sync::mpsc::{Receiver, Sender};
-#[cfg(test)]
-use tracing::info;
 use tracing::{debug, error, trace};
 pub const DB_CHANNEL_CAPACITY: usize = 1024;
 /// Maximum number of beads (including orphans) to insert in a single bulk query to limit the memory consumption
@@ -87,7 +85,10 @@ impl DBHandler {
 
     #[cfg(test)]
     pub async fn new_in_memory() -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
-        use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
+        use sqlx::{
+            sqlite::{SqliteConnectOptions, SqlitePoolOptions},
+            Executor,
+        };
         use std::str::FromStr;
         const SCHEMA: &str = include_str!("schema.sql");
 
@@ -99,14 +100,20 @@ impl DBHandler {
             .foreign_keys(true)
             .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
 
-        let db_connection_pool = SqlitePool::connect_with(pool_options).await.map_err(|e| {
-            DBErrors::ConnectionToSQlitePoolFailed {
+        // sqlite::memory: creates a separate DB per connection; max_connections(1)
+        // ensures all operations share the same in-memory database.
+        let db_connection_pool = SqlitePoolOptions::new()
+            .min_connections(1)
+            .max_connections(1)
+            .connect_with(pool_options)
+            .await
+            .map_err(|e| DBErrors::ConnectionToSQlitePoolFailed {
                 error: e.to_string(),
-            }
-        })?;
+            })?;
 
-        sqlx::query(SCHEMA)
-            .execute(&db_connection_pool)
+        // execute() handles multi-statement SQL; sqlx::query() would only run the first statement.
+        db_connection_pool
+            .execute(SCHEMA)
             .await
             .map_err(|e| DBErrors::SchemaNotInitialized {
                 error: e.to_string(),
@@ -853,44 +860,19 @@ pub async fn fetch_bead_by_bead_hash(
 #[allow(unused)]
 pub mod test {
     use super::*;
-    use serde_json::json;
-    use sqlx::{sqlite::SqliteConnectOptions, SqlitePool};
-    use std::collections::{HashMap, HashSet};
-    use std::{fs, path::Path, str::FromStr};
-    const TEST_DB_URL: &str = "sqlite::memory:";
     use crate::{
         braid,
         utils::test_utils::test_utility_functions::{
             emit_bead, loading_braid_from_file, BRAIDTESTDIRECTORY,
         },
     };
-    pub async fn test_db_initializer() -> Pool<Sqlite> {
-        let test_pool_settings = SqliteConnectOptions::from_str(TEST_DB_URL)
-            .unwrap()
-            .foreign_keys(true)
-            .with_regexp()
-            .journal_mode(sqlx::sqlite::SqliteJournalMode::Wal);
-        let test_pool = SqlitePool::connect_with(test_pool_settings).await.unwrap();
-        let schema_path = std::env::current_dir().unwrap().join("src/db/schema.sql");
-        let schema_sql = fs::read_to_string(&schema_path).unwrap();
-
-        let setup_result = sqlx::query(&schema_sql.as_str()).execute(&test_pool).await;
-
-        match setup_result {
-            Ok(_) => {
-                info!("Test Schema setup success");
-            }
-            Err(error) => {
-                panic!("{:?}", error);
-            }
-        }
-
-        test_pool
-    }
-
+    use serde_json::json;
+    use std::collections::{HashMap, HashSet};
+    use std::path::Path;
     #[tokio::test]
     async fn test_batch_insertion_beads() {
-        let test_pool = test_db_initializer().await;
+        let (handler, _db_tx) = DBHandler::new_in_memory().await.unwrap();
+        let test_pool = handler.db_connection_pool.clone();
         let ancestors = std::env::current_dir().unwrap();
         let ancestors_directory: Vec<&Path> = ancestors.ancestors().collect();
         let parent_directory = ancestors_directory[1];
@@ -913,12 +895,7 @@ pub mod test {
         let orphans = bead_insert_data.split_off(split_at);
         let beads = bead_insert_data;
 
-        // Drive the real batched-insert code path over the in-memory test pool.
-        let (_db_tx, db_rx) = tokio::sync::mpsc::channel::<BraidpoolDBTypes>(DB_CHANNEL_CAPACITY);
-        let handler = DBHandler {
-            receiver: db_rx,
-            db_connection_pool: test_pool.clone(),
-        };
+        // Use in-memory DBHandler to drive the batched-insert production code path.
         handler
             .insert_beads_batch(beads, orphans)
             .await

--- a/node/src/db/schema.sql
+++ b/node/src/db/schema.sql
@@ -1,5 +1,5 @@
 -- 1. Bead
-CREATE TABLE Bead (
+CREATE TABLE IF NOT EXISTS Bead (
     id                  INTEGER PRIMARY KEY ,
     hash                BLOB NOT NULL,
     -- Block header fields
@@ -27,7 +27,7 @@ CREATE TABLE Bead (
 );
 
 -- 2. Transactions
-CREATE TABLE Transactions (
+CREATE TABLE IF NOT EXISTS Transactions (
       bead_id           INTEGER NOT NULL REFERENCES Bead(id),
       txid              BLOB,
       UNIQUE (bead_id, txid)
@@ -36,12 +36,12 @@ CREATE TABLE Transactions (
 -- 3. Cohorts
 -- Auxiliary: positive cohort numbers (append a row for each new cohort)
 -- Cohort metadata can be added here
-CREATE TABLE CohortIds (
+CREATE TABLE IF NOT EXISTS CohortIds (
     id INTEGER PRIMARY KEY CHECK (id > 0)
 );
 
 -- Mapping: exactly one row per bead; cohort_id NULL means "unassigned"
-CREATE TABLE Cohorts (
+CREATE TABLE IF NOT EXISTS Cohorts (
     bead_id INTEGER PRIMARY KEY,    -- the bead’s id from Bead
     cohort_id INTEGER,              -- NULL until known; else references CohortIds(id)
     FOREIGN KEY (bead_id) REFERENCES Bead(id),
@@ -49,24 +49,24 @@ CREATE TABLE Cohorts (
 );
 
 -- Helpful index: fast to pull all beads in a cohort and to scan for NULLs
-CREATE INDEX cohorts_by_cohortid ON Cohorts(cohort_id);
+CREATE INDEX IF NOT EXISTS cohorts_by_cohortid ON Cohorts(cohort_id);
 
 -- Quick view of beads still awaiting a cohort assignment
-CREATE VIEW Orphans AS
+CREATE VIEW IF NOT EXISTS Orphans AS
 SELECT b.id
 FROM Bead b
 LEFT JOIN Cohorts c ON c.bead_id = b.id
 WHERE c.cohort_id IS NULL;
 
 -- 4. Relatives (parent/child link)
-CREATE TABLE Relatives (
+CREATE TABLE IF NOT EXISTS Relatives (
     child  INTEGER NOT NULL REFERENCES Bead(id),
     parent INTEGER NOT NULL REFERENCES Bead(id),
     PRIMARY KEY (parent, child)
 );
 
 -- 5. Timestamps provided by beads witnessing when they saw ancestors
-CREATE TABLE ParentTimestamps (
+CREATE TABLE IF NOT EXISTS ParentTimestamps (
     parent      INTEGER NOT NULL REFERENCES Bead(id),
     child       INTEGER NOT NULL REFERENCES Bead(id),
     timestamp   INTEGER NOT NULL,               -- 64-bit unix epoch in MICROseconds
@@ -76,7 +76,7 @@ CREATE TABLE ParentTimestamps (
 
 -- 6. A table allowing beads to witness timestamps for non-parent ancestors
 -- (Not used currently)
-CREATE TABLE AncestorTimestamps (
+CREATE TABLE IF NOT EXISTS AncestorTimestamps (
     bead_id  INTEGER NOT NULL REFERENCES Bead(id), 
     ancestor INTEGER NOT NULL REFERENCES Bead(id),
     timestamp INTEGER NOT NULL,
@@ -84,13 +84,13 @@ CREATE TABLE AncestorTimestamps (
 );
 
 -- 7. Fast look-up indices
-CREATE INDEX bead_txids ON Transactions(bead_id);
-CREATE INDEX parents ON Relatives(parent);
-CREATE INDEX bead_hash ON Bead(hash);
-CREATE INDEX timestamps_parents ON ParentTimestamps(parent);
-CREATE INDEX timestamps_children ON ParentTimestamps(child);
-CREATE INDEX bead_start_timestamp ON Bead(start_timestamp);
-CREATE INDEX parent_timestamps_timestamp ON ParentTimestamps(timestamp);
+CREATE INDEX IF NOT EXISTS bead_txids ON Transactions(bead_id);
+CREATE INDEX IF NOT EXISTS parents ON Relatives(parent);
+CREATE INDEX IF NOT EXISTS bead_hash ON Bead(hash);
+CREATE INDEX IF NOT EXISTS timestamps_parents ON ParentTimestamps(parent);
+CREATE INDEX IF NOT EXISTS timestamps_children ON ParentTimestamps(child);
+CREATE INDEX IF NOT EXISTS bead_start_timestamp ON Bead(start_timestamp);
+CREATE INDEX IF NOT EXISTS parent_timestamps_timestamp ON ParentTimestamps(timestamp);
 
 -- 8. WAL mode for append-only workloads
 PRAGMA journal_mode = WAL;

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -4017,7 +4017,7 @@ mod test {
         let connection_mapping = Arc::new(RwLock::new(ConnectionMapping::new()));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
         let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
-        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new_in_memory().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx, DashboardEvents::new());
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -4084,7 +4084,7 @@ mod test {
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
-        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new_in_memory().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx, DashboardEvents::new());
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -4138,7 +4138,7 @@ mod test {
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
         let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
-        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new_in_memory().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx, DashboardEvents::new());
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));
@@ -4189,7 +4189,7 @@ mod test {
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
-        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new_in_memory().await.unwrap();
         let mining_job_map = Arc::new(Mutex::new(std::collections::HashMap::new()));
         let notify_tx = mpsc::channel::<NotifyCmd>(32).0;
         let (swarm_handler, mut swarm_command_receiver) =
@@ -4235,7 +4235,7 @@ mod test {
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
-        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new_in_memory().await.unwrap();
         let mining_job_map: Arc<Mutex<HashMap<String, Arc<Mutex<MiningJobMap>>>>> =
             Arc::new(Mutex::new(HashMap::new()));
         let (notify_tx, _notify_rx) = mpsc::channel::<NotifyCmd>(32);
@@ -4327,7 +4327,7 @@ mod test {
         let genesis_beads = Vec::from([]);
         let test_braid: Arc<RwLock<braid::Braid>> =
             Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
-        let (_test_db_handler, test_db_tx) = DBHandler::new().await.unwrap();
+        let (_test_db_handler, test_db_tx) = DBHandler::new_in_memory().await.unwrap();
         let (swarm_handler, mut swarm_command_receiver) =
             SwarmHandler::new(Arc::clone(&test_braid), test_db_tx, DashboardEvents::new());
         let swarm_handler_arc = Arc::new(Mutex::new(swarm_handler));


### PR DESCRIPTION
server_start_test and other stratum tests fail intermittently on CI. All stratum tests call DBHandler::new() which writes to a shared file path (~/.braidpool/braidpool.db). With parallel test execution, two tests race at schema creation,  one errors with table Bead already exists or database is locked.

changes:
schema.sql:  IF NOT EXISTS on all CREATE TABLE, CREATE INDEX, CREATE VIEW. Eliminates the already-exists race for any file-based test.
DBHandler::new_in_memory():  new #[cfg(test)] constructor using sqlite::memory:. Schema embedded via include_str!, no file path dependency, works on any machine.
stratum.rs:  all six DBHandler::new() callsites in tests switched to new_in_memory(). Each test now gets a private isolated database.

Fixes #504