### PR TITLE
fix(node): drop peer connection instead of panicking on a malformed message

### DIFF
--- a/node/src/connection.rs
+++ b/node/src/connection.rs
@@ -69,7 +69,10 @@ impl Connection {
     async fn message_received(&mut self, message: &Bytes) -> Result<(), &'static str> {
         use futures::SinkExt;
 
-        let message: Message = protocol::Message::from_bytes(message).unwrap();
+        // A peer can send arbitrary bytes; a failed decode must drop this
+        // connection, not panic the whole node.
+        let message: Message = protocol::Message::from_bytes(message)
+            .map_err(|_| "failed to deserialize peer message")?;
         match message.response_for_received() {
             Ok(result) => {
                 if let Some(response) = result {

--- a/node/src/protocol.rs
+++ b/node/src/protocol.rs
@@ -74,6 +74,15 @@ mod tests {
     }
 
     #[test]
+    fn it_returns_err_on_malformed_bytes() {
+        // A peer can send arbitrary bytes. from_bytes must return Err instead of
+        // panicking so that message_received can drop the connection rather than
+        // crash the whole node.
+        assert!(Message::from_bytes(&[0xff, 0xff, 0xff, 0xff]).is_err());
+        assert!(Message::from_bytes(&[]).is_err());
+    }
+
+    #[test]
     fn it_matches_start_message_for_ping() {
         let addr = SocketAddr::from_str("127.0.0.1:25188").unwrap();
         let start_message = PingMessage::start(&addr).unwrap();


### PR DESCRIPTION
### what

`message_received()` in `node/src/connection.rs` decoded peer bytes with `Message::from_bytes(...).unwrap()`. a peer sending anything that fails to deserialize would panic and take down the whole node.

### why

the bytes here come straight off the network and are fully untrusted. `message_received()` already returns `Result<(), &'static str>` and the read loop closes the connection whenever it gets an `Err`, so the fix is to return an error instead of unwrapping. a malformed message now just drops that one peer.

### how tested

added `it_returns_err_on_malformed_bytes` in `protocol.rs`: `from_bytes` returns `Err` on garbage bytes and on empty input. verified the underlying flexbuffers decode rejects both cases, and a valid round-trip still decodes. CI compiles the node crate and runs the test on linux.

### risk

low. only turns a panic on bad input into a dropped connection. no change for valid messages.
