### PR TITLE
bead: Fix merkle proof root calculation to fold pairwise per tree level

### DIFF
--- a/braidpool-primitives/src/utils/bitcoin/mod.rs
+++ b/braidpool-primitives/src/utils/bitcoin/mod.rs
@@ -10,42 +10,34 @@ type MerkleRoot = TxMerkleNode;
 
 pub struct MerklePathProof {
     pub transaction_hash: Txid,
-    pub is_right_leaf: bool,
+    /// Index of the transaction in the block. Its bits give the left/right
+    /// position of the running hash at each level of the merkle tree.
+    /// Fixed-width so the layout is identical across platforms.
+    pub transaction_index: u32,
     pub merkle_path: Vec<TxMerkleNode>,
 }
 
 impl MerklePathProof {
     pub fn calculate_corresponding_merkle_root(&self) -> MerkleRoot {
-        let hashing_order = self.get_merkle_hashing_order();
-        let mut concatenated_hashes: Vec<u8> = Vec::new();
-        for hash in hashing_order.iter() {
-            concatenated_hashes.extend_from_slice(hash);
+        let mut current_hash: [u8; 32] = self.transaction_hash.to_byte_array();
+        let mut index = self.transaction_index;
+        let mut preimage = [0u8; 64];
+
+        for sibling in self.merkle_path.iter() {
+            if index & 1 == 1 {
+                // Running hash is the right child at this level.
+                preimage[..32].copy_from_slice(sibling.as_byte_array());
+                preimage[32..].copy_from_slice(&current_hash);
+            } else {
+                // Running hash is the left child at this level.
+                preimage[..32].copy_from_slice(&current_hash);
+                preimage[32..].copy_from_slice(sibling.as_byte_array());
+            }
+            current_hash = Sha256d::hash(&preimage).to_byte_array();
+            index >>= 1;
         }
 
-        let calculated_merkle_root = Sha256d::hash(&concatenated_hashes);
-        TxMerkleNode::from_byte_array(calculated_merkle_root.to_byte_array())
-    }
-}
-
-impl MerklePathProof {
-    // All private functions go here!
-    fn get_merkle_hashing_order(&self) -> Vec<[u8; 32]> {
-        let mut hashing_order: Vec<[u8; 32]> = Vec::new();
-        let index_for_starting_the_copy: usize;
-        if self.is_right_leaf {
-            hashing_order.push(self.merkle_path[0].as_byte_array().clone());
-            hashing_order.push(self.transaction_hash.as_byte_array().clone());
-            index_for_starting_the_copy = 1;
-        } else {
-            hashing_order.push(self.transaction_hash.as_byte_array().clone());
-            index_for_starting_the_copy = 0;
-        };
-
-        for index in index_for_starting_the_copy..self.merkle_path.len() {
-            hashing_order.push(self.merkle_path[index].as_byte_array().clone());
-        }
-
-        hashing_order
+        TxMerkleNode::from_byte_array(current_hash)
     }
 }
 

--- a/braidpool-primitives/src/utils/bitcoin/tests.rs
+++ b/braidpool-primitives/src/utils/bitcoin/tests.rs
@@ -1,1 +1,80 @@
+use super::*;
+use bitcoin::hashes::Sha256d;
 
+fn hash_pair(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+    let mut concatenated: Vec<u8> = Vec::with_capacity(64);
+    concatenated.extend_from_slice(left);
+    concatenated.extend_from_slice(right);
+    Sha256d::hash(&concatenated).to_byte_array()
+}
+
+fn leaf(seed: u8) -> [u8; 32] {
+    Sha256d::hash(&[seed]).to_byte_array()
+}
+
+#[test]
+fn merkle_root_from_single_transaction() {
+    // A block with one transaction: the merkle root is the txid itself.
+    let txid = Txid::from_byte_array(leaf(1));
+    let proof = MerklePathProof {
+        transaction_hash: txid,
+        transaction_index: 0u32,
+        merkle_path: vec![],
+    };
+    assert_eq!(
+        proof.calculate_corresponding_merkle_root(),
+        TxMerkleNode::from_byte_array(leaf(1))
+    );
+}
+
+#[test]
+fn merkle_root_from_four_transactions_all_positions() {
+    // Manually constructed 4-leaf tree:
+    //        root
+    //       /    \
+    //     h01    h23
+    //     / \    / \
+    //    h0 h1  h2 h3
+    let leaves = [leaf(0), leaf(1), leaf(2), leaf(3)];
+    let h01 = hash_pair(&leaves[0], &leaves[1]);
+    let h23 = hash_pair(&leaves[2], &leaves[3]);
+    let root = TxMerkleNode::from_byte_array(hash_pair(&h01, &h23));
+
+    // (index, sibling path bottom-up)
+    let proofs = [
+        (0, vec![leaves[1], h23]),
+        (1, vec![leaves[0], h23]),
+        (2, vec![leaves[3], h01]),
+        (3, vec![leaves[2], h01]),
+    ];
+
+    for (index, path) in proofs {
+        let proof = MerklePathProof {
+            transaction_hash: Txid::from_byte_array(leaves[index]),
+            transaction_index: index as u32,
+            merkle_path: path
+                .into_iter()
+                .map(TxMerkleNode::from_byte_array)
+                .collect(),
+        };
+        assert_eq!(
+            proof.calculate_corresponding_merkle_root(),
+            root,
+            "proof failed for transaction index {}",
+            index
+        );
+    }
+}
+
+#[test]
+fn merkle_root_rejects_wrong_sibling() {
+    let leaves = [leaf(0), leaf(1)];
+    let root = TxMerkleNode::from_byte_array(hash_pair(&leaves[0], &leaves[1]));
+
+    let proof = MerklePathProof {
+        transaction_hash: Txid::from_byte_array(leaves[0]),
+        transaction_index: 0u32,
+        merkle_path: vec![TxMerkleNode::from_byte_array(leaf(9))],
+    };
+    assert_ne!(proof.calculate_corresponding_merkle_root(), root);
+}


### PR DESCRIPTION
Fixes #511.

## What

`MerklePathProof::calculate_corresponding_merkle_root()` previously concatenated the txid and every path sibling into one buffer and applied a single double-SHA256, which produces a wrong root for any block with more than 2 transactions. It also carried a single `is_right_leaf: bool`, which can only describe the leaf's position at level 0 — orientation differs at every level of the tree.

## Why

Coinbase/payout inclusion proofs are practically always depth ≥ 2, so every real proof evaluated to a wrong root. Valid beads would be rejected, and anything comparing against this function's output was validating garbage. This is consensus-critical for share/bead validation.

## How

- Fold the merkle path iteratively: `current = SHA256d(current ‖ sibling)`, one step per level, matching Bitcoin's merkle branch verification.
- Replace `is_right_leaf` with `transaction_index`; the index bits give the left/right ordering at each level (bit `i` = position at level `i`), shifting right as we walk up.
- Fill in the previously empty `utils/bitcoin/tests.rs`:
  - single-transaction block (root == txid),
  - a hand-built 4-leaf tree verifying proofs for **all four** leaf positions (covers left/left, right/left, left/right, right/right),
  - a negative test that a wrong sibling does not produce the root.

## Testing

```
cargo test -p braidpool-primitives
# 4 passed; 0 failed
```

No other code in the workspace constructs `MerklePathProof` yet, so no call sites needed updating.
