### PR TITLE
Testframework phase4: Report manager and Base class

### DIFF
--- a/tests/functional/docs/FRAMEWORK_GUIDE.md
+++ b/tests/functional/docs/FRAMEWORK_GUIDE.md
@@ -1,0 +1,552 @@
+# Braidpool Functional Test Framework Guide
+
+Use this guide to write, run, and debug executable functional tests under
+`tests/functional/`. The framework starts the requested Bitcoin, Braidpool,
+and miner processes; assigns isolated ports; collects logs and timing; and
+always attempts cleanup.
+
+If you are in a hurry, read **Quick start**, **Running tests**, and **Things to
+keep in mind**. Use the other sections as reference while writing a test.
+
+## Quick start
+
+1. Create `tests/functional/feature_<name>.py`.
+2. Subclass `BraidpoolTestFramework`.
+3. Implement `set_test_params()` and `run_test()`.
+4. Run the file through `test_runner.py`.
+
+```python
+#!/usr/bin/env python3
+
+from test_framework.network_config import NetworkConfig
+from test_framework.test_framework import BraidpoolTestFramework
+from test_framework.util import assert_equal
+
+
+class FeatureNodeHealth(BraidpoolTestFramework):
+    """Check that two nodes start and agree on their bead count."""
+
+    def set_test_params(self) -> None:
+        self.config = NetworkConfig(
+            num_braidpool_nodes=2,
+            num_cpu_miners=0,
+            initial_blocks=101,
+        )
+
+    def run_test(self) -> None:
+        assert_equal(len(self.nodes), 2)
+        assert_equal(all(node.is_running() for node in self.nodes), True)
+
+        self.sync_all()
+        assert_equal(
+            self.nodes[0].rpc.get_bead_count(),
+            self.nodes[1].rpc.get_bead_count(),
+        )
+
+
+if __name__ == "__main__":
+    FeatureNodeHealth(__file__).main()
+```
+
+From the repository root:
+
+```bash
+python3 tests/functional/test_runner.py feature_node_health.py
+```
+
+The base class owns `__init__()` and `main()`. Do not override them.
+
+## Lifecycle and responsibilities
+
+Every test follows the same lifecycle:
+
+1. Parse framework and test-specific options.
+2. Create the test directory and start its timing report.
+3. Call `set_test_params()`.
+4. Validate the configuration and initialize logging, cleanup, and ports.
+5. Call `setup_network()` to start Bitcoin, Braidpool nodes, and miners.
+6. Call `run_test()`.
+7. Stop managed resources, run custom cleanup, finalize the report, and
+   remove or preserve the test directory.
+
+The shutdown phase runs after passes, skips, failures, and interruptions.
+
+### Methods a test may implement
+
+| Method | Required | Purpose |
+|---|---:|---|
+| `set_test_params()` | Yes | Assign the test's `NetworkConfig`. |
+| `run_test()` | Yes | Make RPC calls and assertions after setup completes. |
+| `add_options(parser)` | No | Add test-specific CLI options. |
+| `setup_network()` | Rarely | Replace the default network startup completely. |
+
+`set_test_params()` and `run_test()` must be declared on every concrete test
+class. The framework rejects classes that omit them or override `__init__()`
+or `main()`.
+
+The default `setup_network()` calls `NodeManager.setup()`. Override it only
+for a custom topology or a test that deliberately needs no external binaries.
+Once overridden, the test owns all setup performed in that method.
+
+## Configuring the test network
+
+Assign a `NetworkConfig` in `set_test_params()`:
+
+```python
+def set_test_params(self) -> None:
+    self.config = NetworkConfig(
+        num_braidpool_nodes=3,
+        num_cpu_miners=2,
+        network="regtest",
+        initial_blocks=101,
+        random_seed=42,
+    )
+```
+
+### NetworkConfig reference
+
+| Field | Default | Meaning |
+|---|---:|---|
+| `num_braidpool_nodes` | `1` | Number of Braidpool nodes to start. |
+| `num_cpu_miners` | `0` | Number of `minerd` processes, distributed across the nodes. |
+| `network` | `"regtest"` | Bitcoin/Braidpool network: `regtest`, `cpunet`, or `signet`. |
+| `initial_blocks` | `101` | Bitcoin blocks generated before Braidpool nodes start. |
+| `bitcoin_rpc_port` | `None` | Manual Bitcoin RPC port; normally leave unset. |
+| `bitcoin_p2p_port` | `None` | Manual Bitcoin P2P port; normally leave unset. |
+| `bitcoin_ipc_socket` | `None` | Manual IPC socket; normally use the isolated per-test path. |
+| `bitcoin_bin_path` | `None` | Explicit `bitcoin-node` path. |
+| `braidpool_bin_path` | `None` | Explicit Braidpool node path. |
+| `minerd_bin_path` | `None` | Explicit CPU miner path. |
+| `startup_timeout_braidpool` | `30.0` | Braidpool startup timeout in seconds. |
+| `startup_timeout_btc` | `90.0` | Bitcoin startup timeout in seconds. |
+| `startup_timeout_minerd` | `60.0` | Miner startup timeout in seconds. |
+| `rpc_timeout` | `10.0` | Timeout for one RPC call. |
+| `peer_connection_timeout` | `15.0` | Peer connection timeout. |
+| `bead_propagation_timeout` | `60.0` | Default `sync_all()` timeout. |
+| `log_level` | `"INFO"` | Framework log level. |
+| `random_seed` | `42` | Seed used by Python's global `random` module. |
+
+Counts cannot be negative. Miners require at least one Braidpool node.
+
+Avoid fixed ports and shared IPC sockets: they make parallel tests collide.
+The runner assigns a stable `--portseed` to each script, and `PortPool` uses it
+to create an isolated port band.
+
+## Objects available in run_test()
+
+After normal setup, the base class exposes:
+
+| Attribute | Type/use |
+|---|---|
+| `self.bitcoin` | Managed `BitcoinNode`; use `self.bitcoin.rpc._call(...)`. |
+| `self.nodes` | List of managed `TestNode` objects. |
+| `self.miners` | List of managed `CpuMiner` objects. |
+| `self.config` | Effective `NetworkConfig`, including CLI overrides. |
+| `self.options` | Parsed framework and test-specific arguments. |
+| `self.tmpdir` | This script's artifact directory. |
+| `self.log` | Structured framework logger. |
+| `self.cleanup_manager` | LIFO cleanup registry for custom resources. |
+| `self.port_pool` | Isolated port allocator for extra services. |
+| `self.report` | Timing report owned and finalized by the framework. |
+
+The framework manages the lifecycle of `self.bitcoin`, `self.nodes`, and
+`self.miners`. Tests should normally inspect them, not stop them manually.
+
+### RPC calls
+
+Use the typed Braidpool helpers where available:
+
+```python
+count = self.nodes[0].rpc.get_bead_count()
+tips = self.nodes[0].rpc.get_tips()
+info = self.nodes[0].rpc.get_braid_info()
+```
+
+`TestNode` also delegates unknown public attributes to its RPC client, so
+`self.nodes[0].get_bead_count()` works. Using `.rpc` explicitly is clearer when
+reading a test.
+
+For Bitcoin RPC:
+
+```python
+chain = self.bitcoin.rpc._call("getblockchaininfo")
+```
+
+Unknown Braidpool RPC method names are dispatched dynamically. A typo therefore
+becomes a server RPC failure rather than a local `AttributeError`; prefer the
+defined helper methods.
+
+The RPC client retries transient connection-refused and HTTP 503 failures.
+Timeouts, authentication failures, malformed responses, and ordinary RPC
+errors still fail the call.
+
+## Assertions, waiting, synchronization, and skipping
+
+Use the shared assertion helpers for useful failure messages:
+
+```python
+from test_framework.util import (
+    assert_equal,
+    assert_greater_than,
+    assert_greater_than_or_equal,
+)
+```
+
+Do not use fixed sleeps to wait for asynchronous state. Poll the condition:
+
+```python
+self.wait_until(
+    lambda: self.nodes[0].rpc.get_bead_count() >= 5,
+    timeout=30.0,
+    message="node did not receive five beads",
+)
+```
+
+`self.wait_until()` automatically applies `--timeout-factor`. It remembers the
+last predicate exception and includes it if the wait expires.
+
+Useful RPC polling helpers include:
+
+```python
+self.nodes[0].rpc.wait_for_ready(timeout=30.0)
+count = self.nodes[0].rpc.wait_for_bead_count(5, timeout=60.0)
+self.nodes[0].rpc.wait_for_peers(1, timeout=30.0)
+```
+
+Use `self.sync_all()` to wait until all Braidpool nodes report the same bead
+count. It checks counts, not complete DAG equality.
+
+Skip when a required runtime capability is unavailable:
+
+```python
+if not capability_available:
+    self.skip_test("requires capability X")
+```
+
+Missing binaries are skipped automatically. Do not catch an unexpected
+exception just to turn it into a skip.
+
+## Test-specific options
+
+Add options without replacing the framework parser:
+
+```python
+import argparse
+
+def add_options(self, parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--expected-beads", type=int, default=5)
+
+def run_test(self) -> None:
+    self.nodes[0].rpc.wait_for_bead_count(self.options.expected_beads)
+```
+
+Run it directly:
+
+```bash
+python3 tests/functional/feature_example.py --expected-beads=10
+```
+
+Or through the runner; unrecognized runner options are forwarded to the test:
+
+```bash
+python3 tests/functional/test_runner.py feature_example.py --expected-beads=10
+```
+
+When several scripts are selected, a forwarded option is passed to all of
+them. Use it only when every selected script accepts it. Pass option-style
+arguments directly as shown; a separate `--` delimiter is not needed.
+
+## Custom resources and cleanup
+
+Framework-created processes are registered automatically. Register every
+additional long-lived resource as soon as it is created:
+
+```python
+def setup_network(self) -> None:
+    super().setup_network()
+    self.helper = start_helper()
+    self.cleanup_manager.register(self.helper.close, name="helper")
+```
+
+Callbacks run exactly once in last-in, first-out order. One callback failure is
+logged and does not prevent later callbacks from running.
+
+For a custom subprocess, start a new session and register the process group:
+
+```python
+process = subprocess.Popen(command, start_new_session=True)
+self.cleanup_manager.managed_process(process, name="custom-helper")
+```
+
+Register immediately after creation, before another operation can raise. Do not
+duplicate process termination logic or rely on garbage collection. Use context
+managers for ordinary files and short-lived resources.
+
+`CleanupManager` installs `atexit`, `SIGINT`, and `SIGTERM` hooks in the actual
+framework lifecycle. A low-level unit test may create `CleanupManager()` without
+installing those global hooks and call `run_all()` directly.
+
+## Writing a no-binary framework test
+
+The default network setup always starts Bitcoin first. For a framework-only
+test, configure zero processes and override `setup_network()`:
+
+```python
+class FeatureNoBinaries(BraidpoolTestFramework):
+    def set_test_params(self) -> None:
+        self.config = NetworkConfig(
+            num_braidpool_nodes=0,
+            num_cpu_miners=0,
+            initial_blocks=0,
+        )
+
+    def setup_network(self) -> None:
+        pass
+
+    def run_test(self) -> None:
+        assert_equal(self.nodes, [])
+```
+
+See [`feature_framework_lifecycle.py`](../feature_framework_lifecycle.py) for a
+complete example with custom options, polling, logging, and cleanup callbacks.
+
+## Binaries and discovery
+
+A normal network test needs `bitcoin-node`; tests with Braidpool nodes also need
+the Braidpool binary, and miner tests need `minerd`.
+
+```bash
+# Build the Braidpool node from the repository root.
+cargo build --bin node
+```
+
+Binary selection uses this order:
+
+1. A path supplied by a test configuration or CLI option.
+2. The component's environment variable.
+3. Known paths relative to the repository root.
+4. The executable found on `PATH`.
+
+| Component | CLI option | Environment variable | Common relative path |
+|---|---|---|---|
+| Braidpool node | `--braidpool-bin` | `BRAIDPOOL_BIN_PATH` | `target/debug/node` |
+| Bitcoin node | `--bitcoin-bin` | `BITCOIN_NODE_PATH` | `../bitcoin/build/bin/bitcoin-node` |
+| CPU miner | `--minerd-bin` | `MINERD_PATH` | `node/src/cpuminer/minerd` |
+
+Example:
+
+```bash
+export BRAIDPOOL_BIN_PATH="$PWD/target/debug/node"
+export BITCOIN_NODE_PATH="$PWD/../bitcoin/build/bin/bitcoin-node"
+python3 tests/functional/test_runner.py feature_node_health.py
+```
+
+Paths are resolved from the framework's location, not the caller's current
+directory.
+
+## Running tests
+
+All commands below assume the repository root.
+
+### Direct execution
+
+```bash
+python3 tests/functional/feature_example.py
+```
+
+Direct execution is useful for `--pdbonfailure`. If direct tests run in
+parallel, give each one a unique `--portseed`.
+
+### Test runner
+
+```bash
+# Run every script registered in BASE_SCRIPTS.
+python3 tests/functional/test_runner.py
+
+# Run one or more named scripts.
+python3 tests/functional/test_runner.py feature_a.py feature_b.py
+
+# Run up to four scripts concurrently.
+python3 tests/functional/test_runner.py --jobs=4
+
+# Keep artifacts from successful scripts.
+python3 tests/functional/test_runner.py --nocleanup feature_a.py
+```
+
+To include a new script in the default suite, add its filename to
+`BASE_SCRIPTS` in [`test_runner.py`](../test_runner.py). Put expensive or
+optional integration scripts in `EXTENDED_SCRIPTS`; they run when
+`--extended` is supplied.
+
+### Runner options
+
+| Option | Purpose |
+|---|---|
+| `SCRIPT...` | Run the named scripts; `.py` is optional. |
+| `--jobs=N`, `-j N` | Maximum scripts running concurrently. |
+| `--timeout=SECONDS` | Hard limit per script; `0` disables it. |
+| `--failfast`, `-F` | Stop scheduling after a failure is observed. |
+| `--filter=REGEX` | Keep registered/selected tests matching a regex. |
+| `--exclude=A,B`, `-x A,B` | Exclude comma-separated script names. |
+| `--extended` | Add scripts registered in `EXTENDED_SCRIPTS`. |
+| `--nocleanup` | Preserve artifacts for successful tests too. |
+| `--combinedlogslen=N`, `-c N` | Print the final N stdout/stderr lines on failure. |
+| `--resultsfile=PATH`, `-r PATH` | Write a CSV result summary. |
+| `--tmpdirprefix=PATH`, `-t PATH` | Parent directory for the runner's artifacts. |
+
+`--timeout` belongs to the runner and can terminate a whole script.
+`--timeout-factor` belongs to the framework and scales its internal startup,
+RPC, peer, propagation, and `self.wait_until()` timeouts.
+
+### Framework options
+
+These options are available during direct execution. The runner forwards the
+applicable options to each child script:
+
+| Option | Purpose |
+|---|---|
+| `--tmpdir=PATH` | Use an explicit per-test artifact directory. |
+| `--nocleanup` | Preserve artifacts after pass or skip. |
+| `--loglevel=LEVEL` | Override the configured log level. |
+| `--tracerpc` | Add RPC request tracing to the framework log. |
+| `--portseed=N` | Select the deterministic port band; must be non-negative. |
+| `--randomseed=N` | Override `NetworkConfig.random_seed`. |
+| `--timeout-factor=N` | Multiply framework timeouts; must be positive. |
+| `--pdbonfailure` | Enter post-mortem debugging after a test exception. |
+| `--network=NAME` | Override the configured network. |
+| `--braidpool-bin=PATH` | Override the Braidpool node binary. |
+| `--bitcoin-bin=PATH` | Override the Bitcoin node binary. |
+| `--minerd-bin=PATH` | Override the CPU miner binary. |
+
+`--cachedir` and `--configfile` are currently reserved; do not rely on them to
+change framework behavior.
+
+The runner owns each child's `--tmpdir` and `--portseed` so concurrent scripts
+remain isolated. Values supplied for those two options through the runner are
+overridden; use them only when executing a script directly. `--pdbonfailure`
+is also most useful during direct execution in an interactive terminal.
+
+### Exit codes
+
+| Code | Meaning |
+|---:|---|
+| `0` | Passed. |
+| `1` | Failed. |
+| `77` | Skipped; the runner treats this as successful. |
+
+The runner itself returns `0` when all results are passed or skipped, otherwise
+`1`.
+
+## Artifacts and reports
+
+Failed tests are always preserved. Passed and skipped tests are removed unless
+`--nocleanup` is used.
+
+```text
+/tmp/bp_func_test_runner_<timestamp>_<suffix>/
+└── feature_example_0/
+    ├── stdout.log
+    ├── stderr.log
+    ├── test_framework.log
+    ├── reports/
+    │   └── summary.json
+    ├── bitcoin/
+    │   ├── stdout.log
+    │   └── stderr.log
+    ├── node0/
+    │   ├── stdout.log
+    │   └── stderr.log
+    └── miner0/
+        ├── stdout.log
+        └── stderr.log
+```
+
+`test_framework.log` contains one structured JSON event per line. Component
+directories contain the raw process output. Combine a preserved run's logs with:
+
+```bash
+python3 tests/functional/combine_logs.py /tmp/bp_func_test_runner_.../feature_example_0
+```
+
+The timing report currently contains only identity, status, start, end, and
+total runtime:
+
+```json
+{
+  "end_time": "2026-08-13T10:00:03.250+00:00",
+  "run_id": "feature_example-feature_example_0",
+  "start_time": "2026-08-13T10:00:00.000+00:00",
+  "status": "passed",
+  "test_name": "feature_example",
+  "total_time_seconds": 3.25
+}
+```
+
+Do not write or finalize this report from the test. The framework writes it
+atomically during shutdown; the runner supplies a failed fallback report if a
+timed-out or abruptly terminated child cannot finalize its own report.
+
+## Debugging failures
+
+1. Re-run only the failing script with `--nocleanup`.
+2. Add `--loglevel=DEBUG --tracerpc` when RPC flow matters.
+3. Use `--combinedlogslen=100` for immediate runner output.
+4. Inspect `stderr.log`, then `test_framework.log`, then component logs.
+5. Increase `--timeout-factor` only if the operation is legitimately slow.
+
+```bash
+python3 tests/functional/test_runner.py \
+  --nocleanup \
+  --combinedlogslen=100 \
+  feature_example.py \
+  --loglevel=DEBUG \
+  --tracerpc
+```
+
+Useful framework events include:
+
+| Event | Meaning |
+|---|---|
+| `test_failed` | The test body or setup raised an exception. |
+| `test_skipped` | The test deliberately skipped. |
+| `rpc_retry` / `rpc_timeout` | RPC transport retry or timeout. |
+| `cleanup_callback_failed` | One cleanup callback failed; others continue. |
+| `cleanup_signal_received` | SIGINT or SIGTERM initiated cleanup. |
+| `process_signal_sent` | A managed process received SIGTERM or SIGKILL. |
+| `process_group_is_self` | A subprocess was not isolated safely. |
+| `log_cleanup_failed` | Successful-run artifact deletion failed. |
+
+## Things to keep in mind
+
+- Keep one scenario per script and use descriptive `feature_*.py` names.
+- Never override `__init__()` or `main()`.
+- Prefer the default network setup; override it only with a clear reason.
+- Use `self.wait_until()` instead of `time.sleep()` for asynchronous state.
+- Use deterministic seeds and framework-allocated ports.
+- Register custom resources immediately and start subprocesses with
+  `start_new_session=True`.
+- Let the framework stop its own nodes and miners.
+- Preserve artifacts with `--nocleanup`; there is no separate log-retention
+  option.
+- Avoid secrets in arguments and logs. RPC tracing is for controlled test data.
+- Do not assume `sync_all()` proves complete DAG equivalence.
+- Keep tests bounded so runner timeouts can diagnose a real hang.
+- A cleanup callback exception is logged but does not stop the remaining
+  callbacks; inspect cleanup errors even when the test body passed.
+
+## Pre-submit checklist
+
+- The script implements `set_test_params()` and `run_test()`.
+- Process counts, block count, network, and timeouts are explicit where relevant.
+- Assertions test observable behavior, not only successful startup.
+- Asynchronous assertions use bounded polling.
+- Custom processes and resources are registered for cleanup.
+- No fixed port or shared IPC path breaks parallel execution.
+- The test passes directly and through `test_runner.py`.
+- The test passes with `--jobs` alongside another network test.
+- Failure output is understandable from preserved logs.
+- The script is added to `BASE_SCRIPTS` or `EXTENDED_SCRIPTS` when appropriate.
+
+For a shorter command-only reference, see
+[`running_tests.md`](running_tests.md). For framework internals and lessons from
+past bugs, see [`learnings.md`](learnings.md).

--- a/tests/functional/docs/FRAMEWORK_GUIDE.md
+++ b/tests/functional/docs/FRAMEWORK_GUIDE.md
@@ -214,7 +214,10 @@ self.nodes[0].rpc.wait_for_peers(1, timeout=30.0)
 ```
 
 Use `self.sync_all()` to wait until all Braidpool nodes report the same bead
-count. It checks counts, not complete DAG equality.
+count. It checks counts, not complete DAG equality. An explicit
+`self.sync_all(timeout=...)` value and the configured
+`bead_propagation_timeout` default are both expressed in unscaled seconds;
+`--timeout-factor` is applied exactly once by `sync_all()`.
 
 Skip when a required runtime capability is unavailable:
 

--- a/tests/functional/docs/running_tests.md
+++ b/tests/functional/docs/running_tests.md
@@ -1,188 +1,86 @@
-# Running the Functional Test Suite
+# Running Braidpool Functional Tests
 
-This guide explains how to run both the framework self-tests and the node-startup integration test.
+This is the quick command reference. See the
+[`Functional Test Framework Guide`](FRAMEWORK_GUIDE.md) for writing tests,
+configuration, lifecycle details, cleanup rules, artifacts, and debugging.
 
+Run commands from the repository root.
 
-## 2. Unit Tests — No Binaries Required
-
-`feature_framework_unit_tests.py` is entirely self-contained. All 38 tests run in-process using mocks and temporary directories.
-
-### Run directly
-
-```bash
-cd tests/functional
-python3 feature_framework_unit_tests.py
-# Exit 0 = all passed.  Exit 1 = at least one failure.
-```
-
-### Run via the test runner
+## Common commands
 
 ```bash
-cd tests/functional
-python3 test_runner.py feature_framework_unit_tests.py
+# Run scripts registered in test_runner.py's BASE_SCRIPTS.
+python3 tests/functional/test_runner.py
+
+# Run one script.
+python3 tests/functional/test_runner.py feature_framework_lifecycle.py
+
+# Run selected scripts in parallel.
+python3 tests/functional/test_runner.py --jobs=4 feature_a.py feature_b.py
+
+# Include scripts registered in EXTENDED_SCRIPTS.
+python3 tests/functional/test_runner.py --extended
+
+# Preserve artifacts and print the last 100 stdout/stderr lines on failure.
+python3 tests/functional/test_runner.py \
+  --nocleanup \
+  --combinedlogslen=100 \
+  feature_framework_lifecycle.py
+
+# Apply a test-specific option; unknown runner options are forwarded.
+python3 tests/functional/test_runner.py \
+  feature_framework_lifecycle.py \
+  --scenario=pass
+
+# Run a script directly.
+python3 tests/functional/feature_framework_lifecycle.py --nocleanup
 ```
 
-### Scan for failures
+## Useful runner options
+
+| Option | Purpose |
+|---|---|
+| `--jobs=N` | Run at most N scripts concurrently. |
+| `--timeout=SECONDS` | Hard timeout for each script; `0` disables it. |
+| `--failfast` | Stop scheduling after a failure is observed. |
+| `--filter=REGEX` | Keep test names matching a regex. |
+| `--exclude=A,B` | Exclude comma-separated script names. |
+| `--extended` | Include `EXTENDED_SCRIPTS`. |
+| `--nocleanup` | Preserve successful and skipped test artifacts. |
+| `--combinedlogslen=N` | Print N trailing stdout/stderr lines on failure. |
+| `--resultsfile=PATH` | Write a CSV summary. |
+| `--tmpdirprefix=PATH` | Choose the artifact parent directory. |
+
+Use `--timeout-factor=N` to scale internal framework timeouts; it is different
+from the runner's hard `--timeout`.
+
+## Binary overrides
 
 ```bash
-python3 feature_framework_unit_tests.py 2>&1 | grep '"test_failed"'
-# Silent = all green
+export BRAIDPOOL_BIN_PATH="$PWD/target/debug/node"
+export BITCOIN_NODE_PATH="$PWD/../bitcoin/build/bin/bitcoin-node"
+export MINERD_PATH="$PWD/node/src/cpuminer/minerd"
 ```
 
-### Count pass/fail
+Equivalent per-test options are `--braidpool-bin`, `--bitcoin-bin`, and
+`--minerd-bin`. Missing required binaries cause a skip (exit `77`), not a
+failure.
 
-```bash
-python3 feature_framework_unit_tests.py 2>&1 | \
-  python3 -c "
-import sys, json
-p = f = 0
-for l in sys.stdin:
-    l = l.strip()
-    if not l.startswith('{'): continue
-    ev = json.loads(l).get('event','')
-    if ev == 'test_passed': p += 1
-    elif ev == 'test_failed': f += 1
-print(f'{p} passed, {f} failed')
-"
-```
-
----
-
-## 3. Integration Test — Requires Real Binaries
-
-`feature_node_startup.py` starts a real `bitcoin-node` (regtest), mines 101 blocks, starts 2
-`braidpool-node` instances, and verifies RPC health and sync.
-
-**If binaries are absent, the test is automatically skipped (not failed).**
-
-### Step 1 — Build braidpool-node
-
-```bash
-# From the repository root:
-cargo build --bin node
-# → target/debug/node
-```
-
-### Step 2 — Build bitcoin-node
-
-```bash
-# Clone Bitcoin Core adjacent to braidpool/ if not already done:
-cd ..
-git clone https://github.com/bitcoin/bitcoin.git
-cd bitcoin
-cmake -B build -DBUILD_UTIL_CHAINSTATE=OFF
-cmake --build build -j$(nproc) --target bitcoin-node bitcoin-cli
-# → build/bin/bitcoin-node, build/bin/bitcoin-cli
-cd ../braidpool
-```
-
-### Step 3 — Tell the framework where the binaries are
-
-**Option A — Environment variables (recommended for CI)**
-
-```bash
-
-# These paths are according to the paths stated above, if it is something els, then define accordingly:
-export BRAIDPOOL_BIN_PATH=$(pwd)/target/debug/node
-export BITCOIN_NODE_PATH=$(pwd)/../bitcoin/build/bin/bitcoin-node
-export BITCOIN_CLI_PATH=$(pwd)/../bitcoin/build/bin/bitcoin-cli
-```
-
-**Option B — CLI flags (recommended for one-off runs)**
-
-```bash
-cd tests/functional
-python3 feature_node_startup.py \
-  --braidpool-bin ../../target/debug/node \
-  --bitcoin-bin   ../../bitcoin/build/bin/bitcoin-node \
-  --bitcoin-cli   ../../bitcoin/build/bin/bitcoin-cli
-```
-
-### Step 4 — Run via test runner
-
-```bash
-cd tests/functional
-python3 test_runner.py feature_node_startup.py --combinedlogslen=50
-# --combinedlogslen=50 prints the last 50 log lines on failure
-```
-
-### Step 5 — Run the full suite
-
-```bash
-cd tests/functional
-python3 test_runner.py          # unit tests + integration test (sequential)
-python3 test_runner.py --jobs=2 # parallel (safe; each test gets its own port band)
-```
-
----
-
-## 4. Inspecting Logs After a Run
-
-When a test fails, logs are kept in a temp directory printed at the bottom of the output:
-`Test data left in /tmp/bp_func_test_runner_YYYYMMDD_HHMMSS_.../`
-
-```
-/tmp/bp_func_test_runner_<timestamp>/
-  feature_node_startup_0/
-    test_framework.log      ← structured JSON events
-    bitcoin/
-      stdout.log            ← bitcoin-node stdout
-      stderr.log            ← bitcoin-node stderr
-    node0/
-      stdout.log            ← braidpool node 0 stdout
-      stderr.log            ← braidpool node 0 stderr
-    node1/
-      stdout.log            ← braidpool node 1 stdout
-      stderr.log            ← braidpool node 1 stderr
-```
-
-Useful one-liners:
-
-```bash
-# Pretty-print framework log
-cat /tmp/bp_func_test_runner_*/feature_node_startup_0/test_framework.log | \
-  python3 -c "import sys,json; [print(json.dumps(json.loads(l), indent=2)) for l in sys.stdin if l.strip()]"
-
-# Tail node 0 stderr
-tail -50 /tmp/bp_func_test_runner_*/feature_node_startup_0/node0/stderr.log
-
-# Keep all logs even on success (for debugging)
-python3 test_runner.py --nocleanup
-```
-
----
-
-## 5. Binary Finding Logic
-
-The framework resolves binaries in three layers, in order:
-
-| Priority | Source | How to override |
-|----------|--------|-----------------|
-| 1 | `$ENV_VAR` (e.g. `$BRAIDPOOL_BIN_PATH`) | `export BRAIDPOOL_BIN_PATH=/path/to/node` |
-| 2 | Relative paths from repo root | Automatically searched; see table below |
-| 3 | `PATH` (system-wide install) | `sudo install target/debug/node /usr/local/bin/braidpool-node` |
-
-If all three fail, `SkipTest` is raised and the test is marked **Skipped** (exit code 77), not Failed.
-
-**Relative paths searched automatically (no config needed if you build in-tree):**
-
-| Binary | Paths tried |
-|--------|-------------|
-| `braidpool-node` | `target/debug/node`, `target/release/node`, `node` |
-| `bitcoin-node` | `../bitcoin/build/bin/bitcoin-node`, `bitcoin-node`, `target/debug/bitcoin-node` |
-| `bitcoin-cli` | `../bitcoin/build/bin/bitcoin-cli`, `bitcoin-cli`, `target/debug/bitcoin-cli` |
-| `minerd` | `node/src/cpuminer/minerd` |
-
-> **Note:** The framework always resolves repo root from its own file location
-> (`Path(__file__).resolve().parents[3]`), never from `cwd`. This means all paths work
-> correctly regardless of where you invoke `test_runner.py` from.
-
----
-
-## 6. Expected Exit Codes
+## Results and artifacts
 
 | Exit code | Meaning |
-|-----------|---------|
-| `0` | All tests passed |
-| `1` | At least one test failed |
-| `77` | Test skipped (missing binary) — counted as passing by the runner |
+|---:|---|
+| `0` | Passed, or every runner result passed/skipped. |
+| `1` | Failed. |
+| `77` | Direct script skipped. |
+
+Failed runs are preserved under
+`/tmp/bp_func_test_runner_<timestamp>_<suffix>/`. Successful runs are removed
+unless `--nocleanup` is supplied. Each preserved test directory contains
+`test_framework.log`, `stdout.log`, `stderr.log`, component logs, and
+`reports/summary.json`.
+
+```bash
+python3 tests/functional/combine_logs.py \
+  /tmp/bp_func_test_runner_.../feature_framework_lifecycle_0
+```

--- a/tests/functional/feature_framework_lifecycle.py
+++ b/tests/functional/feature_framework_lifecycle.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Exercise the base framework lifecycle without requiring external binaries."""
+
+from __future__ import annotations
+
+import argparse
+import random
+import time
+
+from test_framework.network_config import NetworkConfig
+from test_framework.test_framework import BraidpoolTestFramework
+from test_framework.util import assert_equal
+
+
+class FrameworkLifecycleTest(BraidpoolTestFramework):
+    """Validate setup, helpers, reporting, logging, and LIFO cleanup."""
+
+    def add_options(self, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--scenario",
+            choices=("pass", "fail", "setup-fail", "cleanup-error", "hang"),
+            default="pass",
+            help="internal scenario used by the framework self-tests",
+        )
+        parser.add_argument("--expected-token", default="framework-ready")
+
+    def set_test_params(self) -> None:
+        self.config = NetworkConfig(
+            num_braidpool_nodes=0,
+            num_cpu_miners=0,
+            initial_blocks=0,
+            random_seed=1729,
+        )
+
+    def setup_network(self) -> None:
+        """Install deterministic cleanup probes instead of starting binaries."""
+        if self.cleanup_manager is None or self.tmpdir is None:
+            raise AssertionError("Framework managers were not initialized before setup_network()")
+
+        cleanup_path = self.tmpdir / "cleanup_order.txt"
+
+        def record(name: str, *, fail: bool = False) -> None:
+            with cleanup_path.open("a", encoding="utf8") as output:
+                output.write(name + "\n")
+            if fail:
+                raise RuntimeError("intentional cleanup callback failure")
+
+        self.cleanup_manager.register(lambda: record("first"), name="probe:first")
+        cleanup_error = self.options.scenario == "cleanup-error"
+        middle_name = "failing" if cleanup_error else "middle"
+        self.cleanup_manager.register(
+            lambda: record(middle_name, fail=cleanup_error),
+            name=f"probe:{middle_name}",
+        )
+        self.cleanup_manager.register(lambda: record("last"), name="probe:last")
+
+        if self.options.scenario == "setup-fail":
+            raise RuntimeError("intentional setup failure")
+
+    def run_test(self) -> None:
+        if self.options.scenario == "fail":
+            raise AssertionError("intentional test failure")
+        if self.options.scenario == "hang":
+            time.sleep(60)
+            return
+
+        if self.tmpdir is None or self.report is None or self.port_pool is None:
+            raise AssertionError("Base framework handles were not exposed")
+        assert_equal(self.options.expected_token, "framework-ready")
+        assert_equal(self.nodes, [])
+        assert_equal(self.miners, [])
+        assert_equal(self.bitcoin, None)
+        assert_equal(self.port_pool.port_seed, self.options.portseed)
+        assert_equal(self.report.summary_path.exists(), False)
+
+        expected_random = random.Random(self.config.random_seed).random()
+        assert_equal(random.random(), expected_random)
+
+        attempts = 0
+
+        def ready_after_three_attempts() -> bool:
+            nonlocal attempts
+            attempts += 1
+            return attempts == 3
+
+        self.wait_until(ready_after_three_attempts, timeout=1.0, interval=0.001)
+        assert_equal(attempts, 3)
+        self.log.info("Framework lifecycle assertions passed")
+
+
+if __name__ == "__main__":
+    FrameworkLifecycleTest(__file__).main()

--- a/tests/functional/feature_framework_lifecycle.py
+++ b/tests/functional/feature_framework_lifecycle.py
@@ -6,10 +6,21 @@ from __future__ import annotations
 import argparse
 import random
 import time
+from unittest.mock import Mock
 
 from test_framework.network_config import NetworkConfig
 from test_framework.test_framework import BraidpoolTestFramework
 from test_framework.util import assert_equal
+
+
+class SyncAllTimeoutProbe(BraidpoolTestFramework):
+    """Expose ``sync_all`` timeout handling without starting a network."""
+
+    def set_test_params(self) -> None:
+        self.config = NetworkConfig(bead_propagation_timeout=60.0)
+
+    def run_test(self) -> None:
+        """Satisfy the framework subclass contract; this probe is not run."""
 
 
 class FrameworkLifecycleTest(BraidpoolTestFramework):
@@ -85,6 +96,26 @@ class FrameworkLifecycleTest(BraidpoolTestFramework):
 
         self.wait_until(ready_after_three_attempts, timeout=1.0, interval=0.001)
         assert_equal(attempts, 3)
+
+        timeout_probe = SyncAllTimeoutProbe(__file__)
+        timeout_probe.parse_args(["--timeout-factor=2"])
+        timeout_probe.set_test_params()
+        timeout_probe._apply_option_overrides()
+        assert_equal(timeout_probe.config.bead_propagation_timeout, 60.0)
+
+        timeout_probe.node_manager = Mock()
+        sync_all = timeout_probe.node_manager.sync_all
+
+        timeout_probe.sync_all()
+        sync_all.assert_called_once_with(timeout=120.0)
+        sync_all.reset_mock()
+
+        timeout_probe.sync_all(timeout=60.0)
+        sync_all.assert_called_once_with(timeout=120.0)
+        sync_all.reset_mock()
+
+        timeout_probe.sync_all(timeout=timeout_probe.config.bead_propagation_timeout)
+        sync_all.assert_called_once_with(timeout=120.0)
         self.log.info("Framework lifecycle assertions passed")
 
 

--- a/tests/functional/feature_framework_skip.py
+++ b/tests/functional/feature_framework_skip.py
@@ -1,0 +1,28 @@
+#!/usr/bin/env python3
+"""Verify that a base-class functional test can report a clean skip."""
+
+from __future__ import annotations
+
+from test_framework.network_config import NetworkConfig
+from test_framework.test_framework import BraidpoolTestFramework
+
+
+class FrameworkSkipTest(BraidpoolTestFramework):
+    """Exercise exit code 77 and skipped report generation."""
+
+    def set_test_params(self) -> None:
+        self.config = NetworkConfig(
+            num_braidpool_nodes=0,
+            num_cpu_miners=0,
+            initial_blocks=0,
+        )
+
+    def setup_network(self) -> None:
+        """Avoid external binaries; this script only tests skip handling."""
+
+    def run_test(self) -> None:
+        self.skip_test("intentional framework self-test skip")
+
+
+if __name__ == "__main__":
+    FrameworkSkipTest(__file__).main()

--- a/tests/functional/test_framework/cleanup_manager.py
+++ b/tests/functional/test_framework/cleanup_manager.py
@@ -21,9 +21,8 @@ _LOGGER = logging.getLogger(__name__)
 class CleanupManager:
     """Register and run cleanup callbacks for a functional test process.
 
-    Instances install ``atexit``, ``SIGTERM``, and ``SIGINT`` hooks during
-    initialization. Construct this class from the main thread; CPython only
-    allows signal handlers to be installed there.
+    Call :meth:`install_signal_handlers` from the main thread when the manager
+    should own ``atexit``, ``SIGTERM``, and ``SIGINT`` cleanup.
     """
 
     def __init__(
@@ -34,6 +33,7 @@ class CleanupManager:
         self._stack: list[tuple[str, Callable[[], None]]] = []
         self._lock = threading.RLock()
         self._ran = False
+        self._hooks_installed = False
         self._previous_handlers: dict[int, signal.Handlers] = {}
 
     # The cleanup manager is a registrable that is attached to different modules
@@ -66,6 +66,9 @@ class CleanupManager:
                 return
             self._ran = True
             stack = list(self._stack)
+            # Release callback closures and anything they capture as soon as
+            # cleanup completes instead of retaining them until process exit.
+            self._stack.clear()
 
         for name, fn in reversed(stack):
             try:
@@ -84,7 +87,9 @@ class CleanupManager:
                 # Not the main thread, or signal already changed — skip.
                 pass
         self._previous_handlers.clear()
-        atexit.unregister(self.run_all)
+        if self._hooks_installed:
+            atexit.unregister(self.run_all)
+            self._hooks_installed = False
 
     def managed_process(
         self,
@@ -112,18 +117,27 @@ class CleanupManager:
     # terminated due to signals it can gracefully exit after running all the
     # cleanup callbacks.
     def install_signal_handlers(self) -> None:
+        """Install process cleanup hooks exactly once."""
+        if self._hooks_installed:
+            return
         atexit.register(self.run_all)
         for signum in (signal.SIGTERM, signal.SIGINT):
             self._previous_handlers[signum] = signal.getsignal(signum)
             signal.signal(signum, self._signal_handler)
+        self._hooks_installed = True
 
     def _signal_handler(self, signum: int, frame: FrameType | None) -> None:
         log_event(self._logger, "cleanup_signal_received", signal=signum)
-        self.run_all()
-        self._delegate_signal(signum, frame)
-
-    def _delegate_signal(self, signum: int, frame: FrameType | None) -> None:
         previous = self._previous_handlers.get(signum, signal.SIG_DFL)
+        self.run_all()
+        self._delegate_signal(signum, frame, previous)
+
+    def _delegate_signal(
+        self,
+        signum: int,
+        frame: FrameType | None,
+        previous: signal.Handlers,
+    ) -> None:
         if previous == signal.SIG_IGN:
             return
         if callable(previous):

--- a/tests/functional/test_framework/log_manager.py
+++ b/tests/functional/test_framework/log_manager.py
@@ -61,14 +61,9 @@ class LogManager:
 
     def cleanup(self, *, passed: bool, nocleanup: bool = False) -> None:
         """Remove the temp directory on successful tests unless preservation is requested."""
-        if passed and not nocleanup:
-            try:
-                log_event(self.logger, "log_cleanup_started", tmpdir=self.tmpdir)
-                close_logger(self.logger)
-                shutil.rmtree(self.tmpdir)
-            except Exception as exc:
-                self.logger = configure_file_logger(self._logger_name, self.framework_log, level=self._log_level)
-                log_exception(self.logger, "log_cleanup_failed", exc, tmpdir=self.tmpdir)
+        should_remove = passed and not nocleanup
+        if should_remove:
+            log_event(self.logger, "log_cleanup_started", tmpdir=self.tmpdir)
         else:
             log_event(
                 self.logger,
@@ -76,3 +71,15 @@ class LogManager:
                 passed=passed,
                 nocleanup=nocleanup,
             )
+
+        # A preserved test directory does not require an open file descriptor.
+        # Closing here also makes repeated in-process framework tests safe.
+        close_logger(self.logger)
+
+        if should_remove:
+            try:
+                shutil.rmtree(self.tmpdir)
+            except Exception as exc:
+                self.logger = configure_file_logger(self._logger_name, self.framework_log, level=self._log_level)
+                log_exception(self.logger, "log_cleanup_failed", exc, tmpdir=self.tmpdir)
+                close_logger(self.logger)

--- a/tests/functional/test_framework/log_manager.py
+++ b/tests/functional/test_framework/log_manager.py
@@ -16,13 +16,11 @@ class LogManager:
         self,
         tmpdir: Path,
         test_name: str,
-        keep_on_success: bool = False,
         *,
         log_level: str | int = "INFO",
     ) -> None:
         self.tmpdir = Path(tmpdir)
         self.test_name = test_name
-        self.keep_on_success = keep_on_success
         self.tmpdir.mkdir(parents=True, exist_ok=True)
         self.framework_log = self.tmpdir / FRAMEWORK_LOG_NAME
         self.framework_log.touch(exist_ok=True)
@@ -63,7 +61,7 @@ class LogManager:
 
     def cleanup(self, *, passed: bool, nocleanup: bool = False) -> None:
         """Remove the temp directory on successful tests unless preservation is requested."""
-        if passed and not nocleanup and not self.keep_on_success:
+        if passed and not nocleanup:
             try:
                 log_event(self.logger, "log_cleanup_started", tmpdir=self.tmpdir)
                 close_logger(self.logger)
@@ -77,5 +75,4 @@ class LogManager:
                 "log_cleanup_skipped",
                 passed=passed,
                 nocleanup=nocleanup,
-                keep_on_success=self.keep_on_success,
             )

--- a/tests/functional/test_framework/network_config.py
+++ b/tests/functional/test_framework/network_config.py
@@ -39,6 +39,4 @@ class NetworkConfig:
 
     #Logging config
     log_level: str = "INFO"
-    keep_logs_on_success: bool = False
     random_seed: int = 42
-

--- a/tests/functional/test_framework/report_manager.py
+++ b/tests/functional/test_framework/report_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import threading
 import time
 from datetime import datetime, timezone
 from pathlib import Path
@@ -32,6 +33,7 @@ class ReportManager:
         self.total_time_seconds: float | None = None
         self._started_monotonic = time.monotonic()
         self._finalized = False
+        self._finalize_lock = threading.Lock()
 
     @property
     def summary_path(self) -> Path:
@@ -46,25 +48,26 @@ class ReportManager:
             skipped: Whether the test was skipped.  A skipped status takes
                 precedence over ``passed`` when constructing the summary.
         """
-        if self._finalized:
-            return
+        with self._finalize_lock:
+            if self._finalized:
+                return
 
-        self.end_time = datetime.now(tz=timezone.utc)
-        self.total_time_seconds = max(0.0, time.monotonic() - self._started_monotonic)
-        status = "skipped" if skipped else "passed" if passed else "failed"
-        payload: dict[str, Any] = {
-            "test_name": self.test_name,
-            "run_id": self.run_id,
-            "status": status,
-            "start_time": self.start_time.isoformat(timespec="milliseconds"),
-            "end_time": self.end_time.isoformat(timespec="milliseconds"),
-            "total_time_seconds": round(self.total_time_seconds, 6),
-        }
+            self.end_time = datetime.now(tz=timezone.utc)
+            self.total_time_seconds = max(0.0, time.monotonic() - self._started_monotonic)
+            status = "skipped" if skipped else "passed" if passed else "failed"
+            payload: dict[str, Any] = {
+                "test_name": self.test_name,
+                "run_id": self.run_id,
+                "status": status,
+                "start_time": self.start_time.isoformat(timespec="milliseconds"),
+                "end_time": self.end_time.isoformat(timespec="milliseconds"),
+                "total_time_seconds": round(self.total_time_seconds, 6),
+            }
 
-        temporary_path = self.summary_path.with_suffix(".json.tmp")
-        temporary_path.write_text(
-            json.dumps(payload, indent=2, sort_keys=True) + "\n",
-            encoding="utf8",
-        )
-        temporary_path.replace(self.summary_path)
-        self._finalized = True
+            temporary_path = self.summary_path.with_suffix(".json.tmp")
+            temporary_path.write_text(
+                json.dumps(payload, indent=2, sort_keys=True) + "\n",
+                encoding="utf8",
+            )
+            temporary_path.replace(self.summary_path)
+            self._finalized = True

--- a/tests/functional/test_framework/report_manager.py
+++ b/tests/functional/test_framework/report_manager.py
@@ -1,0 +1,70 @@
+"""Timing reports for Braidpool functional test scripts."""
+
+from __future__ import annotations
+
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+class ReportManager:
+    """
+    Record the wall-clock start, end, and total runtime of one test script.
+    """
+
+    SUMMARY_FILE_NAME = "summary.json"
+
+    def __init__(self, test_name: str, run_id: str, reports_dir: Path) -> None:
+        if not test_name:
+            raise ValueError("test_name must not be empty")
+        if not run_id:
+            raise ValueError("run_id must not be empty")
+
+        self.test_name = test_name
+        self.run_id = run_id
+        self.reports_dir = Path(reports_dir)
+        self.reports_dir.mkdir(parents=True, exist_ok=True)
+
+        self.start_time = datetime.now(tz=timezone.utc)
+        self.end_time: datetime | None = None
+        self.total_time_seconds: float | None = None
+        self._started_monotonic = time.monotonic()
+        self._finalized = False
+
+    @property
+    def summary_path(self) -> Path:
+        """Return the path of this test's JSON summary."""
+        return self.reports_dir / self.SUMMARY_FILE_NAME
+
+    def finalize(self, passed: bool, skipped: bool = False) -> None:
+        """Finish timing and write ``summary.json`` exactly once.
+
+        Args:
+            passed: Whether the test completed successfully.
+            skipped: Whether the test was skipped.  A skipped status takes
+                precedence over ``passed`` when constructing the summary.
+        """
+        if self._finalized:
+            return
+
+        self.end_time = datetime.now(tz=timezone.utc)
+        self.total_time_seconds = max(0.0, time.monotonic() - self._started_monotonic)
+        status = "skipped" if skipped else "passed" if passed else "failed"
+        payload: dict[str, Any] = {
+            "test_name": self.test_name,
+            "run_id": self.run_id,
+            "status": status,
+            "start_time": self.start_time.isoformat(timespec="milliseconds"),
+            "end_time": self.end_time.isoformat(timespec="milliseconds"),
+            "total_time_seconds": round(self.total_time_seconds, 6),
+        }
+
+        temporary_path = self.summary_path.with_suffix(".json.tmp")
+        temporary_path.write_text(
+            json.dumps(payload, indent=2, sort_keys=True) + "\n",
+            encoding="utf8",
+        )
+        temporary_path.replace(self.summary_path)
+        self._finalized = True

--- a/tests/functional/test_framework/test_framework.py
+++ b/tests/functional/test_framework/test_framework.py
@@ -1,0 +1,371 @@
+"""Base lifecycle for executable Braidpool functional test scripts."""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import pdb
+import random
+import shutil
+import sys
+import tempfile
+import traceback
+from collections.abc import Callable, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NoReturn
+
+from test_framework.cleanup_manager import CleanupManager
+from test_framework.constants import TEST_EXIT_FAILED, TEST_EXIT_PASSED, TEST_EXIT_SKIPPED
+from test_framework.log_manager import LogManager
+from test_framework.logging_utils import log_event, log_exception
+from test_framework.network_config import NetworkConfig
+from test_framework.node_manager import NodeManager
+from test_framework.port_pool import PortPool, PortSeed
+from test_framework.report_manager import ReportManager
+from test_framework.util import SkipTest, wait_until as framework_wait_until
+
+if TYPE_CHECKING:
+    from test_framework.bitcoin_node import BitcoinNode
+    from test_framework.miner_manager import CpuMiner
+    from test_framework.test_node import TestNode
+
+
+class BraidpoolTestMetaClass(type):
+    """Protect the framework-owned lifecycle from accidental overrides."""
+
+    def __new__(
+        metaclass,
+        name: str,
+        bases: tuple[type, ...],
+        namespace: dict[str, Any],
+        **kwargs: Any,
+    ) -> BraidpoolTestMetaClass:
+        cls = super().__new__(metaclass, name, bases, namespace, **kwargs)
+        is_framework_subclass = any(isinstance(base, BraidpoolTestMetaClass) for base in bases)
+        if not is_framework_subclass:
+            return cls
+
+        forbidden = [method for method in ("__init__", "main") if method in namespace]
+        if forbidden:
+            methods = ", ".join(forbidden)
+            raise TypeError(f"{name} must not override framework lifecycle method(s): {methods}")
+
+        required = [method for method in ("set_test_params", "run_test") if method not in namespace]
+        if required:
+            methods = ", ".join(required)
+            raise TypeError(f"{name} must override required method(s): {methods}")
+        return cls
+
+
+class BraidpoolTestFramework(metaclass=BraidpoolTestMetaClass):
+    """Own setup, execution, reporting, and cleanup for one test script.
+
+    Subclasses only define :meth:`set_test_params` and :meth:`run_test`.
+    Optional script-specific arguments can be registered through
+    :meth:`add_options` without replacing the framework argument parser.
+    """
+
+    def __init__(self, test_file: str | Path) -> None:
+        self.test_file = Path(test_file).resolve()
+        self.test_name = self.test_file.stem
+
+        self.options: argparse.Namespace | None = None
+        self.config = NetworkConfig()
+        self.timeout_factor = 1.0
+        self.tmpdir: Path | None = None
+
+        self.log: logging.Logger = logging.getLogger(f"braidpool.functional.{self.test_name}")
+        self.log_manager: LogManager | None = None
+        self.cleanup_manager: CleanupManager | None = None
+        self.port_pool: PortPool | None = None
+        self.node_manager: NodeManager | None = None
+        self.report: ReportManager | None = None
+
+        self.bitcoin: BitcoinNode | None = None
+        self.nodes: list[TestNode] = []
+        self.miners: list[CpuMiner] = []
+
+    def set_test_params(self) -> None:
+        """Set ``self.config`` to the network required by the test."""
+        raise NotImplementedError
+
+    def run_test(self) -> None:
+        """Execute the test scenario after the configured network is ready."""
+        raise NotImplementedError
+
+    def add_options(self, parser: argparse.ArgumentParser) -> None:
+        """Register optional test-specific command-line arguments."""
+
+    def parse_args(self, argv: Sequence[str] | None = None) -> argparse.Namespace:
+        """Parse framework and subclass command-line arguments."""
+        parser = argparse.ArgumentParser(description=self.__class__.__doc__)
+        parser.add_argument("--tmpdir", type=Path, help="directory for this test's data and reports")
+        parser.add_argument("--cachedir", type=Path, help="shared cache directory reserved for future use")
+        parser.add_argument("--configfile", type=Path, help="runner configuration file")
+        parser.add_argument("--nocleanup", action="store_true", help="preserve the test directory on success")
+        parser.add_argument("--noshutdown", action="store_true", help="leave test processes running for debugging")
+        parser.add_argument("--keep-logs", action="store_true", help="keep logs and reports after a passing test")
+        parser.add_argument("--loglevel", default=None, help="framework log level")
+        parser.add_argument("--tracerpc", action="store_true", help="log RPC request parameters")
+        parser.add_argument("--portseed", type=int, default=0, help="deterministic port range seed")
+        parser.add_argument("--randomseed", type=int, default=None, help="deterministic random seed")
+        parser.add_argument("--timeout-factor", type=float, default=1.0, help="multiply all framework timeouts")
+        parser.add_argument("--pdbonfailure", action="store_true", help="open pdb when the test body fails")
+        parser.add_argument("--braidpool-bin", type=Path, help="path to the braidpool-node binary")
+        parser.add_argument("--bitcoin-bin", type=Path, help="path to the bitcoin-node binary")
+        parser.add_argument("--minerd-bin", type=Path, help="path to the minerd binary")
+        parser.add_argument("--network", choices=("regtest", "cpunet", "signet"))
+        self.add_options(parser)
+        self.options = parser.parse_args(argv)
+
+        if self.options.portseed < 0:
+            parser.error("--portseed must be greater than or equal to zero")
+        if self.options.timeout_factor <= 0:
+            parser.error("--timeout-factor must be greater than zero")
+        return self.options
+
+    def setup(self) -> None:
+        """Create framework managers and start the configured test network."""
+        if self.options is None:
+            raise RuntimeError("parse_args() must be called before setup()")
+        if not isinstance(self.config, NetworkConfig):
+            raise TypeError("set_test_params() must assign a NetworkConfig to self.config")
+
+        self._apply_option_overrides()
+        self._validate_config()
+
+        self._prepare_test_directory()
+        if self.tmpdir is None:
+            raise RuntimeError("Test directory was not initialized")
+
+        keep_on_success = self.options.keep_logs or self.config.keep_logs_on_success
+        self.log_manager = LogManager(
+            self.tmpdir,
+            self.test_name,
+            keep_on_success=keep_on_success,
+            log_level=self.config.log_level,
+        )
+        self.log = self.log_manager.logger
+        log_event(
+            self.log,
+            "test_setup_started",
+            test_name=self.test_name,
+            random_seed=self.config.random_seed,
+            port_seed=self.options.portseed,
+            timeout_factor=self.timeout_factor,
+        )
+
+        random.seed(self.config.random_seed)
+        PortSeed.n = self.options.portseed
+        self.port_pool = PortPool(port_seed=self.options.portseed)
+        self.cleanup_manager = CleanupManager(self.log)
+        self.cleanup_manager.install_signal_handlers()
+        self.node_manager = NodeManager(
+            self.config,
+            self.log_manager,
+            self.cleanup_manager,
+            self.port_pool,
+        )
+
+        try:
+            self.setup_network()
+        finally:
+            self._refresh_process_handles()
+
+        if self.options.tracerpc:
+            self._enable_rpc_tracing()
+        log_event(self.log, "test_setup_finished", test_name=self.test_name)
+
+    def setup_network(self) -> None:
+        """Start Bitcoin, Braidpool nodes, and miners from ``self.config``."""
+        if self.node_manager is None:
+            raise RuntimeError("NodeManager is not initialized")
+        self.node_manager.setup()
+
+    def shutdown(self, status: int = TEST_EXIT_FAILED) -> int:
+        """Stop managed resources, finalize timing, and clean successful runs."""
+        options = self.options
+        no_shutdown = bool(options and options.noshutdown)
+
+        if no_shutdown:
+            if self.cleanup_manager is not None:
+                self.cleanup_manager.disarm()
+            if self.log_manager is not None:
+                log_event(self.log, "test_shutdown_skipped", reason="--noshutdown")
+        else:
+            if self.node_manager is not None:
+                try:
+                    self.node_manager.teardown()
+                except Exception as exc:
+                    status = TEST_EXIT_FAILED
+                    self._log_exception("test_network_teardown_failed", exc)
+            if self.cleanup_manager is not None:
+                try:
+                    self.cleanup_manager.run_all()
+                except Exception as exc:
+                    status = TEST_EXIT_FAILED
+                    self._log_exception("test_cleanup_failed", exc)
+
+        if self.report is not None:
+            try:
+                self.report.finalize(
+                    passed=status == TEST_EXIT_PASSED,
+                    skipped=status == TEST_EXIT_SKIPPED,
+                )
+            except Exception as exc:
+                status = TEST_EXIT_FAILED
+                self._log_exception("test_report_failed", exc)
+
+        if self.log_manager is not None:
+            passed_or_skipped = status in (TEST_EXIT_PASSED, TEST_EXIT_SKIPPED)
+            nocleanup = bool(options and (options.nocleanup or options.noshutdown))
+            self.log_manager.cleanup(passed=passed_or_skipped, nocleanup=nocleanup)
+        elif self.tmpdir is not None:
+            preserve = status == TEST_EXIT_FAILED or bool(
+                options and (options.nocleanup or options.noshutdown or options.keep_logs)
+            )
+            if not preserve:
+                shutil.rmtree(self.tmpdir, ignore_errors=True)
+        return status
+
+    def main(self, argv: Sequence[str] | None = None) -> NoReturn:
+        """Run the complete test lifecycle and exit with the framework status."""
+        status = TEST_EXIT_FAILED
+        try:
+            self.parse_args(argv)
+            # Start the report before subclass code so failures or skips in
+            # set_test_params() still produce the same timing artifact.
+            self._prepare_test_directory()
+            self.set_test_params()
+            self.setup()
+            self.run_test()
+            status = TEST_EXIT_PASSED
+            log_event(self.log, "test_passed", test_name=self.test_name)
+        except SkipTest as exc:
+            status = TEST_EXIT_SKIPPED
+            self._log_event("test_skipped", reason=str(exc))
+            print(f"{self.test_name}: skipped: {exc}", file=sys.stderr)
+        except KeyboardInterrupt as exc:
+            status = TEST_EXIT_FAILED
+            self._log_exception("test_interrupted", exc)
+            print(f"{self.test_name}: interrupted", file=sys.stderr)
+        except Exception as exc:
+            status = TEST_EXIT_FAILED
+            self._log_exception("test_failed", exc)
+            traceback.print_exc()
+            if self.options is not None and self.options.pdbonfailure:
+                pdb.post_mortem(exc.__traceback__)
+        finally:
+            status = self.shutdown(status)
+        raise SystemExit(status)
+
+    def wait_until(
+        self,
+        predicate: Callable[[], bool],
+        *,
+        timeout: float = 60.0,
+        interval: float = 0.05,
+        message: str | None = None,
+    ) -> None:
+        """Poll a predicate using this test's timeout factor."""
+        framework_wait_until(
+            predicate,
+            timeout=timeout,
+            interval=interval,
+            timeout_factor=self.timeout_factor,
+            message=message,
+        )
+
+    def sync_all(self, timeout: float | None = None) -> None:
+        """Wait for all Braidpool nodes to agree on their bead count."""
+        if self.node_manager is None:
+            raise RuntimeError("The test network has not been set up")
+        effective_timeout = (
+            self.config.bead_propagation_timeout
+            if timeout is None
+            else timeout * self.timeout_factor
+        )
+        self.node_manager.sync_all(timeout=effective_timeout)
+
+    @staticmethod
+    def skip_test(reason: str) -> NoReturn:
+        """Skip the current test with an explanatory reason."""
+        raise SkipTest(reason)
+
+    def _apply_option_overrides(self) -> None:
+        if self.options is None:
+            raise RuntimeError("Framework options are unavailable")
+
+        self.timeout_factor = self.options.timeout_factor
+        if self.options.network is not None:
+            self.config.network = self.options.network
+        if self.options.randomseed is not None:
+            self.config.random_seed = self.options.randomseed
+        if self.options.loglevel is not None:
+            self.config.log_level = self.options.loglevel
+        if self.options.braidpool_bin is not None:
+            self.config.braidpool_bin_path = self.options.braidpool_bin
+        if self.options.bitcoin_bin is not None:
+            self.config.bitcoin_bin_path = self.options.bitcoin_bin
+        if self.options.minerd_bin is not None:
+            self.config.minerd_bin_path = self.options.minerd_bin
+
+        for field_name in (
+            "startup_timeout_braidpool",
+            "startup_timeout_btc",
+            "startup_timeout_minerd",
+            "rpc_timeout",
+            "peer_connection_timeout",
+            "bead_propagation_timeout",
+        ):
+            current_value = getattr(self.config, field_name)
+            setattr(self.config, field_name, current_value * self.timeout_factor)
+
+    def _prepare_test_directory(self) -> None:
+        """Create the test directory and begin timing once per lifecycle."""
+        if self.tmpdir is not None:
+            return
+        if self.options is None:
+            raise RuntimeError("Framework options are unavailable")
+
+        if self.options.tmpdir is None:
+            self.tmpdir = Path(tempfile.mkdtemp(prefix=f"bp_func_test_{self.test_name}_"))
+        else:
+            self.tmpdir = self.options.tmpdir.expanduser().resolve()
+            self.tmpdir.mkdir(parents=True, exist_ok=True)
+
+        run_id = f"{self.test_name}-{self.tmpdir.name}"
+        self.report = ReportManager(self.test_name, run_id, self.tmpdir / "reports")
+
+    def _validate_config(self) -> None:
+        if self.config.num_braidpool_nodes < 0:
+            raise ValueError("num_braidpool_nodes must be greater than or equal to zero")
+        if self.config.num_cpu_miners < 0:
+            raise ValueError("num_cpu_miners must be greater than or equal to zero")
+        if self.config.num_cpu_miners and not self.config.num_braidpool_nodes:
+            raise ValueError("num_cpu_miners requires at least one Braidpool node")
+        if self.config.network not in ("regtest", "cpunet", "signet"):
+            raise ValueError(f"Unsupported network: {self.config.network!r}")
+
+    def _refresh_process_handles(self) -> None:
+        if self.node_manager is None:
+            return
+        self.bitcoin = self.node_manager.bitcoin
+        self.nodes = self.node_manager.nodes
+        self.miners = self.node_manager.miners
+
+    def _enable_rpc_tracing(self) -> None:
+        rpc_clients = []
+        if self.bitcoin is not None:
+            rpc_clients.append(self.bitcoin.rpc)
+        rpc_clients.extend(node.rpc for node in self.nodes)
+        for rpc_client in rpc_clients:
+            rpc_client.trace = True
+
+    def _log_event(self, event: str, **fields: Any) -> None:
+        if self.log_manager is not None:
+            log_event(self.log, event, test_name=self.test_name, **fields)
+
+    def _log_exception(self, event: str, exc: BaseException) -> None:
+        if self.log_manager is not None:
+            log_exception(self.log, event, exc, test_name=self.test_name)

--- a/tests/functional/test_framework/test_framework.py
+++ b/tests/functional/test_framework/test_framework.py
@@ -264,14 +264,17 @@ class BraidpoolTestFramework(metaclass=BraidpoolTestMetaClass):
         )
 
     def sync_all(self, timeout: float | None = None) -> None:
-        """Wait for all Braidpool nodes to agree on their bead count."""
+        """Wait for all Braidpool nodes to agree on their bead count.
+
+        ``timeout`` and the configured default are expressed before applying
+        this test's timeout factor.
+        """
         if self.node_manager is None:
             raise RuntimeError("The test network has not been set up")
-        effective_timeout = (
-            self.config.bead_propagation_timeout
-            if timeout is None
-            else timeout * self.timeout_factor
+        base_timeout = (
+            self.config.bead_propagation_timeout if timeout is None else timeout
         )
+        effective_timeout = base_timeout * self.timeout_factor
         self.node_manager.sync_all(timeout=effective_timeout)
 
     @staticmethod
@@ -297,13 +300,14 @@ class BraidpoolTestFramework(metaclass=BraidpoolTestMetaClass):
         if self.options.minerd_bin is not None:
             self.config.minerd_bin_path = self.options.minerd_bin
 
+        # sync_all() scales bead_propagation_timeout after choosing between
+        # the configured default and a caller-provided timeout.
         for field_name in (
             "startup_timeout_braidpool",
             "startup_timeout_btc",
             "startup_timeout_minerd",
             "rpc_timeout",
             "peer_connection_timeout",
-            "bead_propagation_timeout",
         ):
             current_value = getattr(self.config, field_name)
             setattr(self.config, field_name, current_value * self.timeout_factor)

--- a/tests/functional/test_framework/test_framework.py
+++ b/tests/functional/test_framework/test_framework.py
@@ -103,8 +103,6 @@ class BraidpoolTestFramework(metaclass=BraidpoolTestMetaClass):
         parser.add_argument("--cachedir", type=Path, help="shared cache directory reserved for future use")
         parser.add_argument("--configfile", type=Path, help="runner configuration file")
         parser.add_argument("--nocleanup", action="store_true", help="preserve the test directory on success")
-        parser.add_argument("--noshutdown", action="store_true", help="leave test processes running for debugging")
-        parser.add_argument("--keep-logs", action="store_true", help="keep logs and reports after a passing test")
         parser.add_argument("--loglevel", default=None, help="framework log level")
         parser.add_argument("--tracerpc", action="store_true", help="log RPC request parameters")
         parser.add_argument("--portseed", type=int, default=0, help="deterministic port range seed")
@@ -138,11 +136,9 @@ class BraidpoolTestFramework(metaclass=BraidpoolTestMetaClass):
         if self.tmpdir is None:
             raise RuntimeError("Test directory was not initialized")
 
-        keep_on_success = self.options.keep_logs or self.config.keep_logs_on_success
         self.log_manager = LogManager(
             self.tmpdir,
             self.test_name,
-            keep_on_success=keep_on_success,
             log_level=self.config.log_level,
         )
         self.log = self.log_manager.logger
@@ -185,26 +181,19 @@ class BraidpoolTestFramework(metaclass=BraidpoolTestMetaClass):
     def shutdown(self, status: int = TEST_EXIT_FAILED) -> int:
         """Stop managed resources, finalize timing, and clean successful runs."""
         options = self.options
-        no_shutdown = bool(options and options.noshutdown)
 
-        if no_shutdown:
-            if self.cleanup_manager is not None:
-                self.cleanup_manager.disarm()
-            if self.log_manager is not None:
-                log_event(self.log, "test_shutdown_skipped", reason="--noshutdown")
-        else:
-            if self.node_manager is not None:
-                try:
-                    self.node_manager.teardown()
-                except Exception as exc:
-                    status = TEST_EXIT_FAILED
-                    self._log_exception("test_network_teardown_failed", exc)
-            if self.cleanup_manager is not None:
-                try:
-                    self.cleanup_manager.run_all()
-                except Exception as exc:
-                    status = TEST_EXIT_FAILED
-                    self._log_exception("test_cleanup_failed", exc)
+        if self.node_manager is not None:
+            try:
+                self.node_manager.teardown()
+            except Exception as exc:
+                status = TEST_EXIT_FAILED
+                self._log_exception("test_network_teardown_failed", exc)
+        if self.cleanup_manager is not None:
+            try:
+                self.cleanup_manager.run_all()
+            except Exception as exc:
+                status = TEST_EXIT_FAILED
+                self._log_exception("test_cleanup_failed", exc)
 
         if self.report is not None:
             try:
@@ -218,12 +207,10 @@ class BraidpoolTestFramework(metaclass=BraidpoolTestMetaClass):
 
         if self.log_manager is not None:
             passed_or_skipped = status in (TEST_EXIT_PASSED, TEST_EXIT_SKIPPED)
-            nocleanup = bool(options and (options.nocleanup or options.noshutdown))
+            nocleanup = bool(options and options.nocleanup)
             self.log_manager.cleanup(passed=passed_or_skipped, nocleanup=nocleanup)
         elif self.tmpdir is not None:
-            preserve = status == TEST_EXIT_FAILED or bool(
-                options and (options.nocleanup or options.noshutdown or options.keep_logs)
-            )
+            preserve = status == TEST_EXIT_FAILED or bool(options and options.nocleanup)
             if not preserve:
                 shutil.rmtree(self.tmpdir, ignore_errors=True)
         return status

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -22,12 +22,15 @@ from typing import Sequence
 from test_framework.cleanup_manager import terminate_process_group
 from test_framework.constants import STDERR_LOG_NAME, STDOUT_LOG_NAME, TEST_EXIT_PASSED, TEST_EXIT_SKIPPED
 from test_framework.logging_utils import configure_stream_logger, log_duration, log_event, log_exception
+from test_framework.report_manager import ReportManager
 
 
 logger = logging.getLogger(__name__)
 
 # Set of test scripts to run, in order. Extended tests are optional.
 BASE_SCRIPTS = [
+    "feature_framework_lifecycle.py",
+    "feature_framework_skip.py",
 ]
 
 EXTENDED_SCRIPTS: list[str] = []
@@ -81,6 +84,8 @@ class RunningJob:
     testdir: Path
     stdout_path: Path
     stderr_path: Path
+    #if the test fails, we want to make sure we have a summary.json file for it, so we can use this fallback report manager to finalize it if needed
+    fallback_report: ReportManager | None = None 
     timed_out: bool = False
 
     @property
@@ -111,6 +116,12 @@ class RunningJob:
             status = "Skipped"
         else:
             status = "Failed"
+        if (
+            status == "Failed"
+            and self.fallback_report is not None
+            and not self.fallback_report.summary_path.exists()
+        ):
+            self.fallback_report.finalize(passed=False)
         return TestResult(
             name=self.name,
             status=status,
@@ -172,10 +183,9 @@ class TestHandler:
                     self.running.remove(job)
                     finished.append(job.to_result())
 
-            self._fill_available_slots()
-
             if finished:
                 return finished
+            self._fill_available_slots()
             if self.done():
                 return []
             time.sleep(0.1)
@@ -202,6 +212,11 @@ class TestHandler:
         testdir.mkdir(parents=True, exist_ok=True)
         stdout_path = testdir / STDOUT_LOG_NAME
         stderr_path = testdir / STDERR_LOG_NAME
+        fallback_report = ReportManager(
+            test_base,
+            f"{test_base}-{testdir.name}",
+            testdir / "reports",
+        )
         args = [
             sys.executable,
             str(self.tests_dir / script_name),
@@ -248,6 +263,7 @@ class TestHandler:
                 testdir=testdir,
                 stdout_path=stdout_path,
                 stderr_path=stderr_path,
+                fallback_report=fallback_report,
             )
         )
         log_event(logger, "runner_test_started", test=scheduled.display_name, pid=proc.pid, port_seed=scheduled.port_seed)

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -307,8 +307,6 @@ def schedule_tests(test_list: list[str]) -> list[ScheduledTest]:
     return scheduled
 
 
-
-
 # Read last N lines of a file efficiently without loading the whole file, used for printing combined logs on failure with a specified line limit.
 def tail_file(path: Path, lines: int) -> str:
     """Return the last *lines* lines without loading the whole file."""

--- a/tests/functional/test_runner.py
+++ b/tests/functional/test_runner.py
@@ -17,10 +17,16 @@ import tempfile
 import time
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Sequence
+from typing import Iterator, Sequence
 
 from test_framework.cleanup_manager import terminate_process_group
-from test_framework.constants import STDERR_LOG_NAME, STDOUT_LOG_NAME, TEST_EXIT_PASSED, TEST_EXIT_SKIPPED
+from test_framework.constants import (
+    LOG_NAMES,
+    STDERR_LOG_NAME,
+    STDOUT_LOG_NAME,
+    TEST_EXIT_PASSED,
+    TEST_EXIT_SKIPPED,
+)
 from test_framework.logging_utils import configure_stream_logger, log_duration, log_event, log_exception
 from test_framework.report_manager import ReportManager
 
@@ -84,8 +90,8 @@ class RunningJob:
     testdir: Path
     stdout_path: Path
     stderr_path: Path
-    #if the test fails, we want to make sure we have a summary.json file for it, so we can use this fallback report manager to finalize it if needed
-    fallback_report: ReportManager | None = None 
+    # If the test fails, ensure we still emit reports/summary.json by finalizing a fallback ReportManager when needed.
+    fallback_report: ReportManager | None = None
     timed_out: bool = False
 
     @property
@@ -331,6 +337,29 @@ def tail_file(path: Path, lines: int) -> str:
     return "\n".join(data.decode("utf8", errors="replace").splitlines()[-lines:])
 
 
+def iter_combined_logs(result: TestResult) -> Iterator[tuple[str, Path]]:
+    """Yield framework, test, and component log files for a test result."""
+    seen: set[Path] = set()
+    for log_name in LOG_NAMES:
+        path = result.testdir / log_name
+        if path.exists():
+            seen.add(path)
+            yield log_name, path
+
+    for path in sorted(result.testdir.rglob("*")):
+        if not path.is_file() or path.name not in LOG_NAMES or path in seen:
+            continue
+        yield path.relative_to(result.testdir).as_posix(), path
+
+
+def print_combined_log_tails(result: TestResult, lines: int) -> None:
+    """Print the tail of each relevant log file for a failed test."""
+    for label, path in iter_combined_logs(result):
+        tail = tail_file(path, lines)
+        if tail:
+            print(f"\n{label} tail:\n" + tail)
+
+
 def print_results(results: list[TestResult], runtime: float) -> None:
     max_name = max(len(result.name) for result in results) if results else 4
     print("\n{} | STATUS  | DURATION".format("TEST".ljust(max_name)))
@@ -421,12 +450,7 @@ def main() -> int:
                     all_passed = False
                     print(f"\n{result.name} failed after {result.duration:.3f}s")
                     if args.combinedlogslen:
-                        stdout_tail = tail_file(result.stdout_path, args.combinedlogslen)
-                        stderr_tail = tail_file(result.stderr_path, args.combinedlogslen)
-                        if stdout_tail:
-                            print("\nstdout tail:\n" + stdout_tail)
-                        if stderr_tail:
-                            print("\nstderr tail:\n" + stderr_tail)
+                        print_combined_log_tails(result, args.combinedlogslen)
     except KeyboardInterrupt:
         all_passed = False
         log_event(logger, "runner_interrupted", level=logging.WARNING)


### PR DESCRIPTION
This PR is the final PR for the test framework as described in #463 and implements the Report manager and the base class for writing the tests.

It follows PR #468, #476, and #491.

It implements two main files:
1) test_framework.py: The base class that all the other tests inherit to avoid rewriting code
2) report_manager.py: Creates a summarised report for all the tests and their timings.

Detailed instructions for running the tests and writing the tests are added in tests/functional/docs.