### PR TITLE
rpc: add getworkbybead method

### DIFF
--- a/braidpool-cli/src/main.rs
+++ b/braidpool-cli/src/main.rs
@@ -113,6 +113,13 @@ enum Commands {
         bead_hash: String,
     },
 
+    /// Get the cumulative work associated with a specific bead
+    #[command(name = "getworkbybead")]
+    GetWorkByBead {
+        /// The bead hash (block hash) as a 64-character hex-encoded string representing the bead's block hash
+        bead_hash: String,
+    },
+
     /// Get peer information (IP/PeerID/libp2p address of connected peers)
     #[command(name = "getpeerinfo")]
     GetPeerInfo,
@@ -317,6 +324,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::GetIpcStats => ("getipcstats", json!([])),
         Commands::GetBraidInfo => ("getbraidinfo", json!([])),
         Commands::GetNodeInfo { bead_hash } => ("getnodeinfo", json!([bead_hash])),
+        Commands::GetWorkByBead { bead_hash } => ("getworkbybead", json!([bead_hash])),
         Commands::GetPeerInfo => ("getpeerinfo", json!([])),
         Commands::StagedTransactions => ("stagedtransactions", json!([])),
         Commands::UnstageTransactions { tx_id } => ("unstagetransactions", json!([tx_id])),

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -965,19 +965,44 @@ impl RpcServer for RpcServerImpl {
 
         let braid_data = self.braid_arc.read().await;
 
-        let bead = braid_data
-            .beads
-            .iter()
-            .find(|bead| bead.block_header.block_hash() == hash)
+        let bead_index = *braid_data
+            .bead_index_mapping
+            .get(&hash)
             .ok_or_else(|| ErrorObjectOwned::owned(
                 3,
                 format!("Bead not found. No bead with hash '{}' exists in the braid. Use 'gettips' or 'getbraidinfo' to find available bead hashes.", bead_hash),
                 None::<()>
             ))?;
 
+        // Cumulative work = the bead's own work plus the work of every one of its
+        // ancestors (its full "past set" in the DAG), mirroring how `total_work` in
+        // `getbraidinfo` sums work across beads rather than reporting a single PoW value.
+        let mut parents_map: HashMap<usize, HashSet<usize>> = HashMap::new();
+        for (index, bead) in braid_data.beads.iter().enumerate() {
+            let parent_indices: HashSet<usize> = bead
+                .committed_metadata
+                .parents
+                .iter()
+                .filter_map(|p_hash| braid_data.bead_index_mapping.get(p_hash).copied())
+                .collect();
+            parents_map.insert(index, parent_indices);
+        }
+
+        let mut ancestors: HashMap<usize, HashSet<usize>> = HashMap::new();
+        consensus_functions::get_all_ancestors(&braid_data, hash, &mut ancestors, &parents_map);
+
+        let bead_own_work = braid_data.beads[bead_index].block_header.work();
+        let cumulative_work = ancestors
+            .get(&bead_index)
+            .into_iter()
+            .flatten()
+            .fold(bead_own_work, |acc, &ancestor_idx| {
+                acc + braid_data.beads[ancestor_idx].block_header.work()
+            });
+
         let bead_work = BeadWork {
             bead_hash,
-            work: bead.block_header.work().to_string(),
+            work: cumulative_work.to_string(),
         };
 
         serde_json::to_value(&bead_work)
@@ -1884,10 +1909,20 @@ pub async fn test_get_node_info_rpc() {
 
 #[tokio::test]
 pub async fn test_get_work_by_bead_rpc() {
+    // Build a 3-bead chain: bead1 (genesis) -> bead2 -> bead3, so the RPC's
+    // cumulative-work computation (bead + all ancestors) can be distinguished
+    // from a single bead's own proof-of-work.
     let test_bead1 = create_test_bead(1, None);
+    let test_bead2 = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let test_bead3 = create_test_bead(3, Some(test_bead2.block_header.block_hash()));
     let genesis_beads = vec![test_bead1.clone()];
 
     let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    {
+        let mut braid_guard = braid.write().await;
+        braid_guard.extend(&test_bead2);
+        braid_guard.extend(&test_bead3);
+    }
 
     let (proxy_tx, _) = mpsc::unbounded_channel();
 
@@ -1906,18 +1941,42 @@ pub async fn test_get_work_by_bead_rpc() {
     let target_uri = format!("http://{}", server_addr);
     let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
 
-    let bead_hash = test_bead1.block_header.block_hash().to_string();
-    let mut params = ArrayParams::new();
-    params.insert(bead_hash.clone()).unwrap();
+    // Genesis bead has no ancestors, so cumulative work equals its own work.
+    let bead1_hash = test_bead1.block_header.block_hash().to_string();
+    let mut params1 = ArrayParams::new();
+    params1.insert(bead1_hash.clone()).unwrap();
 
-    let response: Result<Value, jsonrpsee::core::ClientError> =
-        client.request("getworkbybead", params).await;
+    let response1: Result<Value, jsonrpsee::core::ClientError> =
+        client.request("getworkbybead", params1).await;
 
-    assert!(response.is_ok());
-    let bead_work: BeadWork = serde_json::from_value(response.unwrap()).unwrap();
+    assert!(response1.is_ok());
+    let bead1_work: BeadWork = serde_json::from_value(response1.unwrap()).unwrap();
 
-    assert_eq!(bead_work.bead_hash, bead_hash);
-    assert_eq!(bead_work.work, test_bead1.block_header.work().to_string());
+    assert_eq!(bead1_work.bead_hash, bead1_hash);
+    assert_eq!(bead1_work.work, test_bead1.block_header.work().to_string());
+
+    // Tip bead's cumulative work must be the sum of its own work plus every
+    // ancestor's work, not just its own proof-of-work.
+    let bead3_hash = test_bead3.block_header.block_hash().to_string();
+    let mut params3 = ArrayParams::new();
+    params3.insert(bead3_hash.clone()).unwrap();
+
+    let response3: Result<Value, jsonrpsee::core::ClientError> =
+        client.request("getworkbybead", params3).await;
+
+    assert!(response3.is_ok());
+    let bead3_work: BeadWork = serde_json::from_value(response3.unwrap()).unwrap();
+
+    let expected_cumulative_work = (test_bead1.block_header.work()
+        + test_bead2.block_header.work()
+        + test_bead3.block_header.work())
+    .to_string();
+
+    assert_eq!(bead3_work.bead_hash, bead3_hash);
+    assert_eq!(bead3_work.work, expected_cumulative_work);
+    // Sanity check: cumulative work must differ from the bead's own PoW alone,
+    // otherwise this test wouldn't catch a regression to per-bead PoW.
+    assert_ne!(bead3_work.work, test_bead3.block_header.work().to_string());
 
     // Unknown bead hash should return an error
     let mut missing_params = ArrayParams::new();
@@ -1927,6 +1986,68 @@ pub async fn test_get_work_by_bead_rpc() {
     let missing_response: Result<Value, jsonrpsee::core::ClientError> =
         client.request("getworkbybead", missing_params).await;
     assert!(missing_response.is_err());
+}
+
+#[tokio::test]
+pub async fn test_get_work_by_bead_diamond_dag_rpc() {
+    // Diamond DAG: bead1 is the shared ancestor of bead2 and bead3, which are
+    // both parents of bead4. Cumulative work for bead4 must count bead1's work
+    // exactly once, not twice (no double-counting a shared ancestor reached via
+    // two different paths).
+    let test_bead1 = create_test_bead(1, None);
+    let test_bead2 = create_test_bead(2, Some(test_bead1.block_header.block_hash()));
+    let mut test_bead3 = create_test_bead(3, Some(test_bead1.block_header.block_hash()));
+    test_bead3.block_header.nonce = 30;
+    let mut test_bead4 = create_test_bead(4, Some(test_bead2.block_header.block_hash()));
+    test_bead4
+        .committed_metadata
+        .parents
+        .insert(test_bead3.block_header.block_hash());
+
+    let genesis_beads = vec![test_bead1.clone()];
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+    {
+        let mut braid_guard = braid.write().await;
+        braid_guard.extend(&test_bead2);
+        braid_guard.extend(&test_bead3);
+        braid_guard.extend(&test_bead4);
+    }
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let (server_addr, _) = run_rpc_server(
+        Arc::clone(&braid),
+        "127.0.0.1:0",
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(tokio::sync::RwLock::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+        test_db_tx(),
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let bead4_hash = test_bead4.block_header.block_hash().to_string();
+    let mut params = ArrayParams::new();
+    params.insert(bead4_hash.clone()).unwrap();
+
+    let response: Result<Value, jsonrpsee::core::ClientError> =
+        client.request("getworkbybead", params).await;
+
+    assert!(response.is_ok());
+    let bead4_work: BeadWork = serde_json::from_value(response.unwrap()).unwrap();
+
+    let expected_cumulative_work = (test_bead1.block_header.work()
+        + test_bead2.block_header.work()
+        + test_bead3.block_header.work()
+        + test_bead4.block_header.work())
+    .to_string();
+
+    assert_eq!(bead4_work.bead_hash, bead4_hash);
+    assert_eq!(bead4_work.work, expected_cumulative_work);
 }
 
 #[tokio::test]

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -99,6 +99,9 @@ pub trait Rpc {
     #[method(name = "getnodeinfo")]
     async fn get_node_info(&self, bead_hash: String) -> Result<Value, ErrorObjectOwned>;
 
+    #[method(name = "getworkbybead")]
+    async fn get_work_by_bead(&self, bead_hash: String) -> Result<Value, ErrorObjectOwned>;
+
     #[method(name = "getpeerinfo")]
     async fn get_peer_info(&self) -> Result<Value, ErrorObjectOwned>;
 
@@ -158,6 +161,12 @@ struct NodeInfo {
     miner_ip: String,
     payout_address: String,
     minimum_target: String,
+}
+
+#[derive(Serialize, Deserialize)]
+struct BeadWork {
+    bead_hash: String,
+    work: String,
 }
 
 /// Per-tx entry returned by stagedtransactions. Includes txid so callers can pass it to unstagetransactions.
@@ -940,6 +949,38 @@ impl RpcServer for RpcServerImpl {
         };
 
         serde_json::to_value(&node_info)
+            .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error", None::<()>))
+    }
+
+    async fn get_work_by_bead(&self, bead_hash: String) -> Result<Value, ErrorObjectOwned> {
+        info!(bead_hash = %bead_hash, "Get Work By Bead request received");
+
+        let hash = bead_hash
+            .parse::<BeadHash>()
+            .map_err(|_| ErrorObjectOwned::owned(
+                1,
+                "Invalid bead hash format. Expected a 64-character hex-encoded string representing a bead's block hash.",
+                None::<()>
+            ))?;
+
+        let braid_data = self.braid_arc.read().await;
+
+        let bead = braid_data
+            .beads
+            .iter()
+            .find(|bead| bead.block_header.block_hash() == hash)
+            .ok_or_else(|| ErrorObjectOwned::owned(
+                3,
+                format!("Bead not found. No bead with hash '{}' exists in the braid. Use 'gettips' or 'getbraidinfo' to find available bead hashes.", bead_hash),
+                None::<()>
+            ))?;
+
+        let bead_work = BeadWork {
+            bead_hash,
+            work: bead.block_header.work().to_string(),
+        };
+
+        serde_json::to_value(&bead_work)
             .map_err(|_| ErrorObjectOwned::owned(2, "Internal Server Error", None::<()>))
     }
 
@@ -1839,6 +1880,53 @@ pub async fn test_get_node_info_rpc() {
         node_info.payout_address,
         test_bead1.committed_metadata.payout_address
     );
+}
+
+#[tokio::test]
+pub async fn test_get_work_by_bead_rpc() {
+    let test_bead1 = create_test_bead(1, None);
+    let genesis_beads = vec![test_bead1.clone()];
+
+    let braid: Arc<RwLock<braid::Braid>> = Arc::new(RwLock::new(braid::Braid::new(genesis_beads)));
+
+    let (proxy_tx, _) = mpsc::unbounded_channel();
+
+    let (server_addr, _) = run_rpc_server(
+        Arc::clone(&braid),
+        "127.0.0.1:0",
+        Arc::new(tokio::sync::RwLock::new(PeerManager::new(8))),
+        Arc::new(tokio::sync::RwLock::new(stratum::ConnectionMapping::new())),
+        Arc::new(Mutex::new(stratum::BlockTemplate::default())),
+        proxy_tx,
+        None,
+        test_db_tx(),
+    )
+    .await
+    .unwrap();
+    let target_uri = format!("http://{}", server_addr);
+    let client: HttpClient = HttpClient::builder().build(target_uri).unwrap();
+
+    let bead_hash = test_bead1.block_header.block_hash().to_string();
+    let mut params = ArrayParams::new();
+    params.insert(bead_hash.clone()).unwrap();
+
+    let response: Result<Value, jsonrpsee::core::ClientError> =
+        client.request("getworkbybead", params).await;
+
+    assert!(response.is_ok());
+    let bead_work: BeadWork = serde_json::from_value(response.unwrap()).unwrap();
+
+    assert_eq!(bead_work.bead_hash, bead_hash);
+    assert_eq!(bead_work.work, test_bead1.block_header.work().to_string());
+
+    // Unknown bead hash should return an error
+    let mut missing_params = ArrayParams::new();
+    missing_params
+        .insert("0000000000000000000000000000000000000000000000000000000000000000".to_string())
+        .unwrap();
+    let missing_response: Result<Value, jsonrpsee::core::ClientError> =
+        client.request("getworkbybead", missing_params).await;
+    assert!(missing_response.is_err());
 }
 
 #[tokio::test]


### PR DESCRIPTION
Fixes #499 

- Add `getworkbybead` RPC method (node/src/rpc_server.rs) that looks up a bead
  by hash and returns {bead_hash, work}, reusing the same lookup/error pattern
  as `getnodeinfo/getbead`.
- Add the matching `getworkbybead` <bead_hash> subcommand to `braidpool-cli`.
- Add `test_get_work_by_bead_rpc` covering the happy path and an unknown-hash
  error case.
