### PR TITLE
feat(stratum): log per-miner notify delivery latency and queue depth

### DIFF
--- a/node/src/lib.rs
+++ b/node/src/lib.rs
@@ -5,7 +5,7 @@ use bitcoin::{
     CompactTarget, EcdsaSighashType, Txid,
 };
 use num::ToPrimitive;
-use std::{collections::HashMap, str::FromStr, sync::Arc, time::UNIX_EPOCH};
+use std::{collections::HashMap, str::FromStr, sync::Arc, time::Instant, time::UNIX_EPOCH};
 
 use futures::lock::Mutex;
 use tokio::sync::mpsc::{self, Receiver, Sender};
@@ -217,32 +217,37 @@ pub async fn ipc_template_consumer(
                 ..Default::default()
             };
 
-            let mut latest_template = latest_template_arc.lock().await;
-            latest_template.version = template.version;
-            latest_template.rules = template.rules.clone();
-            latest_template.vbavailable = template.vbavailable.clone();
-            latest_template.vbrequired = template.vbrequired;
-            latest_template.previousblockhash = template.previousblockhash.clone();
-            latest_template.transactions = template.transactions.clone();
-            latest_template.coinbaseaux = template.coinbaseaux.clone();
-            latest_template.coinbasevalue = template.coinbasevalue;
-            latest_template.longpollid = template.longpollid.clone();
-            latest_template.target = template.target.clone();
-            latest_template.mintime = template.mintime;
-            latest_template.mutable = template.mutable.clone();
-            latest_template.noncerange = template.noncerange.clone();
-            latest_template.sigoplimit = template.sigoplimit;
-            latest_template.sizelimit = template.sizelimit;
-            latest_template.weightlimit = template.weightlimit;
-            latest_template.curtime = template.curtime;
-            latest_template.bits = template.bits;
-            latest_template.height = template.height;
-            latest_template.default_witness_commitment =
-                template.default_witness_commitment.clone();
-            let mut latest_template_merkle_branch = latest_template_merkle_branch_arc.lock().await;
-            latest_template_merkle_branch.clear();
-            for branch in merkle_branch_coinbase.iter() {
-                latest_template_merkle_branch.push(branch.clone());
+            {
+                let mut latest_template = latest_template_arc.lock().await;
+                latest_template.version = template.version;
+                latest_template.rules = template.rules.clone();
+                latest_template.vbavailable = template.vbavailable.clone();
+                latest_template.vbrequired = template.vbrequired;
+                latest_template.previousblockhash = template.previousblockhash.clone();
+                latest_template.transactions = template.transactions.clone();
+                latest_template.coinbaseaux = template.coinbaseaux.clone();
+                latest_template.coinbasevalue = template.coinbasevalue;
+                latest_template.longpollid = template.longpollid.clone();
+                latest_template.target = template.target.clone();
+                latest_template.mintime = template.mintime;
+                latest_template.mutable = template.mutable.clone();
+                latest_template.noncerange = template.noncerange.clone();
+                latest_template.sigoplimit = template.sigoplimit;
+                latest_template.sizelimit = template.sizelimit;
+                latest_template.weightlimit = template.weightlimit;
+                latest_template.curtime = template.curtime;
+                latest_template.bits = template.bits;
+                latest_template.height = template.height;
+                latest_template.default_witness_commitment =
+                    template.default_witness_commitment.clone();
+            }
+            {
+                let mut latest_template_merkle_branch =
+                    latest_template_merkle_branch_arc.lock().await;
+                latest_template_merkle_branch.clear();
+                for branch in merkle_branch_coinbase.iter() {
+                    latest_template_merkle_branch.push(branch.clone());
+                }
             }
             info!(
                 template_id = %template_id,
@@ -250,11 +255,17 @@ pub async fn ipc_template_consumer(
                 "New block template"
             );
 
+            // Capture after both guards have dropped — this is the moment the template
+            // is ready to broadcast. Threaded into SendToAll so the notifier can measure
+            // per-miner delivery latency against this reference point.
+            let template_ready_at = Instant::now();
+
             let notification_sent_or_not = notifier_tx
                 .send(NotifyCmd::SendToAll {
                     template: template,
                     merkle_branch_coinbase,
                     template_id: template_id.clone(),
+                    template_ready_at,
                 })
                 .await;
             match notification_sent_or_not {

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -30,6 +30,9 @@ use tokio_util::codec::{FramedRead, LinesCodec};
 use tracing::{debug, error, info, trace, warn};
 
 pub const DISCONNECT_SIGNAL: &str = "!!!_INTERNAL_DISCONNECT_SIGNAL_!!!";
+/// Bounded capacity of each miner's outbound channel.
+/// Referenced at both channel-creation and queue-depth calculation sites so they stay in sync.
+const DOWNSTREAM_CHANNEL_CAPACITY: usize = 1024;
 const PREFIX_EXHAUSTION_WARNING_THRESHOLD: u16 = 60000;
 const PREFIX_MAX_VALUE: u16 = u16::MAX; // Maximum prefix value in audit mode
 const PREFIX_BYTES_SIZE: usize = 2; // Size of prefix in bytes
@@ -1939,6 +1942,7 @@ pub enum NotifyCmd {
         template: BlockTemplate,
         merkle_branch_coinbase: Vec<Vec<u8>>,
         template_id: TemplateId,
+        template_ready_at: std::time::Instant,
     },
     SendLatestTemplateToNewDownstream {
         new_downstream_addr: String,
@@ -2444,6 +2448,7 @@ impl Notifier {
                     template,
                     merkle_branch_coinbase,
                     template_id,
+                    template_ready_at,
                 } => {
                     debug!(
                         template_id = %template_id,
@@ -2556,6 +2561,16 @@ impl Notifier {
                                     continue;
                                 }
                             };
+                        let latency_us = template_ready_at.elapsed().as_micros();
+                        let queue_depth =
+                            DOWNSTREAM_CHANNEL_CAPACITY - connection_info.sender.capacity();
+                        debug!(
+                            connection_id = %connection_id_hex,
+                            peer = %peer_adr,
+                            latency_us = %latency_us,
+                            queue_depth = %queue_depth,
+                            "job_dispatch"
+                        );
                         if let Err(e) = connection_info.sender.send(job_notification_json).await {
                             error!(
                                 connection_id = %connection_id_hex,
@@ -3586,7 +3601,7 @@ impl Server {
                          //Adding the downstream mining map to global mapper
                          mining_job_map.lock().await.insert(peer_addr.to_string(), self_mining_map.clone());
                          //downstream channel for server2client communication to take place
-                         let (downstream_tx,mut downstream_rx) = mpsc::channel(1024);
+                         let (downstream_tx,mut downstream_rx) = mpsc::channel(DOWNSTREAM_CHANNEL_CAPACITY);
                          let (control_tx, control_rx) = mpsc::channel(10);
                          //adding the new connection to the connection map
                          self.downstream_connection_mapping
@@ -3832,7 +3847,7 @@ impl Server {
 #[cfg(test)]
 //Unit tests specific to stratum service
 mod test {
-    use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration};
+    use std::{collections::HashMap, str::FromStr, sync::Arc, time::Duration, time::Instant};
 
     use super::*;
     use crate::{
@@ -4669,5 +4684,33 @@ mod test {
         assert_eq!(client1.extranonce1.len(), UPSTREAM_EXTRANONCE1_SIZE);
         assert_eq!(client2.extranonce1.len(), UPSTREAM_EXTRANONCE1_SIZE);
         assert_eq!(client3.extranonce1.len(), UPSTREAM_EXTRANONCE1_SIZE);
+    }
+
+    /// `template_ready_at` must survive the `NotifyCmd` channel hop unchanged — if it were
+    /// re-captured after receipt instead of passed through, latency measurements would
+    /// silently exclude time spent queued in the channel.
+    #[tokio::test]
+    async fn template_ready_at_survives_channel_hop() {
+        let (tx, mut rx) = tokio::sync::mpsc::channel::<NotifyCmd>(1);
+        let sent_at = Instant::now();
+        tx.send(NotifyCmd::SendToAll {
+            template: BlockTemplate::default(),
+            merkle_branch_coinbase: vec![],
+            template_id: TemplateId::default(),
+            template_ready_at: sent_at,
+        })
+        .await
+        .unwrap();
+
+        let NotifyCmd::SendToAll {
+            template_ready_at, ..
+        } = rx.recv().await.unwrap()
+        else {
+            panic!("unexpected variant");
+        };
+        assert_eq!(
+            template_ready_at, sent_at,
+            "instant must not be re-derived after the channel hop"
+        );
     }
 }


### PR DESCRIPTION
When a new block template arrives, the node sends a personalized `mining.notify` message to every connected miner, one at a time. Today there's no way to see how long that takes for any given miner, or whether a miner is falling behind. If one miner's connection is slow, we currently only find out after the fact,  when their outbound message queue is already full and notifications start getting silently dropped.

what this pr does: 

Timestamp the moment a template is ready to broadcast, and carry that timestamp through to each miner's send. Right before sending, log two things per miner:
- `latency_us`:     how long it took from "template ready" to "sent to this miner"
- `queue_depth` :    how full this miner's outbound message queue is right now

The queue depth is the useful early-warning signal: a miner's queue fills up gradually before it overflows, so watching it rise gives us a chance to notice a struggling miner before their notifications actually start getting dropped, rather than only finding out afterward.