### PR TITLE
feat(NodeHealth): enhance dashboard with real-time bandwidth usage and time range filtering

### DIFF
--- a/dashboard/src/components/Dashboard/Dashboard.tsx
+++ b/dashboard/src/components/Dashboard/Dashboard.tsx
@@ -77,15 +77,7 @@ const Dashboard = () => {
           </div>
         );
       case Page.NODE_HEALTH:
-        return (
-          <div className="p-2">
-            <Card title="Node Health Dashboard">
-              <div>
-                <NodeHealth />
-              </div>
-            </Card>
-          </div>
-        );
+        return <NodeHealth />;
 
       default:
         return (

--- a/dashboard/src/components/NodeHealth/Bandwidth.tsx
+++ b/dashboard/src/components/NodeHealth/Bandwidth.tsx
@@ -75,7 +75,7 @@ const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
             className="p-1.5 rounded text-gray-500 hover:text-gray-300 hover:bg-gray-800 transition-colors"
             aria-label="Download chart"
           >
-            <Download className="w-4.5 h-4.5" />
+            <Download className="w-4 h-4" />
           </button>
         </div>
       </div>

--- a/dashboard/src/components/NodeHealth/Bandwidth.tsx
+++ b/dashboard/src/components/NodeHealth/Bandwidth.tsx
@@ -1,4 +1,4 @@
-import React, { useRef } from 'react';
+import React, { useRef, useState, useMemo } from 'react';
 import {
   LineChart,
   Line,
@@ -8,21 +8,33 @@ import {
   CartesianGrid,
   ResponsiveContainer,
 } from 'recharts';
+import { Activity, Download } from 'lucide-react';
 
 import { BandwidthPanelProps } from './Types';
 import { formatBytes } from './Utils';
-import ActionIconButton from '../common/ActionIconButton';
 import { downloadSvgFromContainer } from '../../utils/downloadSvg';
+import { TimeRangeLabel } from './Types';
+import { TIME_RANGES } from './Constants';
 
 const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
   bandwidthHistory,
 }) => {
   const chartContainerRef = useRef<HTMLDivElement | null>(null);
+  const [timeRange, setTimeRange] = useState<TimeRangeLabel>('1m');
 
   const handleDownload = () => {
     if (!chartContainerRef.current) return;
     downloadSvgFromContainer(chartContainerRef.current, 'bandwidth-usage');
   };
+
+  const filteredHistory = useMemo(() => {
+    if (bandwidthHistory.length === 0) return [];
+    const selected = TIME_RANGES.find((r) => r.label === timeRange);
+    if (!selected) return bandwidthHistory;
+    const cutoff = Date.now() - selected.seconds * 1000;
+    const filtered = bandwidthHistory.filter((p) => p.timestamp >= cutoff);
+    return filtered.length > 0 ? filtered : bandwidthHistory;
+  }, [bandwidthHistory, timeRange]);
 
   if (bandwidthHistory.length === 0) {
     return (
@@ -33,46 +45,72 @@ const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
   }
 
   return (
-    <div className="bg-[#1e1e1e] border border-gray-700 rounded-xl shadow-md p-4 relative">
-      <div className="absolute right-3 top-3 z-10">
-        <ActionIconButton
-          onClick={handleDownload}
-          ariaLabel="Download Bandwidth Chart"
-          icon={
-            <svg
-              xmlns="http://www.w3.org/2000/svg"
-              viewBox="0 0 20 20"
-              fill="currentColor"
-            >
-              <path d="M3 14.5A2.5 2.5 0 0 0 5.5 17h9a2.5 2.5 0 0 0 2.5-2.5V11a.75.75 0 0 0-1.5 0v3.5a1 1 0 0 1-1 1h-9a1 1 0 0 1-1-1V11a.75.75 0 0 0-1.5 0v3.5Z" />
-              <path d="M10 2a.75.75 0 0 0-.75.75v8.19L7.53 9.22a.75.75 0 0 0-1.06 1.06l3 3a.75.75 0 0 0 1.06 0l3-3a.75.75 0 1 0-1.06-1.06L10.75 10.94V2.75A.75.75 0 0 0 10 2Z" />
-            </svg>
-          }
-        />
+    <div className="bg-[#1e1e1e] border border-gray-700 rounded-lg p-5">
+      {/* Header */}
+      <div className="flex items-center justify-between mb-5">
+        <div className="flex items-center gap-2">
+          <Activity className="w-4 h-4 text-blue-400" />
+          <h3 className="text-base font-semibold text-white">
+            Real-Time Bandwidth Usage
+          </h3>
+        </div>
+        <div className="flex items-center gap-2">
+          <div className="flex items-center gap-0.5 bg-gray-800 rounded-md p-0.5">
+            {TIME_RANGES.map(({ label }) => (
+              <button
+                key={label}
+                onClick={() => setTimeRange(label)}
+                className={`px-2 py-0.5 rounded text-xs font-medium transition-colors ${
+                  timeRange === label
+                    ? 'bg-[#1e1e1e] text-white border border-gray-600'
+                    : 'text-gray-500 hover:text-gray-300'
+                }`}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+          <button
+            onClick={handleDownload}
+            className="p-1.5 rounded text-gray-500 hover:text-gray-300 hover:bg-gray-800 transition-colors"
+            aria-label="Download chart"
+          >
+            <Download className="w-4.5 h-4.5" />
+          </button>
+        </div>
       </div>
-      <h3 className="text-lg font-semibold text-white mb-4 text-center">
-        Real-Time Bandwidth Usage
-      </h3>
 
       <div ref={chartContainerRef}>
-        <ResponsiveContainer width="100%" height={350}>
+        <ResponsiveContainer width="100%" height={300}>
           <LineChart
-            data={bandwidthHistory}
-            margin={{ top: 30, right: 30, left: 0, bottom: 5 }}
+            data={filteredHistory}
+            margin={{ top: 10, right: 10, left: 0, bottom: 5 }}
           >
             <CartesianGrid strokeDasharray="3 3" stroke="#444" />
             <XAxis
               dataKey="timestamp"
               tickFormatter={(ts) => new Date(ts).toLocaleTimeString()}
               stroke="#aaa"
+              tickMargin={10}
+              tick={{ fill: '#777', fontSize: 15 }}
+              tickLine={false}
+              axisLine={{ stroke: '#333' }}
             />
             <YAxis
               stroke="#aaa"
               tickFormatter={(value) => formatBytes(value)}
-              allowDataOverflow
+              tick={{ fill: '#777', fontSize: 15 }}
+              tickLine={false}
+              axisLine={false}
+              width={45}
             />
             <Tooltip
-              contentStyle={{ backgroundColor: '#222', borderColor: '#555' }}
+              contentStyle={{
+                backgroundColor: '#1a1a1a',
+                borderColor: '#333',
+                borderRadius: '6px',
+                fontSize: '12px',
+              }}
               labelFormatter={(ts) => new Date(ts).toLocaleTimeString()}
               formatter={(value: number, name: string) => [
                 formatBytes(value),
@@ -82,12 +120,18 @@ const BandwidthPanel: React.FC<BandwidthPanelProps> = ({
             <Line
               dataKey="bandwidthRecv"
               stroke="#4ade80"
-              name="Bytes Received/sec"
+              name="↓ Received/s"
+              strokeWidth={1.5}
+              dot={{ r: 2.5, fill: '#4ade80', strokeWidth: 0 }}
+              activeDot={{ r: 4 }}
             />
             <Line
               dataKey="bandwidthSent"
               stroke="#60a5fa"
-              name="Bytes Sent/sec"
+              name="↑ Sent/s"
+              strokeWidth={1.5}
+              dot={{ r: 2.5, fill: '#60a5fa', strokeWidth: 0 }}
+              activeDot={{ r: 4 }}
             />
           </LineChart>
         </ResponsiveContainer>

--- a/dashboard/src/components/NodeHealth/Constants.ts
+++ b/dashboard/src/components/NodeHealth/Constants.ts
@@ -6,3 +6,10 @@ export const MAX_RECONNECT_ATTEMPTS = 5;
 
 // Utility constants
 export const KILOBYTE = 1024;
+export const TIME_RANGES = [
+  { label: '1m', seconds: 60 },
+  { label: '5m', seconds: 300 },
+  { label: '15m', seconds: 900 },
+  { label: '1h', seconds: 3600 },
+  { label: '1d', seconds: 86400 },
+] as const;

--- a/dashboard/src/components/NodeHealth/InfoRow.tsx
+++ b/dashboard/src/components/NodeHealth/InfoRow.tsx
@@ -1,12 +1,18 @@
 export const InfoRow = ({
   label,
   value,
+  mono = false,
 }: {
   label: string;
   value: string | number;
+  mono?: boolean;
 }) => (
-  <div className="flex justify-between">
-    <span className="text-gray-500">{label}</span>
-    <span className="font-medium text-white">{value}</span>
+  <div className="flex justify-between items-baseline gap-4">
+    <span className="text-gray-500 shrink-0">{label}</span>
+    <span
+      className={`font-medium text-white text-right ${mono ? 'font-mono' : ''}`}
+    >
+      {value}
+    </span>
   </div>
 );

--- a/dashboard/src/components/NodeHealth/Mempool.tsx
+++ b/dashboard/src/components/NodeHealth/Mempool.tsx
@@ -7,7 +7,7 @@ export default function MempoolPanel({ mempool }: { mempool: MempoolInfo }) {
   return (
     <div className="grid grid-cols-1 gap-6 px-4 w-full">
       {/* Stats Card */}
-      <div className="bg-[#1e1e1e] border border-gray-700 rounded-lg p-6 backdrop-blur-sm">
+      <div className="bg-[#1e1e1e] border border-gray-700 rounded-lg p-6">
         <div className="mb-4">
           <h2 className="text-xl font-semibold text-white">
             Mempool Statistics

--- a/dashboard/src/components/NodeHealth/Network.tsx
+++ b/dashboard/src/components/NodeHealth/Network.tsx
@@ -9,7 +9,7 @@ export default function NetworkPanel({ network }: NetworkPanelProps) {
       badge: true,
     },
     {
-      label: 'Protocol:',
+      label: 'Protocol Version:',
       value: network.protocolversion,
     },
     {

--- a/dashboard/src/components/NodeHealth/Network.tsx
+++ b/dashboard/src/components/NodeHealth/Network.tsx
@@ -1,42 +1,61 @@
+import { Share2 } from 'lucide-react';
 import { NetworkPanelProps } from './Types';
 
 export default function NetworkPanel({ network }: NetworkPanelProps) {
+  const cards = [
+    {
+      label: 'Network Status:',
+      value: network.networkactive ? 'Active' : 'Inactive',
+      badge: true,
+    },
+    {
+      label: 'Protocol:',
+      value: network.protocolversion,
+    },
+    {
+      label: 'Version:',
+      value: network.subversion,
+    },
+    {
+      label: 'Relay Fee:',
+      value: `${network.relayfee} BTC`,
+    },
+  ];
+
   return (
-    <div className="grid grid-cols-1 gap-6 px-4 w-full">
-      <div className="bg-[#1e1e1e] border border-gray-700 rounded-xl backdrop-blur-sm p-6">
-        <h2 className="text-white text-lg font-semibold mb-4">
-          Network Status
-        </h2>
-        <div className="grid sm:grid-cols-1 md:grid-cols-2 gap-4">
-          <div>
-            <p className="text-sm font-medium text-gray-300">Network Active</p>
-            <span
-              className={`inline-block mt-1 px-3 py-1 text-sm font-medium rounded-full ${
-                network.networkactive
-                  ? 'bg-green-600 text-white'
-                  : 'bg-red-600 text-white'
-              }`}
-            >
-              {network.networkactive ? 'Active' : 'Inactive'}
-            </span>
+    <div className="rounded-lg border border-gray-700 bg-[#1e1e1e] p-6">
+      <div className="flex items-center gap-2 mb-5">
+        <Share2 className="w-4 h-4 text-blue-400" />
+        <h2 className="text-lg font-semibold text-white">Network Status</h2>
+      </div>
+
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6 ">
+        {cards.map((item) => (
+          <div
+            key={item.label}
+            className="rounded-lg border border-gray-700 p-4"
+          >
+            <div className="flex items-baseline gap-2">
+              <span className="text-gray-500 text-sm">{item.label}</span>
+
+              {item.badge ? (
+                <span
+                  className={`px-2 py-1 rounded-sm text-sm font-semibold ${
+                    network.networkactive
+                      ? 'bg-green-600 text-white'
+                      : 'bg-red-600 text-white'
+                  }`}
+                >
+                  {item.value}
+                </span>
+              ) : (
+                <span className="font-mono text-sm font-semibold text-white">
+                  {item.value}
+                </span>
+              )}
+            </div>
           </div>
-          <div>
-            <p className="text-sm font-medium text-gray-300">Version</p>
-            <p className="font-mono text-white mt-1">{network.subversion}</p>
-          </div>
-          <div>
-            <p className="text-sm font-medium text-gray-300">
-              Protocol Version
-            </p>
-            <p className="font-mono text-white mt-1">
-              {network.protocolversion}
-            </p>
-          </div>
-          <div>
-            <p className="text-sm font-medium text-gray-300">Relay Fee</p>
-            <p className="font-mono text-white mt-1">{network.relayfee} BTC</p>
-          </div>
-        </div>
+        ))}
       </div>
     </div>
   );

--- a/dashboard/src/components/NodeHealth/NodeHealth.tsx
+++ b/dashboard/src/components/NodeHealth/NodeHealth.tsx
@@ -216,21 +216,12 @@ const NodeHealth: React.FC = () => {
   return (
     <div className="bg-[#1e1e1e] px-4 sm:px-6 py-6">
       {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-start justify-between mb-6 gap-2">
+      <div className="flex flex-col sm:flex-row sm:items-start justify-between mb-10 gap-2">
         <div>
           <h1 className="text-2xl font-bold text-white tracking-tight">
             Node Health Dashboard
           </h1>
-          <div className="flex items-center gap-1.5 mt-1">
-            <span
-              className={`w-1.5 h-1.5 rounded-full inline-block ${wsConnected ? 'bg-green-500' : 'bg-yellow-500'}`}
-            />
-            <span
-              className={`text-sm ${wsConnected ? 'text-green-500' : 'text-yellow-500'}`}
-            >
-              {wsConnected ? 'All systems operational' : 'Reconnecting...'}
-            </span>
-          </div>
+         
         </div>
         <div className="flex items-center gap-1.5 text-sm text-gray-500">
           <Clock className="w-3.5 h-3.5" />

--- a/dashboard/src/components/NodeHealth/NodeHealth.tsx
+++ b/dashboard/src/components/NodeHealth/NodeHealth.tsx
@@ -221,7 +221,6 @@ const NodeHealth: React.FC = () => {
           <h1 className="text-2xl font-bold text-white tracking-tight">
             Node Health Dashboard
           </h1>
-         
         </div>
         <div className="flex items-center gap-1.5 text-sm text-gray-500">
           <Clock className="w-3.5 h-3.5" />

--- a/dashboard/src/components/NodeHealth/NodeHealth.tsx
+++ b/dashboard/src/components/NodeHealth/NodeHealth.tsx
@@ -5,10 +5,20 @@ import MempoolPanel from './Mempool';
 import BandwidthPanel from './Bandwidth';
 import { InfoRow } from './InfoRow';
 import { TABS, useIsSmallScreen } from './Utils';
-import { shortenHash } from '../BeadsTab/lib/Utils';
+import { shortenHash, useCopyToClipboard } from '../BeadsTab/lib/Utils';
 import { WEBSOCKET_URLS } from '../../URLs';
 import { MAX_RECONNECT_ATTEMPTS } from './Constants';
-import { Loader } from 'lucide-react';
+import {
+  Loader,
+  Clock,
+  CheckCircle2,
+  Box,
+  Users,
+  Layers,
+  Link2,
+  Copy,
+  Check,
+} from 'lucide-react';
 
 import {
   BlockchainInfo,
@@ -39,6 +49,7 @@ const NodeHealth: React.FC = () => {
   const wsRef = useRef<WebSocket | null>(null);
   const reconnectTimeoutRef = useRef<NodeJS.Timeout | null>(null);
   const isSmallScreen = useIsSmallScreen();
+  const { copied, copy } = useCopyToClipboard();
 
   useEffect(() => {
     let isMounted = true;
@@ -203,65 +214,122 @@ const NodeHealth: React.FC = () => {
   const syncPercentage = ((blocks / headers) * 100).toFixed(2);
 
   return (
-    <div className="min-h-auto bg-[#1e1e1e] px-2 sm:px-4 md:px-6 py-6 md:py-8">
-      <div>
-        <p className="text-xs flex justify-end sm:text-sm text-gray-500 mb-4">
-          {`Last updated: ${lastUpdated}`}
-        </p>
+    <div className="bg-[#1e1e1e] px-4 sm:px-6 py-6">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-start justify-between mb-6 gap-2">
+        <div>
+          <h1 className="text-2xl font-bold text-white tracking-tight">
+            Node Health Dashboard
+          </h1>
+          <div className="flex items-center gap-1.5 mt-1">
+            <span
+              className={`w-1.5 h-1.5 rounded-full inline-block ${wsConnected ? 'bg-green-500' : 'bg-yellow-500'}`}
+            />
+            <span
+              className={`text-sm ${wsConnected ? 'text-green-500' : 'text-yellow-500'}`}
+            >
+              {wsConnected ? 'All systems operational' : 'Reconnecting...'}
+            </span>
+          </div>
+        </div>
+        <div className="flex items-center gap-1.5 text-sm text-gray-500">
+          <Clock className="w-3.5 h-3.5" />
+          <span>Last updated: {lastUpdated}</span>
+        </div>
       </div>
 
       {/* Summary Cards */}
-      <div className="grid sm:grid-cols-1  md:grid-cols-4 gap-4 md:gap-6">
+      <div className="grid sm:grid-cols-1 md:grid-cols-4 gap-4">
         {/* Sync Status */}
-        <div className=" border border-gray-700 rounded-xl px-2 py-2">
-          <h2 className="text-xs sm:text-sm text-gray-500 mb-1">Sync Status</h2>
+        <div className="border border-gray-700 rounded-lg px-4 py-4 relative">
+          <div className="absolute top-3 right-3 w-8 h-8 rounded-full bg-[#0d1f3c] flex items-center justify-center">
+            <CheckCircle2 className="w-4 h-4 text-blue-400" />
+          </div>
+          <h2 className="text-sm text-gray-500 mb-1">Sync Status</h2>
           <p
-            className={`text-lg sm:text-xl font-bold mb-1 ${headers === blocks ? 'text-green-600' : 'text-yellow-500'}`}
+            className={`text-2xl font-bold mb-3 ${headers === blocks ? 'text-green-500' : 'text-yellow-500'}`}
           >
             {headers === blocks ? 'Synced' : 'Syncing'}
           </p>
-          <div className="w-full h-4 rounded bg-gray-200">
+          <div className="flex justify-between text-sm text-gray-500 mb-1">
+            <span>Sync Progress</span>
+            <span>{syncPercentage}%</span>
+          </div>
+          <div className="w-full h-1 rounded bg-gray-800">
             <div
               className="h-full rounded bg-green-500"
               style={{ width: `${syncPercentage}%` }}
-            ></div>
+            />
           </div>
-          <p className="text-xs text-gray-500 mt-1">
-            {syncPercentage}% complete
-          </p>
         </div>
 
         {/* Block Height */}
-        <div className=" border border-gray-700 rounded-xl px-2 py-2">
-          <h2 className="text-xs sm:text-sm text-gray-500 mb-1">
-            Block Height
-          </h2>
-          <p className="text-lg sm:text-xl text-white font-bold">{blocks}</p>
-          <p className="text-xs text-gray-500">
-            {(size_on_disk / 1024 ** 3).toFixed(2)}GB
-          </p>
+        <div className="border border-gray-700 rounded-lg px-4 py-4 relative">
+          <div className="absolute top-3 right-3 w-8 h-8 rounded-full bg-[#0d1f3c] flex items-center justify-center">
+            <Box className="w-4 h-4 text-blue-400" />
+          </div>
+          <h2 className="text-sm text-gray-500 mb-1">Block Height</h2>
+          <p className="text-2xl text-white font-bold font-mono">{blocks}</p>
+          <div className="mt-2 space-y-1">
+            <div className="flex justify-between text-sm text-gray-500">
+              <span>Headers</span>
+              <span className="font-mono text-gray-400">{headers}</span>
+            </div>
+            <div className="flex justify-between text-sm text-gray-500">
+              <span>Disk</span>
+              <span className="font-mono text-gray-400">
+                {(size_on_disk / 1024 ** 3).toFixed(2)} GB
+              </span>
+            </div>
+          </div>
         </div>
 
         {/* Connections */}
-        <div className=" border border-gray-700 rounded-xl px-2 py-2">
-          <h2 className="text-xs sm:text-sm text-gray-500 mb-1">Connections</h2>
-          <p className="text-lg sm:text-xl text-white font-bold">
+        <div className="border border-gray-700 rounded-lg px-4 py-4 relative">
+          <div className="absolute top-3 right-3 w-8 h-8 rounded-full bg-[#0d1f3c] flex items-center justify-center">
+            <Users className="w-4 h-4 text-blue-400" />
+          </div>
+          <h2 className="text-sm text-gray-500 mb-1">Connections</h2>
+          <p className="text-2xl text-white font-bold font-mono">
             {networkInfo?.connections ?? '...'}
           </p>
-          <p className="text-xs text-gray-500">
-            {networkInfo
-              ? `${networkInfo.connections_in ?? '?'} inbound, ${networkInfo.connections_out ?? '?'} outbound`
-              : ''}
-          </p>
+          <div className="mt-2 space-y-1">
+            <div className="flex justify-between text-sm text-gray-500">
+              <span>Inbound</span>
+              <span className="font-mono text-gray-400">
+                {networkInfo?.connections_in ?? '?'}
+              </span>
+            </div>
+            <div className="flex justify-between text-sm text-gray-500">
+              <span>Outbound</span>
+              <span className="font-mono text-gray-400">
+                {networkInfo?.connections_out ?? '?'}
+              </span>
+            </div>
+          </div>
         </div>
 
         {/* Mempool */}
-        <div className="border border-gray-700 rounded-xl px-2 py-2">
-          <h2 className="text-xs sm:text-sm text-gray-500 mb-1">Mempool</h2>
-          <p className="text-lg sm:text-xl text-white font-bold">
-            {mempoolInfo?.size?.toLocaleString() ?? '...'}
-          </p>
-          <div className="w-full h-4 rounded bg-gray-200">
+        <div className="border border-gray-700 rounded-lg px-4 py-4 relative">
+          <div className="absolute top-3 right-3 w-8 h-8 rounded-full bg-[#0d1f3c] flex items-center justify-center">
+            <Layers className="w-4 h-4 text-blue-400" />
+          </div>
+          <h2 className="text-sm text-gray-500 mb-1">Mempool</h2>
+          <div className="flex items-baseline gap-1.5">
+            <p className="text-2xl text-white font-bold font-mono">
+              {mempoolInfo?.size?.toLocaleString() ?? '...'}
+            </p>
+            <span className="text-sm text-gray-600">txs</span>
+          </div>
+          <div className="flex justify-between text-sm text-gray-500 mb-1 mt-3">
+            <span>Memory</span>
+            <span>
+              {mempoolInfo && mempoolInfo.usage
+                ? `${(mempoolInfo.usage / (1024 * 1024)).toFixed(2)} MB`
+                : '...'}
+            </span>
+          </div>
+          <div className="w-full h-1 rounded bg-gray-800">
             <div
               className="h-full rounded bg-green-500"
               style={{
@@ -270,23 +338,18 @@ const NodeHealth: React.FC = () => {
                     ? `${((mempoolInfo.usage / mempoolInfo.maxmempool) * 100).toFixed(2)}%`
                     : '0%',
               }}
-            ></div>
+            />
           </div>
-          <p className="text-xs text-gray-500 mt-1">
-            {mempoolInfo && mempoolInfo.usage
-              ? `${(mempoolInfo.usage / (1024 * 1024)).toFixed(2)} MB`
-              : '...'}
-          </p>
         </div>
       </div>
 
       {/* Tabs */}
-      <div className="mt-8 border border-gray-700 rounded-xl p-3 flex justify-center">
-        <nav className="flex max-sm:flex-col gap-4 sm:gap-10 text-xs sm:text-sm font-medium whitespace-nowrap">
+      <div className="mt-6 border-b border-gray-700">
+        <nav className="flex max-sm:flex-wrap gap-1 text-sm font-medium whitespace-nowrap">
           {TABS.map((tab) => (
             <button
               key={tab.value}
-              className={`py-2 border-b-2 ${activeTab === tab.value ? 'text-white border-blue-900' : 'text-gray-500 cursor-pointer border-transparent'}`}
+              className={`px-3 pb-2 pt-1 border-b-2 -mb-px ${activeTab === tab.value ? 'text-white border-blue-500' : 'text-gray-500 cursor-pointer border-transparent hover:text-gray-300'}`}
               onClick={() => setActiveTab(tab.value)}
             >
               {tab.label}
@@ -298,30 +361,70 @@ const NodeHealth: React.FC = () => {
       {/* Tab Content */}
       <div className="mt-6">
         {activeTab === 'blockchain' && blockchainInfo && (
-          <div className="grid grid-cols-1 gap-6 px-3 w-full">
-            <div className="rounded-xl border border-gray-700 p-4">
-              <h3 className="text-base md:text-lg text-white font-semibold text-center mb-4">
-                Blockchain Information
-              </h3>
-              <div className="space-y-2 text-xs sm:text-sm">
-                <InfoRow label="Chain" value={chain} />
-                <InfoRow label="Current Blocks" value={blocks} />
-                <InfoRow
-                  label="Synced"
-                  value={headers === blocks ? 'True' : 'False'}
-                />
-                <InfoRow
-                  label="Best Block Hash"
-                  value={
-                    isSmallScreen ? shortenHash(bestblockhash) : bestblockhash
-                  }
-                />
-                <InfoRow
-                  label="Verification Progress"
-                  value={`${(verificationprogress * 100).toFixed(4)}%`}
-                />
-                <InfoRow label="Difficulty" value={difficulty} />
-                <InfoRow label="Pruned" value={pruned ? 'True' : 'False'} />
+          <div className="w-full">
+            <div className="rounded-lg border border-gray-700 p-5">
+              <div className="flex items-center gap-2 mb-5">
+                <Link2 className="w-4 h-4 text-blue-400" />
+                <h3 className="text-lg text-white font-semibold">
+                  Blockchain Information
+                </h3>
+              </div>
+              <div className="grid md:grid-cols-2 gap-6">
+                <div className="space-y-3 text-sm">
+                  <InfoRow label="Chain" value={chain} />
+                  <InfoRow label="Blocks" value={blocks} mono />
+                  <InfoRow label="Headers" value={headers} mono />
+                  <div className="flex justify-between items-center">
+                    <span className="text-gray-500">Synced</span>
+                    <span
+                      className={`px-2 py-0.5 rounded text-xs font-medium ${headers === blocks ? 'bg-green-900 text-green-400' : 'bg-yellow-900 text-yellow-400'}`}
+                    >
+                      {headers === blocks ? 'Yes' : 'No'}
+                    </span>
+                  </div>
+                  <div className="pt-2 border-t border-gray-800 space-y-3">
+                    <InfoRow
+                      label="Verification"
+                      value={`${(verificationprogress * 100).toFixed(4)}%`}
+                      mono
+                    />
+                    <InfoRow label="Difficulty" value={difficulty} mono />
+                    <div className="flex justify-between items-center">
+                      <span className="text-gray-500">Pruned</span>
+                      <span className="px-2 py-0.5 rounded text-xs font-medium bg-gray-800 text-gray-400">
+                        {pruned ? 'Yes' : 'No'}
+                      </span>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="md:border-l md:border-gray-700 md:pl-6">
+                  <p className="text-sm text-gray-500 mb-3">Best Block Hash</p>
+                  <div className="flex items-start gap-2">
+                    <p className="font-mono text-sm text-white break-all flex-1">
+                      {isSmallScreen
+                        ? shortenHash(bestblockhash)
+                        : bestblockhash}
+                    </p>
+                    <button
+                      onClick={() => copy(bestblockhash)}
+                      className={`flex-shrink-0 p-1.5 rounded transition-colors ${
+                        copied === bestblockhash
+                          ? 'text-green-400'
+                          : 'text-gray-500 hover:text-gray-300 hover:bg-gray-800'
+                      }`}
+                      aria-label={
+                        copied === bestblockhash ? 'Copied!' : 'Copy block hash'
+                      }
+                    >
+                      {copied === bestblockhash ? (
+                        <Check className="w-3.5 h-3.5" />
+                      ) : (
+                        <Copy className="w-3.5 h-3.5" />
+                      )}
+                    </button>
+                  </div>
+                </div>
               </div>
             </div>
           </div>

--- a/dashboard/src/components/NodeHealth/Peers.tsx
+++ b/dashboard/src/components/NodeHealth/Peers.tsx
@@ -32,7 +32,7 @@ export default function Peers({ peers }: { peers: PeerInfo[] }) {
         {paginatedPeers.map((peer) => (
           <div
             key={peer.id}
-            className="flex max-sm:flex-col md:flex-row md:items-start md:justify-between gap-4 p-4 border border-gray-700 rounded-lg bg-gray-900/30 hover:bg-gray-900/50 transition-colors overflow-x-hidden"
+            className="flex max-sm:flex-col md:flex-row md:items-start md:justify-between gap-4 p-4 border border-gray-700 rounded-lg bg-[#161616] hover:bg-gray-800 transition-colors overflow-x-hidden"
           >
             <div className="flex-1 space-y-1 min-w-0">
               <p className="text-white font-medium">{peer.addr}</p>

--- a/dashboard/src/components/NodeHealth/Types.ts
+++ b/dashboard/src/components/NodeHealth/Types.ts
@@ -1,3 +1,4 @@
+import { TIME_RANGES } from './Constants';
 export interface BlockchainInfo {
   chain: string;
   blocks: number;
@@ -87,3 +88,4 @@ export interface BandwidthHistoryPoint {
 export interface BandwidthPanelProps {
   bandwidthHistory: BandwidthHistoryPoint[];
 }
+export type TimeRangeLabel = (typeof TIME_RANGES)[number]['label'];

--- a/dashboard/src/components/NodeHealth/Types.ts
+++ b/dashboard/src/components/NodeHealth/Types.ts
@@ -83,6 +83,8 @@ export interface BandwidthHistoryPoint {
   timestamp: number;
   totalbytesrecv: number;
   totalbytessent: number;
+  bandwidthRecv: number;
+  bandwidthSent: number;
 }
 
 export interface BandwidthPanelProps {

--- a/dashboard/src/components/NodeHealth/__tests__/Network.test.tsx
+++ b/dashboard/src/components/NodeHealth/__tests__/Network.test.tsx
@@ -22,7 +22,9 @@ describe('NetworkPanel', () => {
 
   it('renders network status and details', () => {
     render(<NetworkPanel network={mockNetwork} />);
-    expect(screen.getByText(/Network Status/i)).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /Network Status/i })
+    ).toBeInTheDocument();
     expect(screen.getAllByText(/Active/i).length).toBeGreaterThan(0);
 
     expect(screen.getByText(/Protocol Version/i)).toBeInTheDocument();


### PR DESCRIPTION
This PR redesigns the **Node Health** tab to provide a cleaner, more intuitive, and interactive monitoring experience. It improves the overall UI with better typography, spacing, icons, enhanced tab styling, and a consistent card-based layout, making node information easier to scan at a glance. The PR also introduces copy-to-clipboard functionality for the Best Block Hash and adds selectable bandwidth time-range filters (**1m, 5m, 15m, 1h, and 1d**) to improve real-time network activity monitoring. Additionally, the `NetworkPanel` and `InfoRow` components have been refactored for better consistency, reusability, and maintainability.






## Before

*(old screenshots)*
<img width="1842" height="806" alt="image" src="https://github.com/user-attachments/assets/a82b0b2a-29e6-414e-ad63-62fc540f0e27" />
<img width="1871" height="866" alt="image" src="https://github.com/user-attachments/assets/869a483e-0882-4b34-9286-77b366487290" />

## After

*(new screenshots)*
<img width="1896" height="858" alt="image" src="https://github.com/user-attachments/assets/ec060780-c50a-4489-9f55-53d148aecef4" />
<img width="1810" height="802" alt="image" src="https://github.com/user-attachments/assets/68890a9d-f131-4742-b60c-d3a9d1e5318e" />
---


