### PR TITLE
db: read parent timestamp as u32 in fetch_bead_by_bead_hash

### DIFF
--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -742,7 +742,7 @@ pub async fn fetch_bead_by_bead_hash(
             }
         };
     for parent_beads in parent_timestamp_rows {
-        let parent_timestamp = parent_beads.get::<i32, _>("timestamp");
+        let parent_timestamp = parent_beads.get::<u32, _>("timestamp");
         let parent_bead_id = parent_beads.get::<i64, _>("parent");
         //Fetching parent_bead from DB
         let parent_bead_hash_raw_bytes = match sqlx::query("SELECT  hash FROM Bead WHERE id = ?")
@@ -768,7 +768,7 @@ pub async fn fetch_bead_by_bead_hash(
             }
         };
         //Extending parent bead timestamp
-        let parent_ts = MedianTimePast::from_u32(parent_timestamp as u32).map_err(|e| {
+        let parent_ts = MedianTimePast::from_u32(parent_timestamp).map_err(|e| {
             DBErrors::TupleAttributeParsingError {
                 error: format!("Invalid parent timestamp value {}: {}", parent_timestamp, e),
                 attribute: "parent_bead_timestamps".to_string(),


### PR DESCRIPTION
Fixes #516.

### What

`fetch_bead_by_bead_hash` read the parent bead timestamp with `get::<i32, _>("timestamp")` and then cast it with `as u32`. Timestamps are unsigned, so a value at or beyond 2038-01-19 cannot be decoded into `i32` — `sqlx::Row::get` panics at that point, before the surrounding `map_err` can turn it into a `DBErrors`.

### Why it was missed

#490 fixed exactly this for the batch path (`fetch_beads_in_batch`) and closed #449, but #449 actually quoted the line in `fetch_bead_by_bead_hash`, which was never changed. This finishes that fix.

### Change

Read the column as `u32` and drop the `as u32` cast — matching `fetch_beads_in_batch` and every other timestamp column in this file (`start_timestamp`, `broadcast_timestamp`, `nTime`), which already use `u32`.

Two lines, no behaviour change for in-range timestamps.