### PR TITLE
fix(node): return decode errors instead of panicking on malformed peer metadata

### DIFF
--- a/node/src/committed_metadata/mod.rs
+++ b/node/src/committed_metadata/mod.rs
@@ -122,10 +122,21 @@ impl Decodable for CommittedMetadata {
         let parents = Vec::<BeadHash>::consensus_decode(r)?;
         let parent_bead_timestamps = TimeVec::consensus_decode(r)?;
         let payout_address = String::consensus_decode(r)?;
-        let start_timestamp = Time::from_consensus(u32::consensus_decode(r).unwrap()).unwrap();
-        let comm_pub_key = PublicKey::from_slice(&Vec::<u8>::consensus_decode(r).unwrap()).unwrap();
-        let min_target = CompactTarget::consensus_decode(r).unwrap();
-        let weak_target = CompactTarget::consensus_decode(r).unwrap();
+        let start_timestamp = Time::from_consensus(u32::consensus_decode(r)?).map_err(|_| {
+            Error::from(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid start_timestamp in CommittedMetadata",
+            ))
+        })?;
+        let comm_pub_key =
+            PublicKey::from_slice(&Vec::<u8>::consensus_decode(r)?).map_err(|_| {
+                Error::from(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid comm_pub_key in CommittedMetadata",
+                ))
+            })?;
+        let min_target = CompactTarget::consensus_decode(r)?;
+        let weak_target = CompactTarget::consensus_decode(r)?;
         let miner_ip = String::consensus_decode(r)?;
         Ok(CommittedMetadata {
             transaction_ids,

--- a/node/src/uncommitted_metadata/mod.rs
+++ b/node/src/uncommitted_metadata/mod.rs
@@ -49,8 +49,19 @@ impl Decodable for UnCommittedMetadata {
     fn consensus_decode<R: BufRead + ?Sized>(r: &mut R) -> Result<Self, Error> {
         let extra_nonce_1 = u64::consensus_decode(r)?;
         let extra_nonce_2 = u64::consensus_decode(r)?;
-        let broadcast_timestamp = Time::from_consensus(u32::consensus_decode(r).unwrap()).unwrap();
-        let signature = Signature::from_str(&String::consensus_decode(r).unwrap()).unwrap();
+        let broadcast_timestamp =
+            Time::from_consensus(u32::consensus_decode(r)?).map_err(|_| {
+                Error::from(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "invalid broadcast_timestamp in UnCommittedMetadata",
+                ))
+            })?;
+        let signature = Signature::from_str(&String::consensus_decode(r)?).map_err(|_| {
+            Error::from(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "invalid signature in UnCommittedMetadata",
+            ))
+        })?;
 
         Ok(UnCommittedMetadata {
             extra_nonce_1,


### PR DESCRIPTION
### what

`CommittedMetadata` and `UnCommittedMetadata`'s `consensus_decode` impls call `.unwrap()` on values decoded straight from untrusted peer input — the start/broadcast timestamps (`Time::from_consensus`), the committed public key (`PublicKey::from_slice`), and the ECDSA signature (`Signature::from_str`). A peer sending a malformed bead makes any of these panic, taking down the whole node instead of just rejecting the message.

### why

these fields are decoded from bytes received off the network, so they are fully untrusted. `consensus_decode` already returns `Result<Self, Error>` and the surrounding fields use `?`, so the fix is to propagate the error for these fields too instead of unwrapping. I used the crate's existing idiom (`Error::from(bitcoin::io::Error::new(ErrorKind::InvalidData, ...))`, as in `macros.rs`) so a malformed message is dropped rather than fatal.

### how tested

added `decode_rejects_malformed_metadata_without_panicking` in `committed_metadata/tests.rs`: malformed bytes now return `Err` instead of panicking. verified the changed decode paths type-check against the pinned rust-bitcoin fork. CI compiles the node crate and runs the tests on linux.

### notes

this supersedes #522, which fixed the same class of bug (untrusted-input panic) in the old `connection.rs`/`protocol.rs` decode path that the `dev` refactor removed. based on `dev` per the contributing flow.

### risk

low. only turns panics on malformed peer input into clean decode errors. no change for valid messages.
