### PR TITLE
Remove unused tailwind.config.js from dashboard

### DIFF
--- a/dashboard/tailwind.config.js
+++ b/dashboard/tailwind.config.js
@@ -1,8 +1,0 @@
-/** @type {import('tailwindcss').Config} */
-module.exports = {
-  content: ['./index.html', './src/**/*.{js,ts,jsx,tsx}'],
-  theme: {
-    extend: {},
-  },
-  plugins: [],
-};


### PR DESCRIPTION
## Summary

Removes the unused `dashboard/tailwind.config.js`.

The project uses Tailwind CSS v4 with the `@tailwindcss/vite` plugin, so this config file is no longer used. There is no `@config` directive referencing it, making it effectively dead code.

The file also uses `module.exports` even though the package is configured as ESM (`"type": "module"`). While it isn't currently loaded, keeping it around could cause confusion or parsing errors if it ever is.

## Background

While looking into #514, I noticed the reported Vite CJS deprecation warning could not be reproduced on the pinned Vite version (6.2.6).

The project is already using ESM:
- `package.json` has `"type": "module"`
- `vite.config.ts` is ESM

A clean install starts the dev server without any CJS deprecation warnings. The only CJS-related issue I found was this unused Tailwind config, which this PR removes.

## Verification

- `vite build` produces identical CSS before and after removing the file (same `index-*.css` hash, 53.46 kB).
- `npm run dev` starts without any CJS deprecation warnings.

## Note

`npm run build` (`tsc && vite build`) currently fails on `main` due to existing TypeScript errors unrelated to this change. This PR does not modify `src/` or address those issues.