### PR TITLE
feat(rpc): integrate tower and tower-http for improved middleware support; refactor transaction fetching logic

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,5 +52,7 @@ strum = { version = "0.26", features = ["derive"] }
 if-addrs = "0.13"
 anyhow = "1.0.100"
 reqwest = { version = "0.11", features = ["json"] }
+tower = "0.5"
+tower-http = { version = "0.6", features = ["cors"] }
 
 

--- a/braidpool-cli/src/main.rs
+++ b/braidpool-cli/src/main.rs
@@ -137,9 +137,7 @@ enum Commands {
 
     /// Look up which of the 6 confirmation stages a given txid is currently in
     #[command(name = "gettransactionstatus")]
-    GetTransactionStatus {
-        txid: String,
-    },
+    GetTransactionStatus { txid: String },
 
     /// List txids committed across all beads, paginated (newest-first)
     #[command(name = "getcommittedtransactions")]

--- a/braidpool-cli/src/main.rs
+++ b/braidpool-cli/src/main.rs
@@ -128,6 +128,28 @@ enum Commands {
         tx_id: String,
     },
 
+    /// Get the most recent mempool entries from Bitcoin Core, sorted newest-first
+    #[command(name = "getmempoolentries")]
+    GetMempoolEntries {
+        #[arg(default_value_t = 20)]
+        limit: u32,
+    },
+
+    /// Look up which of the 6 confirmation stages a given txid is currently in
+    #[command(name = "gettransactionstatus")]
+    GetTransactionStatus {
+        txid: String,
+    },
+
+    /// List txids committed across all beads, paginated (newest-first)
+    #[command(name = "getcommittedtransactions")]
+    GetCommittedTransactions {
+        #[arg(default_value_t = 0)]
+        page: u32,
+        #[arg(default_value_t = 50)]
+        page_size: u32,
+    },
+
     /// Proxy a Bitcoin RPC call to bitcoind
     /// Example: braidpool-cli bitcoin getblockchaininfo
     #[command(name = "bitcoin")]
@@ -320,6 +342,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Commands::GetPeerInfo => ("getpeerinfo", json!([])),
         Commands::StagedTransactions => ("stagedtransactions", json!([])),
         Commands::UnstageTransactions { tx_id } => ("unstagetransactions", json!([tx_id])),
+        Commands::GetMempoolEntries { limit } => ("getmempoolentries", json!([limit])),
+        Commands::GetTransactionStatus { txid } => ("gettransactionstatus", json!([txid])),
+        Commands::GetCommittedTransactions { page, page_size } => {
+            ("getcommittedtransactions", json!([page, page_size]))
+        }
         Commands::Bitcoin { method, params } => {
             let params_value: serde_json::Value =
                 serde_json::from_str(params).unwrap_or_else(|_| json!([]));

--- a/dashboard/src/URLs.ts
+++ b/dashboard/src/URLs.ts
@@ -20,8 +20,8 @@ export const API_URLS = {
   // API endpoints (mempool api backend for now)
   BRAIDPOOL_API_BASE: 'http://localhost:8999/api/v1',
 
-  // Bitcoin mempool API endpoints (blockstream)
-  MEMPOOL_API_BASE: 'http://localhost:3002',
+  // Braidpool node JSON-RPC 2.0 endpoint 
+  BRAIDPOOL_NODE_RPC: 'http://localhost:6682',
   // Miner Device Api endpoints
   MINER_DEVICE_URL: 'http://localhost:5001',
 } as const;
@@ -33,14 +33,7 @@ export const getBraidPoolBlockUrl = (hash: string): string =>
 export const getBraidPoolBlocksUrl = (): string =>
   `${API_URLS.BRAIDPOOL_API_BASE}/blocks`;
 
-export const getBraidPoolReplacementsUrl = (): string =>
-  `${API_URLS.BRAIDPOOL_API_BASE}/replacements`;
-
-export const getMempoolRecentUrl = (): string =>
-  `${API_URLS.MEMPOOL_API_BASE}/mempool/recent`;
-
-export const getMempoolTransactionUrl = (txid: string): string =>
-  `${API_URLS.MEMPOOL_API_BASE}/tx/${txid}`;
+export const getBraidpoolNodeRpcUrl = (): string => API_URLS.BRAIDPOOL_NODE_RPC;
 
 export const EXTERNAL_LINKS = {
   // Project Info

--- a/dashboard/src/URLs.ts
+++ b/dashboard/src/URLs.ts
@@ -20,7 +20,7 @@ export const API_URLS = {
   // API endpoints (mempool api backend for now)
   BRAIDPOOL_API_BASE: 'http://localhost:8999/api/v1',
 
-  // Braidpool node JSON-RPC 2.0 endpoint 
+  // Braidpool node JSON-RPC 2.0 endpoint
   BRAIDPOOL_NODE_RPC: 'http://localhost:6682',
   // Miner Device Api endpoints
   MINER_DEVICE_URL: 'http://localhost:5001',

--- a/dashboard/src/components/BitcoinStats/Prices.tsx
+++ b/dashboard/src/components/BitcoinStats/Prices.tsx
@@ -75,7 +75,9 @@ const BitcoinPriceTracker: React.FC = () => {
         const data = await getLatestTransactions();
         setTransactions(data as any[]);
       } catch {
-        console.warn('[TransactionTable] Failed to fetch transactions; node may be unreachable');
+        console.warn(
+          '[TransactionTable] Failed to fetch transactions; node may be unreachable'
+        );
       }
     };
     fetchTransactions();

--- a/dashboard/src/components/BitcoinStats/Prices.tsx
+++ b/dashboard/src/components/BitcoinStats/Prices.tsx
@@ -71,13 +71,21 @@ const BitcoinPriceTracker: React.FC = () => {
 
   useEffect(() => {
     const fetchTransactions = async () => {
-      const data = await getLatestTransactions();
-      setTransactions(data as any[]);
+      try {
+        const data = await getLatestTransactions();
+        setTransactions(data as any[]);
+      } catch {
+        console.warn('[TransactionTable] Failed to fetch transactions; node may be unreachable');
+      }
     };
     fetchTransactions();
     const fetchRbfTransactions = async () => {
-      const data = await latestRBFTransactions();
-      setrbfTransactions(data as any[]);
+      try {
+        const data = await latestRBFTransactions();
+        setrbfTransactions(data as any[]);
+      } catch {
+        console.warn('[RBFTable] Failed to fetch RBF transactions');
+      }
     };
     fetchRbfTransactions();
     const intervalId = setInterval(() => {

--- a/dashboard/src/components/BitcoinStats/RBFTransactionRow.tsx
+++ b/dashboard/src/components/BitcoinStats/RBFTransactionRow.tsx
@@ -13,7 +13,7 @@ export const RBFTransactionRow: React.FC<RBFTransactionRowProps> = ({
   const txData = tx.tx;
   const indent = depth * 20;
   const isExpanded = expandedTxs.has(txData.txid);
-  const hasReplacements = tx.replaces && tx.replaces.length > 0;
+  const hasReplacements = tx.replaces != null && tx.replaces.length > 0;
 
   return (
     <>
@@ -53,8 +53,7 @@ export const RBFTransactionRow: React.FC<RBFTransactionRowProps> = ({
       </tr>
 
       {isExpanded &&
-        tx.replaces &&
-        tx.replaces.map((replacedTx, idx) => (
+        tx.replaces?.map((replacedTx, idx) => (
           <RBFTransactionRow
             isReplacement={true}
             key={replacedTx.tx.txid + idx}

--- a/dashboard/src/components/BitcoinStats/RBFTransactionTable.tsx
+++ b/dashboard/src/components/BitcoinStats/RBFTransactionTable.tsx
@@ -27,7 +27,7 @@ const RBFTransactionTable: React.FC<TransactionTableProps> = ({
       className="rounded-2xl border mt-10 border-white/10 bg-[#1e1e1e] shadow-md p-4"
       style={{ borderColor: colors.cardAccentSecondary }}
     >
-      <div className="mb-2  text-gray-400">Latest RBF Transactions</div>
+      <div className="mb-2 text-gray-400">Latest RBF Transactions</div>
       <div
         className="overflow-auto rounded-md scrollbar-thin"
         style={{

--- a/dashboard/src/components/BitcoinStats/TransactionDialog.tsx
+++ b/dashboard/src/components/BitcoinStats/TransactionDialog.tsx
@@ -57,6 +57,9 @@ const TransactionDialog = ({
           {error && (
             <div className="text-red-500 py-8 text-center">{error}</div>
           )}
+          {!loading && !error && !txInfo && (
+            <div className="text-gray-400 text-center py-8">Transaction not found</div>
+          )}
 
           {txInfo && (
             <>
@@ -89,44 +92,60 @@ const TransactionDialog = ({
                       Status
                     </h3>
                     <p className="text-sm mt-1">
-                      {txInfo.status.confirmed ? 'Confirmed' : 'Unconfirmed'}
+                      {txInfo.stage
+                        ? txInfo.stage.charAt(0).toUpperCase() + txInfo.stage.slice(1)
+                        : txInfo.status?.confirmed ? 'Confirmed' : 'Unconfirmed'}
                     </p>
                   </div>
                   <div>
                     <h3 className="text-sm font-medium text-gray-400">Fee</h3>
-                    <p className="text-sm mt-1">{txInfo.fee / 100000000} BTC</p>
+                    <p className="text-sm mt-1">
+                      {txInfo.fee != null ? `${txInfo.fee / 100000000} BTC` : 'N/A'}
+                    </p>
                   </div>
                   <div>
                     <h3 className="text-sm font-medium text-gray-400">Size</h3>
-                    <p className="text-sm mt-1">{txInfo.size} bytes</p>
+                    <p className="text-sm mt-1">
+                      {txInfo.size != null ? `${txInfo.size} bytes` : 'N/A'}
+                    </p>
                   </div>
                   <div>
                     <h3 className="text-sm font-medium text-gray-400">
                       Weight
                     </h3>
-                    <p className="text-sm mt-1">{txInfo.weight} WU</p>
+                    <p className="text-sm mt-1">
+                      {txInfo.weight != null ? `${txInfo.weight} WU` : 'N/A'}
+                    </p>
                   </div>
                   <div>
                     <h3 className="text-sm font-medium text-gray-400">
                       Version
                     </h3>
-                    <p className="text-sm mt-1">{txInfo.version}</p>
+                    <p className="text-sm mt-1">{txInfo.version ?? 'N/A'}</p>
                   </div>
                   <div>
                     <h3 className="text-sm font-medium text-gray-400">
                       Locktime
                     </h3>
-                    <p className="text-sm mt-1">{txInfo.locktime}</p>
+                    <p className="text-sm mt-1">{txInfo.locktime ?? 'N/A'}</p>
                   </div>
+                  {txInfo.bead_hash && (
+                    <div className="col-span-2">
+                      <h3 className="text-sm font-medium text-gray-400">
+                        Bead Hash
+                      </h3>
+                      <p className="text-xs break-all mt-1">{txInfo.bead_hash}</p>
+                    </div>
+                  )}
                 </div>
               </div>
 
               <div className="pt-6 border-t border-gray-700">
                 <h3 className="font-medium text-gray-400 mb-2">
-                  Inputs ({txInfo.vin.length})
+                  Inputs ({txInfo.vin?.length ?? 0})
                 </h3>
                 <div className="space-y-3">
-                  {txInfo.vin.map((input: any, index: number) => (
+                  {txInfo.vin?.length > 0 ? txInfo.vin.map((input: any, index: number) => (
                     <div key={index} className="bg-[#2a2a2a] rounded p-3">
                       <p className="text-xs break-all">
                         <span className="font-medium">From:</span>{' '}
@@ -139,16 +158,18 @@ const TransactionDialog = ({
                           : 'N/A'}
                       </p>
                     </div>
-                  ))}
+                  )) : (
+                    <p className="text-xs text-gray-500">Not available without Bitcoin Core connection</p>
+                  )}
                 </div>
               </div>
 
               <div className="pt-6 border-t border-gray-700">
                 <h3 className="font-medium text-gray-400 mb-2">
-                  Outputs ({txInfo.vout.length})
+                  Outputs ({txInfo.vout?.length ?? 0})
                 </h3>
                 <div className="space-y-3">
-                  {txInfo.vout.map((output: any, index: number) => (
+                  {txInfo.vout?.length > 0 ? txInfo.vout.map((output: any, index: number) => (
                     <div key={index} className="bg-[#2a2a2a] rounded p-3">
                       <p className="text-xs break-all">
                         <span className="font-medium">To:</span>{' '}
@@ -159,7 +180,9 @@ const TransactionDialog = ({
                         {output.value / 100000000} BTC
                       </p>
                     </div>
-                  ))}
+                  )) : (
+                    <p className="text-xs text-gray-500">Not available without Bitcoin Core connection</p>
+                  )}
                 </div>
               </div>
             </>

--- a/dashboard/src/components/BitcoinStats/TransactionDialog.tsx
+++ b/dashboard/src/components/BitcoinStats/TransactionDialog.tsx
@@ -58,7 +58,9 @@ const TransactionDialog = ({
             <div className="text-red-500 py-8 text-center">{error}</div>
           )}
           {!loading && !error && !txInfo && (
-            <div className="text-gray-400 text-center py-8">Transaction not found</div>
+            <div className="text-gray-400 text-center py-8">
+              Transaction not found
+            </div>
           )}
 
           {txInfo && (
@@ -93,14 +95,19 @@ const TransactionDialog = ({
                     </h3>
                     <p className="text-sm mt-1">
                       {txInfo.stage
-                        ? txInfo.stage.charAt(0).toUpperCase() + txInfo.stage.slice(1)
-                        : txInfo.status?.confirmed ? 'Confirmed' : 'Unconfirmed'}
+                        ? txInfo.stage.charAt(0).toUpperCase() +
+                          txInfo.stage.slice(1)
+                        : txInfo.status?.confirmed
+                          ? 'Confirmed'
+                          : 'Unconfirmed'}
                     </p>
                   </div>
                   <div>
                     <h3 className="text-sm font-medium text-gray-400">Fee</h3>
                     <p className="text-sm mt-1">
-                      {txInfo.fee != null ? `${txInfo.fee / 100000000} BTC` : 'N/A'}
+                      {txInfo.fee != null
+                        ? `${txInfo.fee / 100000000} BTC`
+                        : 'N/A'}
                     </p>
                   </div>
                   <div>
@@ -134,7 +141,9 @@ const TransactionDialog = ({
                       <h3 className="text-sm font-medium text-gray-400">
                         Bead Hash
                       </h3>
-                      <p className="text-xs break-all mt-1">{txInfo.bead_hash}</p>
+                      <p className="text-xs break-all mt-1">
+                        {txInfo.bead_hash}
+                      </p>
                     </div>
                   )}
                 </div>
@@ -145,21 +154,25 @@ const TransactionDialog = ({
                   Inputs ({txInfo.vin?.length ?? 0})
                 </h3>
                 <div className="space-y-3">
-                  {txInfo.vin?.length > 0 ? txInfo.vin.map((input: any, index: number) => (
-                    <div key={index} className="bg-[#2a2a2a] rounded p-3">
-                      <p className="text-xs break-all">
-                        <span className="font-medium">From:</span>{' '}
-                        {input.prevout?.scriptpubkey_address || 'Coinbase'}
-                      </p>
-                      <p className="text-xs mt-1">
-                        <span className="font-medium">Amount:</span>{' '}
-                        {input.prevout?.value
-                          ? `${input.prevout.value / 100000000} BTC`
-                          : 'N/A'}
-                      </p>
-                    </div>
-                  )) : (
-                    <p className="text-xs text-gray-500">Not available without Bitcoin Core connection</p>
+                  {txInfo.vin?.length > 0 ? (
+                    txInfo.vin.map((input: any, index: number) => (
+                      <div key={index} className="bg-[#2a2a2a] rounded p-3">
+                        <p className="text-xs break-all">
+                          <span className="font-medium">From:</span>{' '}
+                          {input.prevout?.scriptpubkey_address || 'Coinbase'}
+                        </p>
+                        <p className="text-xs mt-1">
+                          <span className="font-medium">Amount:</span>{' '}
+                          {input.prevout?.value
+                            ? `${input.prevout.value / 100000000} BTC`
+                            : 'N/A'}
+                        </p>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-xs text-gray-500">
+                      Not available without Bitcoin Core connection
+                    </p>
                   )}
                 </div>
               </div>
@@ -169,19 +182,23 @@ const TransactionDialog = ({
                   Outputs ({txInfo.vout?.length ?? 0})
                 </h3>
                 <div className="space-y-3">
-                  {txInfo.vout?.length > 0 ? txInfo.vout.map((output: any, index: number) => (
-                    <div key={index} className="bg-[#2a2a2a] rounded p-3">
-                      <p className="text-xs break-all">
-                        <span className="font-medium">To:</span>{' '}
-                        {output.scriptpubkey_address}
-                      </p>
-                      <p className="text-xs mt-1">
-                        <span className="font-medium">Amount:</span>{' '}
-                        {output.value / 100000000} BTC
-                      </p>
-                    </div>
-                  )) : (
-                    <p className="text-xs text-gray-500">Not available without Bitcoin Core connection</p>
+                  {txInfo.vout?.length > 0 ? (
+                    txInfo.vout.map((output: any, index: number) => (
+                      <div key={index} className="bg-[#2a2a2a] rounded p-3">
+                        <p className="text-xs break-all">
+                          <span className="font-medium">To:</span>{' '}
+                          {output.scriptpubkey_address}
+                        </p>
+                        <p className="text-xs mt-1">
+                          <span className="font-medium">Amount:</span>{' '}
+                          {output.value / 100000000} BTC
+                        </p>
+                      </div>
+                    ))
+                  ) : (
+                    <p className="text-xs text-gray-500">
+                      Not available without Bitcoin Core connection
+                    </p>
                   )}
                 </div>
               </div>

--- a/dashboard/src/components/BitcoinStats/TransactionTable.tsx
+++ b/dashboard/src/components/BitcoinStats/TransactionTable.tsx
@@ -7,20 +7,26 @@ import { TransactionTableProps } from './Types';
 const TXID_REGEX = /^[a-fA-F0-9]{64}$/;
 
 const STAGE_BADGE: Record<string, { label: string; color: string }> = {
-  unknown:   { label: 'Unknown',   color: '#6b7280' },
-  mempool:   { label: 'Mempool',   color: '#d97706' },
-  staged:    { label: 'Staged',    color: '#3b82f6' },
+  unknown: { label: 'Unknown', color: '#6b7280' },
+  mempool: { label: 'Mempool', color: '#d97706' },
+  staged: { label: 'Staged', color: '#3b82f6' },
   committed: { label: 'Committed', color: '#8b5cf6' },
-  mined:     { label: 'Mined',     color: '#10b981' },
+  mined: { label: 'Mined', color: '#10b981' },
   confirmed: { label: 'Confirmed', color: '#22c55e' },
 };
 
 function StageBadge({ stage }: { stage?: string }) {
-  const s = stage ? STAGE_BADGE[stage] ?? STAGE_BADGE.unknown : STAGE_BADGE.unknown;
+  const s = stage
+    ? (STAGE_BADGE[stage] ?? STAGE_BADGE.unknown)
+    : STAGE_BADGE.unknown;
   return (
     <span
       className="inline-block px-2 py-0.5 rounded-full text-xs font-medium"
-      style={{ backgroundColor: `${s.color}22`, color: s.color, border: `1px solid ${s.color}55` }}
+      style={{
+        backgroundColor: `${s.color}22`,
+        color: s.color,
+        border: `1px solid ${s.color}55`,
+      }}
     >
       {s.label}
     </span>
@@ -45,9 +51,10 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
     setSelectedTx(txid);
   };
 
-  const visibleTransactions = stageFilter === 'all'
-    ? transactions
-    : transactions.filter((tx: any) => tx.stage === stageFilter);
+  const visibleTransactions =
+    stageFilter === 'all'
+      ? transactions
+      : transactions.filter((tx: any) => tx.stage === stageFilter);
   const stageOptions = ['all', ...Object.keys(STAGE_BADGE)];
 
   return (
@@ -56,8 +63,6 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
       style={{ borderColor: colors.cardAccentSecondary }}
     >
       <div className="mb-3 text-gray-400">Latest Transactions</div>
-     
-        
 
       {/* Manual txid lookup + stage filter */}
       <div className="flex gap-2 mb-3">
@@ -76,7 +81,10 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
           type="text"
           placeholder="Look up txid (64-char hex)…"
           value={lookupInput}
-          onChange={(e) => { setLookupInput(e.target.value); setLookupError(null); }}
+          onChange={(e) => {
+            setLookupInput(e.target.value);
+            setLookupError(null);
+          }}
           onKeyDown={(e) => e.key === 'Enter' && handleLookup()}
           className="flex-1 bg-[#2a2a2a] text-white text-xs rounded px-3 py-2 border border-white/10 focus:outline-none focus:border-white/30 font-mono"
           spellCheck={false}

--- a/dashboard/src/components/BitcoinStats/TransactionTable.tsx
+++ b/dashboard/src/components/BitcoinStats/TransactionTable.tsx
@@ -4,16 +4,94 @@ import { shortenAddress } from './Utils';
 import colors from '../../theme/colors';
 import { TransactionTableProps } from './Types';
 
+const TXID_REGEX = /^[a-fA-F0-9]{64}$/;
+
+const STAGE_BADGE: Record<string, { label: string; color: string }> = {
+  unknown:   { label: 'Unknown',   color: '#6b7280' },
+  mempool:   { label: 'Mempool',   color: '#d97706' },
+  staged:    { label: 'Staged',    color: '#3b82f6' },
+  committed: { label: 'Committed', color: '#8b5cf6' },
+  mined:     { label: 'Mined',     color: '#10b981' },
+  confirmed: { label: 'Confirmed', color: '#22c55e' },
+};
+
+function StageBadge({ stage }: { stage?: string }) {
+  const s = stage ? STAGE_BADGE[stage] ?? STAGE_BADGE.unknown : STAGE_BADGE.unknown;
+  return (
+    <span
+      className="inline-block px-2 py-0.5 rounded-full text-xs font-medium"
+      style={{ backgroundColor: `${s.color}22`, color: s.color, border: `1px solid ${s.color}55` }}
+    >
+      {s.label}
+    </span>
+  );
+}
+
 const TransactionTable: React.FC<TransactionTableProps> = ({
   transactions,
 }) => {
   const [selectedTx, setSelectedTx] = useState<string | null>(null);
+  const [lookupInput, setLookupInput] = useState('');
+  const [lookupError, setLookupError] = useState<string | null>(null);
+  const [stageFilter, setStageFilter] = useState<string>('all');
+
+  const handleLookup = () => {
+    const txid = lookupInput.trim();
+    if (!TXID_REGEX.test(txid)) {
+      setLookupError('Enter a valid 64-character hex txid');
+      return;
+    }
+    setLookupError(null);
+    setSelectedTx(txid);
+  };
+
+  const visibleTransactions = stageFilter === 'all'
+    ? transactions
+    : transactions.filter((tx: any) => tx.stage === stageFilter);
+  const stageOptions = ['all', ...Object.keys(STAGE_BADGE)];
+
   return (
     <div
       className="rounded-2xl border border-white/10 bg-[#1e1e1e] shadow-md p-4"
       style={{ borderColor: colors.cardAccentSecondary }}
     >
-      <div className="mb-2  text-gray-400">Latest Transactions</div>
+      <div className="mb-3 text-gray-400">Latest Transactions</div>
+     
+        
+
+      {/* Manual txid lookup + stage filter */}
+      <div className="flex gap-2 mb-3">
+        <select
+          value={stageFilter}
+          onChange={(e) => setStageFilter(e.target.value)}
+          className="bg-[#2a2a2a] text-white text-xs rounded px-2 py-2 border border-white/10 focus:outline-none focus:border-white/30"
+        >
+          {stageOptions.map((s) => (
+            <option key={s} value={s}>
+              {s === 'all' ? 'All stages' : (STAGE_BADGE[s]?.label ?? s)}
+            </option>
+          ))}
+        </select>
+        <input
+          type="text"
+          placeholder="Look up txid (64-char hex)…"
+          value={lookupInput}
+          onChange={(e) => { setLookupInput(e.target.value); setLookupError(null); }}
+          onKeyDown={(e) => e.key === 'Enter' && handleLookup()}
+          className="flex-1 bg-[#2a2a2a] text-white text-xs rounded px-3 py-2 border border-white/10 focus:outline-none focus:border-white/30 font-mono"
+          spellCheck={false}
+        />
+        <button
+          onClick={handleLookup}
+          className="px-3 py-2 text-xs rounded font-medium whitespace-nowrap"
+          style={{ backgroundColor: colors.primary, color: '#fff' }}
+        >
+          Look Up
+        </button>
+      </div>
+      {lookupError && (
+        <p className="text-red-400 text-xs mb-2">{lookupError}</p>
+      )}
       <div
         className="overflow-auto rounded-md scrollbar-thin"
         style={{
@@ -22,7 +100,7 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
         }}
       >
         <table className="w-full">
-          {transactions.length === 0 ? null : (
+          {visibleTransactions.length === 0 ? null : (
             <thead className="sticky top-0 z-10">
               <tr style={{ backgroundColor: colors.paper }}>
                 <th
@@ -30,6 +108,12 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
                   style={{ color: colors.textPrimary }}
                 >
                   TXID
+                </th>
+                <th
+                  className="text-left p-4 font-semibold "
+                  style={{ color: colors.textPrimary }}
+                >
+                  STATUS
                 </th>
                 <th
                   className="text-left p-4 font-semibold "
@@ -53,17 +137,19 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
             </thead>
           )}
           <tbody>
-            {transactions.length === 0 ? (
+            {visibleTransactions.length === 0 ? (
               <tr>
                 <td
-                  colSpan={4}
+                  colSpan={5}
                   className="p-4 text-center text-sm text-gray-400"
                 >
-                  No transactions found
+                  {transactions.length === 0
+                    ? 'No transactions found'
+                    : `No ${stageFilter} transactions`}
                 </td>
               </tr>
             ) : (
-              transactions.map((tx) => (
+              visibleTransactions.map((tx) => (
                 <tr
                   key={tx.txid}
                   className={`transition-colors duration-150 ${
@@ -87,6 +173,9 @@ const TransactionTable: React.FC<TransactionTableProps> = ({
                         {tx.txid}
                       </div>
                     </div>
+                  </td>
+                  <td className="p-4">
+                    <StageBadge stage={tx.stage} />
                   </td>
                   <td className="p-4" style={{ color: colors.textPrimary }}>
                     {tx.fee / 100000000} BTC

--- a/dashboard/src/components/BitcoinStats/Types.ts
+++ b/dashboard/src/components/BitcoinStats/Types.ts
@@ -33,7 +33,7 @@ export interface RBFTransaction {
   tx: TransactionInfo;
   time: number;
   fullRbf?: boolean;
-  replaces: RBFTransaction[];
+  replaces?: RBFTransaction[];
 }
 
 export interface RBFTransactionRowProps {

--- a/dashboard/src/components/BitcoinStats/Utils.ts
+++ b/dashboard/src/components/BitcoinStats/Utils.ts
@@ -1,10 +1,12 @@
 import axios from 'axios';
 import { useState } from 'react';
 import {
-  getMempoolRecentUrl,
-  getMempoolTransactionUrl,
-  getBraidPoolReplacementsUrl,
+  getBraidpoolNodeRpcUrl,
 } from '../../URLs';
+
+const RPC_TIMEOUT = 8000;
+let _rpcId = 0;
+const nextId = () => ++_rpcId;
 
 export const getCurrencySymbol = (curr: string) => {
   switch (curr) {
@@ -41,40 +43,208 @@ export const shortenAddress = (value: string): string => {
   return value.slice(0, 7) + '....' + value.slice(-7);
 };
 
-// via esplora
+const _upliftCache = new Map<string, 'mined' | 'confirmed'>();
+const _noUpliftCount = new Map<string, number>();
+const NO_UPLIFT_GIVE_UP = 3; 
+
 export const getLatestTransactions = async (): Promise<any> => {
-  try {
-    const response = await axios.get(getMempoolRecentUrl());
-    console.log(response.data);
-    return response.data;
-  } catch (error) {
-    console.error('Error fetching transactions:', error);
-    throw error;
+  const [mempoolResult, stagedResult, committedResult] = await Promise.allSettled([
+    axios.post(
+      getBraidpoolNodeRpcUrl(),
+      { jsonrpc: '2.0', id: nextId(), method: 'getmempoolentries', params: [20] },
+      { timeout: RPC_TIMEOUT }
+    ),
+    axios.post(
+      getBraidpoolNodeRpcUrl(),
+      { jsonrpc: '2.0', id: nextId(), method: 'stagedtransactions', params: [] },
+      { timeout: RPC_TIMEOUT }
+    ),
+    axios.post(
+      getBraidpoolNodeRpcUrl(),
+      { jsonrpc: '2.0', id: nextId(), method: 'getcommittedtransactions', params: [0, 20] },
+      { timeout: RPC_TIMEOUT }
+    ),
+  ]);
+
+  const txMap = new Map<string, any>();
+  if (committedResult.status === 'fulfilled' && !committedResult.value.data.error) {
+    const entries: any[] = committedResult.value.data.result?.transactions ?? [];
+    for (const tx of entries) {
+      txMap.set(tx.txid, {
+        txid: tx.txid,
+        fee: 0,
+        vsize: 0,
+        value: 0,
+        time: tx.timestamp,
+        stage: 'committed',
+      });
+    }
   }
+  if (stagedResult.status === 'fulfilled' && !stagedResult.value.data.error) {
+    const entries: any[] = stagedResult.value.data.result ?? [];
+    for (const entry of entries) {
+      if (!txMap.has(entry.txid)) {
+        const totalValue = (entry.tx?.output ?? []).reduce(
+          (sum: number, out: any) => sum + (out.value ?? 0),
+          0
+        );
+        txMap.set(entry.txid, {
+          txid: entry.txid,
+          fee: 0,
+          vsize: 0,
+          value: totalValue,
+          time: 0,
+          stage: 'staged',
+        });
+      }
+    }
+  }
+  if (mempoolResult.status === 'fulfilled' && !mempoolResult.value.data.error) {
+    const entries: any[] = mempoolResult.value.data.result ?? [];
+    for (const tx of entries) {
+      if (!txMap.has(tx.txid)) {
+        txMap.set(tx.txid, {
+          txid: tx.txid,
+          fee: tx.fee,
+          vsize: tx.vsize,
+          value: 0,
+          time: tx.time,
+          stage: 'mempool',
+        });
+      }
+    }
+  }
+
+  if (txMap.size === 0) {
+    throw new Error('Unable to fetch transactions: node unreachable or all RPCs failed');
+  }
+  const committedTxids = Array.from(txMap.values())
+    .filter((tx) => tx.stage === 'committed')
+    .map((tx) => tx.txid as string);
+  for (const txid of committedTxids) {
+    const cached = _upliftCache.get(txid);
+    if (cached) {
+      const tx = txMap.get(txid);
+      if (tx) tx.stage = cached;
+    }
+  }
+  const uncachedTxids = committedTxids.filter(
+    (txid) => !_upliftCache.has(txid) && (_noUpliftCount.get(txid) ?? 0) < NO_UPLIFT_GIVE_UP
+  );
+
+  if (uncachedTxids.length > 0) {
+    const statusResults = await Promise.allSettled(
+      uncachedTxids.map((txid) =>
+        axios.post(
+          getBraidpoolNodeRpcUrl(),
+          { jsonrpc: '2.0', id: nextId(), method: 'gettransactionstatus', params: [txid] },
+          { timeout: RPC_TIMEOUT }
+        )
+      )
+    );
+    statusResults.forEach((result, i) => {
+      const txid = uncachedTxids[i];
+      if (result.status === 'fulfilled' && !result.value.data.error) {
+        const stageName: string = result.value.data.result?.stage_name;
+        if (stageName === 'mined' || stageName === 'confirmed') {
+          _upliftCache.set(txid, stageName);
+          const tx = txMap.get(txid);
+          if (tx) tx.stage = stageName;
+        } else {
+          _noUpliftCount.set(txid, (_noUpliftCount.get(txid) ?? 0) + 1);
+        }
+      } else {
+        _noUpliftCount.set(txid, (_noUpliftCount.get(txid) ?? 0) + 1);
+      }
+    });
+  }
+  const stageOrder: Record<string, number> = {
+    confirmed: 0,
+    mined:     1,
+    committed: 2,
+    staged:    3,
+    mempool:   4,
+  };
+  return Array.from(txMap.values()).sort((a, b) => {
+    const so = (stageOrder[a.stage] ?? 9) - (stageOrder[b.stage] ?? 9);
+    if (so !== 0) return so;
+    return (b.time ?? 0) - (a.time ?? 0);
+  });
 };
 
-// via esplora
+
 export const getTxInfo = async (txid: string): Promise<any> => {
   try {
-    const response = await axios.get(getMempoolTransactionUrl(txid));
-    console.log(response.data);
-    return response.data;
+    const response = await axios.post(
+      getBraidpoolNodeRpcUrl(),
+      { jsonrpc: '2.0', id: nextId(), method: 'gettransactionstatus', params: [txid] },
+      { timeout: RPC_TIMEOUT }
+    );
+    if (response.data.error) {
+      throw new Error(response.data.error.message ?? 'RPC error from gettransactionstatus');
+    }
+    const result = response.data.result;
+    if (!result) throw new Error('Empty result from gettransactionstatus');
+    const { stage_name, detail = {} } = result;
+    const feeSats =
+      detail.fee != null ? Math.round(Math.abs(detail.fee) * 1e8) : null;
+    return {
+      txid: result.txid,
+      stage: stage_name,
+      bead_hash: detail.bead_hash ?? null,
+      status: {
+        confirmed: stage_name === 'mined' || stage_name === 'confirmed',
+      },
+      fee: feeSats,
+      size: detail.size ?? null,
+      vsize: detail.vsize ?? null,
+      weight: detail.weight ?? null,
+      version: detail.version ?? null,
+      locktime: detail.locktime ?? null,
+      vin: (detail.vin ?? []).map((input: any) => ({
+        txid: input.txid,
+        vout: input.vout,
+        prevout: null,
+      })),
+      vout: (detail.vout ?? []).map((out: any) => ({
+        scriptpubkey_address:
+          out.scriptPubKey?.address ??
+          out.scriptPubKey?.addresses?.[0] ??
+          null,
+        value: Math.round((out.value ?? 0) * 1e8),
+      })),
+    };
   } catch (error) {
-    console.error('Error fetching transactions:', error);
+    console.error('Error fetching transaction info:', error);
     throw error;
   }
 };
 
-// via mempool api
-export const latestRBFTransactions = async (): Promise<any> => {
-  try {
-    const response = await axios.get(getBraidPoolReplacementsUrl());
-    console.log(response.data);
-    return response.data;
-  } catch (error) {
-    console.error('Error fetching RBF Transactions:', error);
-    throw error;
+export const latestRBFTransactions = async (): Promise<any[]> => {
+  const response = await axios.post(
+    getBraidpoolNodeRpcUrl(),
+    { jsonrpc: '2.0', id: nextId(), method: 'getmempoolentries', params: [200] },
+    { timeout: RPC_TIMEOUT }
+  );
+  if (response.data.error) {
+    throw new Error(response.data.error.message ?? 'getmempoolentries RPC error');
   }
+  const entries: any[] = response.data.result ?? [];
+  return entries
+    .filter((tx) => tx.rbf === true)
+    .sort((a, b) => (b.fee_rate ?? 0) - (a.fee_rate ?? 0))
+    .map((tx) => ({
+      tx: {
+        txid: tx.txid,
+        fee: tx.fee ?? 0,
+        vsize: tx.vsize ?? 0,
+        value: 0,
+        rate: tx.fee_rate ?? 0,
+        rbf: true,
+      },
+      time: tx.time ?? 0,
+      replaces: [],
+    }));
 };
 
 export const useCopyToClipboard = (

--- a/dashboard/src/components/BitcoinStats/Utils.ts
+++ b/dashboard/src/components/BitcoinStats/Utils.ts
@@ -1,8 +1,6 @@
 import axios from 'axios';
 import { useState } from 'react';
-import {
-  getBraidpoolNodeRpcUrl,
-} from '../../URLs';
+import { getBraidpoolNodeRpcUrl } from '../../URLs';
 
 const RPC_TIMEOUT = 8000;
 let _rpcId = 0;
@@ -45,30 +43,50 @@ export const shortenAddress = (value: string): string => {
 
 const _upliftCache = new Map<string, 'mined' | 'confirmed'>();
 const _noUpliftCount = new Map<string, number>();
-const NO_UPLIFT_GIVE_UP = 3; 
+const NO_UPLIFT_GIVE_UP = 3;
 
 export const getLatestTransactions = async (): Promise<any> => {
-  const [mempoolResult, stagedResult, committedResult] = await Promise.allSettled([
-    axios.post(
-      getBraidpoolNodeRpcUrl(),
-      { jsonrpc: '2.0', id: nextId(), method: 'getmempoolentries', params: [20] },
-      { timeout: RPC_TIMEOUT }
-    ),
-    axios.post(
-      getBraidpoolNodeRpcUrl(),
-      { jsonrpc: '2.0', id: nextId(), method: 'stagedtransactions', params: [] },
-      { timeout: RPC_TIMEOUT }
-    ),
-    axios.post(
-      getBraidpoolNodeRpcUrl(),
-      { jsonrpc: '2.0', id: nextId(), method: 'getcommittedtransactions', params: [0, 20] },
-      { timeout: RPC_TIMEOUT }
-    ),
-  ]);
+  const [mempoolResult, stagedResult, committedResult] =
+    await Promise.allSettled([
+      axios.post(
+        getBraidpoolNodeRpcUrl(),
+        {
+          jsonrpc: '2.0',
+          id: nextId(),
+          method: 'getmempoolentries',
+          params: [20],
+        },
+        { timeout: RPC_TIMEOUT }
+      ),
+      axios.post(
+        getBraidpoolNodeRpcUrl(),
+        {
+          jsonrpc: '2.0',
+          id: nextId(),
+          method: 'stagedtransactions',
+          params: [],
+        },
+        { timeout: RPC_TIMEOUT }
+      ),
+      axios.post(
+        getBraidpoolNodeRpcUrl(),
+        {
+          jsonrpc: '2.0',
+          id: nextId(),
+          method: 'getcommittedtransactions',
+          params: [0, 20],
+        },
+        { timeout: RPC_TIMEOUT }
+      ),
+    ]);
 
   const txMap = new Map<string, any>();
-  if (committedResult.status === 'fulfilled' && !committedResult.value.data.error) {
-    const entries: any[] = committedResult.value.data.result?.transactions ?? [];
+  if (
+    committedResult.status === 'fulfilled' &&
+    !committedResult.value.data.error
+  ) {
+    const entries: any[] =
+      committedResult.value.data.result?.transactions ?? [];
     for (const tx of entries) {
       txMap.set(tx.txid, {
         txid: tx.txid,
@@ -116,7 +134,9 @@ export const getLatestTransactions = async (): Promise<any> => {
   }
 
   if (txMap.size === 0) {
-    throw new Error('Unable to fetch transactions: node unreachable or all RPCs failed');
+    throw new Error(
+      'Unable to fetch transactions: node unreachable or all RPCs failed'
+    );
   }
   const committedTxids = Array.from(txMap.values())
     .filter((tx) => tx.stage === 'committed')
@@ -129,7 +149,9 @@ export const getLatestTransactions = async (): Promise<any> => {
     }
   }
   const uncachedTxids = committedTxids.filter(
-    (txid) => !_upliftCache.has(txid) && (_noUpliftCount.get(txid) ?? 0) < NO_UPLIFT_GIVE_UP
+    (txid) =>
+      !_upliftCache.has(txid) &&
+      (_noUpliftCount.get(txid) ?? 0) < NO_UPLIFT_GIVE_UP
   );
 
   if (uncachedTxids.length > 0) {
@@ -137,7 +159,12 @@ export const getLatestTransactions = async (): Promise<any> => {
       uncachedTxids.map((txid) =>
         axios.post(
           getBraidpoolNodeRpcUrl(),
-          { jsonrpc: '2.0', id: nextId(), method: 'gettransactionstatus', params: [txid] },
+          {
+            jsonrpc: '2.0',
+            id: nextId(),
+            method: 'gettransactionstatus',
+            params: [txid],
+          },
           { timeout: RPC_TIMEOUT }
         )
       )
@@ -160,10 +187,10 @@ export const getLatestTransactions = async (): Promise<any> => {
   }
   const stageOrder: Record<string, number> = {
     confirmed: 0,
-    mined:     1,
+    mined: 1,
     committed: 2,
-    staged:    3,
-    mempool:   4,
+    staged: 3,
+    mempool: 4,
   };
   return Array.from(txMap.values()).sort((a, b) => {
     const so = (stageOrder[a.stage] ?? 9) - (stageOrder[b.stage] ?? 9);
@@ -172,16 +199,22 @@ export const getLatestTransactions = async (): Promise<any> => {
   });
 };
 
-
 export const getTxInfo = async (txid: string): Promise<any> => {
   try {
     const response = await axios.post(
       getBraidpoolNodeRpcUrl(),
-      { jsonrpc: '2.0', id: nextId(), method: 'gettransactionstatus', params: [txid] },
+      {
+        jsonrpc: '2.0',
+        id: nextId(),
+        method: 'gettransactionstatus',
+        params: [txid],
+      },
       { timeout: RPC_TIMEOUT }
     );
     if (response.data.error) {
-      throw new Error(response.data.error.message ?? 'RPC error from gettransactionstatus');
+      throw new Error(
+        response.data.error.message ?? 'RPC error from gettransactionstatus'
+      );
     }
     const result = response.data.result;
     if (!result) throw new Error('Empty result from gettransactionstatus');
@@ -208,9 +241,7 @@ export const getTxInfo = async (txid: string): Promise<any> => {
       })),
       vout: (detail.vout ?? []).map((out: any) => ({
         scriptpubkey_address:
-          out.scriptPubKey?.address ??
-          out.scriptPubKey?.addresses?.[0] ??
-          null,
+          out.scriptPubKey?.address ?? out.scriptPubKey?.addresses?.[0] ?? null,
         value: Math.round((out.value ?? 0) * 1e8),
       })),
     };
@@ -223,11 +254,18 @@ export const getTxInfo = async (txid: string): Promise<any> => {
 export const latestRBFTransactions = async (): Promise<any[]> => {
   const response = await axios.post(
     getBraidpoolNodeRpcUrl(),
-    { jsonrpc: '2.0', id: nextId(), method: 'getmempoolentries', params: [200] },
+    {
+      jsonrpc: '2.0',
+      id: nextId(),
+      method: 'getmempoolentries',
+      params: [200],
+    },
     { timeout: RPC_TIMEOUT }
   );
   if (response.data.error) {
-    throw new Error(response.data.error.message ?? 'getmempoolentries RPC error');
+    throw new Error(
+      response.data.error.message ?? 'getmempoolentries RPC error'
+    );
   }
   const entries: any[] = response.data.result ?? [];
   return entries

--- a/dashboard/src/components/BitcoinStats/__tests__/Utils.test.ts
+++ b/dashboard/src/components/BitcoinStats/__tests__/Utils.test.ts
@@ -100,7 +100,19 @@ describe('Utility Functions', () => {
     it('fetches and returns transactions from node RPCs', async () => {
       // getmempoolentries
       mockedAxios.post.mockResolvedValueOnce({
-        data: { result: [{ txid: 'aaaa', fee: 1000, vsize: 200, fee_rate: 5.0, time: 1000, rbf: false }], error: null },
+        data: {
+          result: [
+            {
+              txid: 'aaaa',
+              fee: 1000,
+              vsize: 200,
+              fee_rate: 5.0,
+              time: 1000,
+              rbf: false,
+            },
+          ],
+          error: null,
+        },
       });
       // stagedtransactions
       mockedAxios.post.mockResolvedValueOnce({
@@ -139,7 +151,16 @@ describe('Utility Functions', () => {
             txid,
             stage: 1,
             stage_name: 'mempool',
-            detail: { fee: -0.0001, vsize: 200, size: 220, weight: 800, version: 2, locktime: 0, vin: [], vout: [] },
+            detail: {
+              fee: -0.0001,
+              vsize: 200,
+              size: 220,
+              weight: 800,
+              version: 2,
+              locktime: 0,
+              vin: [],
+              vout: [],
+            },
           },
           error: null,
         },
@@ -148,7 +169,10 @@ describe('Utility Functions', () => {
       const result = await getTxInfo(txid);
       expect(mockedAxios.post).toHaveBeenCalledWith(
         expect.any(String),
-        expect.objectContaining({ method: 'gettransactionstatus', params: [txid] }),
+        expect.objectContaining({
+          method: 'gettransactionstatus',
+          params: [txid],
+        }),
         expect.any(Object)
       );
       expect(result.txid).toBe(txid);

--- a/dashboard/src/components/BitcoinStats/__tests__/Utils.test.ts
+++ b/dashboard/src/components/BitcoinStats/__tests__/Utils.test.ts
@@ -7,7 +7,6 @@ import {
   getLatestTransactions,
   getTxInfo,
 } from '../Utils';
-import { getMempoolRecentUrl, getMempoolTransactionUrl } from '../../../URLs';
 
 jest.mock('axios');
 const mockedAxios = axios as jest.Mocked<typeof axios>;
@@ -94,34 +93,78 @@ describe('Utility Functions', () => {
   });
 
   describe('getLatestTransactions', () => {
-    it('fetches and returns data', async () => {
-      const data = [{ id: 1 }, { id: 2 }];
-      mockedAxios.get.mockResolvedValueOnce({ data });
-      const result = await getLatestTransactions();
-      expect(mockedAxios.get).toHaveBeenCalledWith(getMempoolRecentUrl());
-      expect(result).toEqual(data);
+    beforeEach(() => {
+      mockedAxios.post.mockReset();
     });
 
-    it('throws error when request fails', async () => {
-      mockedAxios.get.mockRejectedValueOnce(new Error('Network error'));
-      await expect(getLatestTransactions()).rejects.toThrow('Network error');
+    it('fetches and returns transactions from node RPCs', async () => {
+      // getmempoolentries
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { result: [{ txid: 'aaaa', fee: 1000, vsize: 200, fee_rate: 5.0, time: 1000, rbf: false }], error: null },
+      });
+      // stagedtransactions
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { result: [], error: null },
+      });
+      // getcommittedtransactions
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { result: { transactions: [] }, error: null },
+      });
+
+      const result = await getLatestTransactions();
+      expect(mockedAxios.post).toHaveBeenCalledTimes(3);
+      expect(Array.isArray(result)).toBe(true);
+      expect(result[0].txid).toBe('aaaa');
+      expect(result[0].stage).toBe('mempool');
+    });
+
+    it('throws when all three RPC calls fail', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Network error'));
+      await expect(getLatestTransactions()).rejects.toThrow(
+        'Unable to fetch transactions: node unreachable or all RPCs failed'
+      );
     });
   });
 
   describe('getTxInfo', () => {
-    it('fetches and returns tx info', async () => {
-      const txid = 'abc123';
-      const data = { txid, info: 'some info' };
-      mockedAxios.get.mockResolvedValueOnce({ data });
-      const result = await getTxInfo(txid);
-      expect(mockedAxios.get).toHaveBeenCalledWith(
-        getMempoolTransactionUrl(txid)
-      );
-      expect(result).toEqual(data);
+    beforeEach(() => {
+      mockedAxios.post.mockReset();
     });
 
-    it('throws error when request fails', async () => {
-      mockedAxios.get.mockRejectedValueOnce(new Error('Request failed'));
+    it('fetches and returns tx info via gettransactionstatus', async () => {
+      const txid = 'abc123';
+      mockedAxios.post.mockResolvedValueOnce({
+        data: {
+          result: {
+            txid,
+            stage: 1,
+            stage_name: 'mempool',
+            detail: { fee: -0.0001, vsize: 200, size: 220, weight: 800, version: 2, locktime: 0, vin: [], vout: [] },
+          },
+          error: null,
+        },
+      });
+
+      const result = await getTxInfo(txid);
+      expect(mockedAxios.post).toHaveBeenCalledWith(
+        expect.any(String),
+        expect.objectContaining({ method: 'gettransactionstatus', params: [txid] }),
+        expect.any(Object)
+      );
+      expect(result.txid).toBe(txid);
+      expect(result.stage).toBe('mempool');
+      expect(result.fee).toBe(10000); // 0.0001 BTC in sats
+    });
+
+    it('throws when the RPC returns an error', async () => {
+      mockedAxios.post.mockResolvedValueOnce({
+        data: { result: null, error: { message: 'Invalid txid' } },
+      });
+      await expect(getTxInfo('bad')).rejects.toThrow('Invalid txid');
+    });
+
+    it('throws when the network request fails', async () => {
+      mockedAxios.post.mockRejectedValueOnce(new Error('Request failed'));
       await expect(getTxInfo('txid')).rejects.toThrow('Request failed');
     });
   });

--- a/node/Cargo.toml
+++ b/node/Cargo.toml
@@ -38,6 +38,8 @@ if-addrs = { workspace = true }
 anyhow = { workspace = true }
 socket2 = { version = "0.5", features = ["all"] }
 reqwest = { workspace = true }
+tower = { workspace = true }
+tower-http = { workspace = true }
 
 
 [build-dependencies]

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -1,7 +1,7 @@
-use bitcoin::Txid;
 use crate::bead::Bead;
 use crate::error::BraidError;
 use crate::utils::BeadHash;
+use bitcoin::Txid;
 use num::BigUint;
 use serde::{Deserialize, Serialize};
 use std::cmp::Ordering;

--- a/node/src/braid/mod.rs
+++ b/node/src/braid/mod.rs
@@ -1,3 +1,4 @@
+use bitcoin::Txid;
 use crate::bead::Bead;
 use crate::error::BraidError;
 use crate::utils::BeadHash;
@@ -35,6 +36,8 @@ pub struct Braid {
     pub orphan_beads: Vec<Bead>,
     pub genesis_beads: HashSet<usize>,
     pub bead_index_mapping: HashMap<BeadHash, usize>,
+    /// Reverse index: txid → bead_hash for all committed transaction IDs.
+    pub txid_to_bead: HashMap<Txid, BeadHash>,
 }
 
 impl Braid {
@@ -43,11 +46,16 @@ impl Braid {
         let mut beads = Vec::new();
         let mut bead_indices = HashSet::new();
         let mut bead_index_mapping = HashMap::new();
+        let mut txid_to_bead: HashMap<Txid, BeadHash> = HashMap::new();
 
         for (index, bead) in genesis_beads.into_iter().enumerate() {
             beads.push(bead.clone());
             bead_indices.insert(index);
-            bead_index_mapping.insert(bead.block_header.block_hash(), index);
+            let bead_hash = bead.block_header.block_hash();
+            bead_index_mapping.insert(bead_hash, index);
+            for txid in &bead.committed_metadata.transaction_ids.0 {
+                txid_to_bead.insert(*txid, bead_hash);
+            }
         }
         let mut genesis_cohort: Vec<Cohort> = Vec::new();
         if bead_indices.len() != 0 {
@@ -61,6 +69,7 @@ impl Braid {
             orphan_beads: Vec::new(),
             genesis_beads: bead_indices,
             bead_index_mapping,
+            txid_to_bead,
         }
     }
     pub fn reset(&mut self) {
@@ -71,6 +80,7 @@ impl Braid {
         self.orphan_beads.clear();
         self.genesis_beads.clear();
         self.bead_index_mapping.clear();
+        self.txid_to_bead.clear();
     }
 }
 #[allow(unused)]
@@ -122,6 +132,9 @@ impl Braid {
         self.beads.push(bead.clone());
         let new_bead_index = self.beads.len() - 1;
         self.bead_index_mapping.insert(bead_hash, new_bead_index);
+        for txid in &bead.committed_metadata.transaction_ids.0 {
+            self.txid_to_bead.insert(*txid, bead_hash);
+        }
 
         // Find earliest parent of bead in cohorts and nuke all cohorts after that
         let mut found_parent_indices = HashSet::new();

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -38,7 +38,7 @@ pub fn test_extend_functionality() {
             test_bead_0.block_header.block_hash(),
             0,
         )]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
     assert_eq!(
         test_braid.cohorts,
@@ -252,7 +252,7 @@ pub fn test_orphan_beads_functinality() {
             test_bead_0.block_header.block_hash(),
             0,
         )]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
     assert_eq!(
         test_braid.cohorts,
@@ -334,7 +334,7 @@ pub fn test_genesis1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -385,7 +385,7 @@ pub fn test_genesis2() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -439,7 +439,7 @@ pub fn test_genesis3() {
             (test_bead_3.block_header.block_hash(), 3),
             (test_bead_4.block_header.block_hash(), 4),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -527,7 +527,7 @@ pub fn test_tips1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -584,7 +584,7 @@ pub fn test_tips2() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -671,7 +671,7 @@ pub fn test_tips3() {
             (test_bead_4.block_header.block_hash(), 4),
             (test_bead_5.block_header.block_hash(), 5),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -760,7 +760,7 @@ pub fn test_reverse() {
             (test_bead_4.block_header.block_hash(), 4),
             (test_bead_5.block_header.block_hash(), 5),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -869,7 +869,7 @@ pub fn test_cohorts_parents_1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -1014,7 +1014,7 @@ pub fn test_highest_work_path_1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -1083,7 +1083,7 @@ pub fn test_diamond_path_highest_work() {
             (test_bead_3.block_header.block_hash(), 3),
             (test_bead_4.block_header.block_hash(), 4),
         ]),
-            txid_to_bead: HashMap::new(),
+        txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -1433,7 +1433,7 @@ fn test_extend_function() {
             orphan_beads: Vec::new(),
             genesis_beads: genesis_set,
             bead_index_mapping,
-                    txid_to_bead: HashMap::new(),
+            txid_to_bead: HashMap::new(),
         };
 
         // Extend braid with remaining beads in order of index

--- a/node/src/braid/tests.rs
+++ b/node/src/braid/tests.rs
@@ -38,6 +38,7 @@ pub fn test_extend_functionality() {
             test_bead_0.block_header.block_hash(),
             0,
         )]),
+            txid_to_bead: HashMap::new(),
     };
     assert_eq!(
         test_braid.cohorts,
@@ -251,6 +252,7 @@ pub fn test_orphan_beads_functinality() {
             test_bead_0.block_header.block_hash(),
             0,
         )]),
+            txid_to_bead: HashMap::new(),
     };
     assert_eq!(
         test_braid.cohorts,
@@ -332,6 +334,7 @@ pub fn test_genesis1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
+            txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -382,6 +385,7 @@ pub fn test_genesis2() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
+            txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -435,6 +439,7 @@ pub fn test_genesis3() {
             (test_bead_3.block_header.block_hash(), 3),
             (test_bead_4.block_header.block_hash(), 4),
         ]),
+            txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -522,6 +527,7 @@ pub fn test_tips1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
+            txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -578,6 +584,7 @@ pub fn test_tips2() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
+            txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -664,6 +671,7 @@ pub fn test_tips3() {
             (test_bead_4.block_header.block_hash(), 4),
             (test_bead_5.block_header.block_hash(), 5),
         ]),
+            txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -752,6 +760,7 @@ pub fn test_reverse() {
             (test_bead_4.block_header.block_hash(), 4),
             (test_bead_5.block_header.block_hash(), 5),
         ]),
+            txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -860,6 +869,7 @@ pub fn test_cohorts_parents_1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
+            txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -1004,6 +1014,7 @@ pub fn test_highest_work_path_1() {
             (test_bead_2.block_header.block_hash(), 2),
             (test_bead_3.block_header.block_hash(), 3),
         ]),
+            txid_to_bead: HashMap::new(),
     };
 
     //mapping of the indices with set of indices representing its parents
@@ -1072,6 +1083,7 @@ pub fn test_diamond_path_highest_work() {
             (test_bead_3.block_header.block_hash(), 3),
             (test_bead_4.block_header.block_hash(), 4),
         ]),
+            txid_to_bead: HashMap::new(),
     };
     //mapping of the indices with set of indices representing its parents
     //where the key represents the ith indexed bead from self.beads which contains all the beads
@@ -1421,6 +1433,7 @@ fn test_extend_function() {
             orphan_beads: Vec::new(),
             genesis_beads: genesis_set,
             bead_index_mapping,
+                    txid_to_bead: HashMap::new(),
         };
 
         // Extend braid with remaining beads in order of index
@@ -1509,6 +1522,7 @@ fn test_get_beads_after() {
         orphan_beads: Vec::new(),
         genesis_beads: genesis_set,
         bead_index_mapping,
+        txid_to_bead: HashMap::new(),
     };
 
     // Extend braid with remaining beads
@@ -1612,6 +1626,7 @@ fn test_get_beads_after_diamond_structure() {
         orphan_beads: Vec::new(),
         genesis_beads: genesis_set,
         bead_index_mapping,
+        txid_to_bead: HashMap::new(),
     };
 
     // Extend braid with remaining beads
@@ -1709,6 +1724,7 @@ fn test_get_beads_after_complex_braid() {
         orphan_beads: Vec::new(),
         genesis_beads: genesis_set,
         bead_index_mapping,
+        txid_to_bead: HashMap::new(),
     };
 
     // Extend braid with remaining beads
@@ -1790,6 +1806,7 @@ fn test_get_beads_after_edge_cases() {
         orphan_beads: Vec::new(),
         genesis_beads: genesis_set,
         bead_index_mapping,
+        txid_to_bead: HashMap::new(),
     };
 
     test_braid.extend(&beads[1]);
@@ -1886,6 +1903,7 @@ fn test_get_beads_after_multiple_tips() {
         orphan_beads: Vec::new(),
         genesis_beads: genesis_set,
         bead_index_mapping,
+        txid_to_bead: HashMap::new(),
     };
 
     for i in 1..6 {

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -81,11 +81,21 @@ async fn setup_sqlite_db(db_name: &str, schema_sql: &str) -> Result<SqlitePool, 
 
     let pool = if db_exists {
         info!(db_path = %db_path.display(), "Using existing database");
-        SqlitePool::connect_with(sql_lite_connections)
+        let pool = SqlitePool::connect_with(sql_lite_connections)
             .await
             .map_err(|error| DBErrors::ConnectionToSQlitePoolFailed {
                 error: error.to_string(),
-            })?
+            })?;
+        // Idempotent startup migration: ensure indices added after initial schema
+        let migrations = [
+            "CREATE INDEX IF NOT EXISTS transactions_txid ON Transactions(txid)",
+        ];
+        for migration in &migrations {
+            if let Err(e) = pool.execute(*migration).await {
+                warn!(error = ?e, migration = migration, "Startup migration failed (non-fatal)");
+            }
+        }
+        pool
     } else {
         info!(db_path = %db_path.display(), "Creating new database");
         if let Err(e) = std::fs::File::create_new(&db_path) {

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -87,9 +87,7 @@ async fn setup_sqlite_db(db_name: &str, schema_sql: &str) -> Result<SqlitePool, 
                 error: error.to_string(),
             })?;
         // Idempotent startup migration: ensure indices added after initial schema
-        let migrations = [
-            "CREATE INDEX IF NOT EXISTS transactions_txid ON Transactions(txid)",
-        ];
+        let migrations = ["CREATE INDEX IF NOT EXISTS transactions_txid ON Transactions(txid)"];
         for migration in &migrations {
             if let Err(e) = pool.execute(*migration).await {
                 warn!(error = ?e, migration = migration, "Startup migration failed (non-fatal)");

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -81,19 +81,11 @@ async fn setup_sqlite_db(db_name: &str, schema_sql: &str) -> Result<SqlitePool, 
 
     let pool = if db_exists {
         info!(db_path = %db_path.display(), "Using existing database");
-        let pool = SqlitePool::connect_with(sql_lite_connections)
+        SqlitePool::connect_with(sql_lite_connections)
             .await
             .map_err(|error| DBErrors::ConnectionToSQlitePoolFailed {
                 error: error.to_string(),
-            })?;
-        // Idempotent startup migration: ensure indices added after initial schema
-        let migrations = ["CREATE INDEX IF NOT EXISTS transactions_txid ON Transactions(txid)"];
-        for migration in &migrations {
-            if let Err(e) = pool.execute(*migration).await {
-                warn!(error = ?e, migration = migration, "Startup migration failed (non-fatal)");
-            }
-        }
-        pool
+            })?
     } else {
         info!(db_path = %db_path.display(), "Creating new database");
         if let Err(e) = std::fs::File::create_new(&db_path) {

--- a/node/src/db/schema.sql
+++ b/node/src/db/schema.sql
@@ -86,6 +86,7 @@ CREATE TABLE IF NOT EXISTS AncestorTimestamps (
 -- 7. Fast look-up indices
 CREATE INDEX IF NOT EXISTS bead_txids ON Transactions(bead_id);
 CREATE INDEX IF NOT EXISTS parents ON Relatives(parent);
+CREATE INDEX IF NOT EXISTS transactions_txid ON Transactions(txid);
 CREATE INDEX IF NOT EXISTS bead_hash ON Bead(hash);
 CREATE INDEX IF NOT EXISTS timestamps_parents ON ParentTimestamps(parent);
 CREATE INDEX IF NOT EXISTS timestamps_children ON ParentTimestamps(child);

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -11,6 +11,7 @@ use crate::stratum::BlockTemplate;
 use crate::utils::BeadHash;
 use bitcoin::block::HeaderExt;
 use bitcoin::Transaction;
+use bitcoin::Txid;
 use futures::lock::Mutex;
 use jsonrpsee::core::async_trait;
 use jsonrpsee::core::middleware::Batch;
@@ -107,6 +108,22 @@ pub trait Rpc {
 
     #[method(name = "unstagetransactions")]
     async fn unstage_transactions(&self, txid: String) -> Result<bool, ErrorObjectOwned>;
+
+    /// Returns which of the 6 confirmation stages a given txid is currently in.
+    #[method(name = "gettransactionstatus")]
+    async fn get_transaction_status(&self, txid: String) -> Result<Value, ErrorObjectOwned>;
+
+    /// Returns the most recent mempool entries from Bitcoin Core, sorted newest-first.
+    #[method(name = "getmempoolentries")]
+    async fn get_mempool_entries(&self, limit: u32) -> Result<Value, ErrorObjectOwned>;
+
+    /// Returns paginated list of txids committed across all beads.
+    #[method(name = "getcommittedtransactions")]
+    async fn get_committed_transactions(
+        &self,
+        page: u32,
+        page_size: u32,
+    ) -> Result<Value, ErrorObjectOwned>;
 
     #[method(name = "bitcoinproxy")]
     async fn bitcoin_proxy(
@@ -1010,12 +1027,239 @@ impl RpcServer for RpcServerImpl {
         }
     }
 
+    async fn get_transaction_status(&self, txid: String) -> Result<Value, ErrorObjectOwned> {
+        info!(txid = %txid, "get_transaction_status request received");
+
+        // Stage 2: txid is in the current block template (staged for next share/block)
+        {
+            let template = self.latest_block.lock().await;
+            let in_template = template
+                .transactions
+                .iter()
+                .skip(1) // skip coinbase
+                .any(|tx| tx.compute_txid().to_string() == txid);
+            if in_template {
+                return Ok(serde_json::json!({
+                    "txid": txid,
+                    "stage": 2,
+                    "stage_name": "staged",
+                    "detail": {}
+                }));
+            }
+        }
+
+        // Stage 3: txid committed in a bead
+        let txid_parsed = txid.parse::<Txid>().map_err(|_| {
+            ErrorObjectOwned::owned(
+                1,
+                "Invalid txid: expected 64-character hex string",
+                None::<()>,
+            )
+        })?;
+        {
+            let braid = self.braid_arc.read().await;
+            if let Some(bead_hash) = braid.txid_to_bead.get(&txid_parsed) {
+                return Ok(serde_json::json!({
+                    "txid": txid,
+                    "stage": 3,
+                    "stage_name": "committed",
+                    "detail": { "bead_hash": bead_hash.to_string() }
+                }));
+            }
+        }
+
+        // Stages 1, 5, 6: query Bitcoin Core via getrawtransaction
+        if let Some(rpc_config) = &self.bitcoin_rpc_config {
+            match call_bitcoin_rpc_direct(
+                rpc_config,
+                "getrawtransaction",
+                &serde_json::json!([txid, true]),
+            )
+            .await
+            {
+                Ok(tx_data) => {
+                    let confirmations = tx_data
+                        .get("confirmations")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0);
+                    let has_block = tx_data.get("blockhash").is_some();
+                    let (stage, stage_name): (u8, &str) = if has_block && confirmations >= 6 {
+                        (6, "confirmed")
+                    } else if has_block {
+                        (5, "mined")
+                    } else {
+                        (1, "mempool")
+                    };
+                    let mut detail = serde_json::json!({
+                        "fee": tx_data.get("fee"),
+                        "vsize": tx_data.get("vsize"),
+                        "size": tx_data.get("size"),
+                        "weight": tx_data.get("weight"),
+                        "version": tx_data.get("version"),
+                        "locktime": tx_data.get("locktime"),
+                        "vin": tx_data.get("vin"),
+                        "vout": tx_data.get("vout"),
+                    });
+                    if let Some(block_hash) = tx_data.get("blockhash") {
+                        detail["block_hash"] = block_hash.clone();
+                        detail["confirmations"] = serde_json::json!(confirmations);
+                        if let Some(bt) = tx_data.get("blocktime") {
+                            detail["blocktime"] = bt.clone();
+                        }
+                    }
+                    return Ok(serde_json::json!({
+                        "txid": txid,
+                        "stage": stage,
+                        "stage_name": stage_name,
+                        "detail": detail,
+                    }));
+                }
+                Err(e) => {
+                    warn!(txid = %txid, error = %e, "getrawtransaction failed in gettransactionstatus");
+                }
+            }
+        }
+
+        Ok(serde_json::json!({
+            "txid": txid,
+            "stage": 0,
+            "stage_name": "unknown",
+            "detail": {}
+        }))
+    }
+
+    async fn get_mempool_entries(&self, limit: u32) -> Result<Value, ErrorObjectOwned> {
+        info!(limit = %limit, "get_mempool_entries request received");
+
+        let rpc_config = self.bitcoin_rpc_config.as_ref().ok_or_else(|| {
+            ErrorObjectOwned::owned(
+                5,
+                "Bitcoin RPC not configured. Provide --rpcuser/--rpcpass to enable mempool queries.",
+                None::<()>,
+            )
+        })?;
+
+        let raw =
+            call_bitcoin_rpc_direct(rpc_config, "getrawmempool", &serde_json::json!([true]))
+                .await
+                .map_err(|e| {
+                    ErrorObjectOwned::owned(
+                        6,
+                        format!("Bitcoin RPC error: {}", e),
+                        None::<()>,
+                    )
+                })?;
+
+        let obj = raw.as_object().ok_or_else(|| {
+            ErrorObjectOwned::owned(2, "Unexpected getrawmempool response", None::<()>)
+        })?;
+
+        let mut entries: Vec<serde_json::Value> = obj
+            .iter()
+            .map(|(txid, entry)| {
+                let fee_btc = entry
+                    .get("fees")
+                    .and_then(|f| f.get("base"))
+                    .and_then(|v| v.as_f64())
+                    .or_else(|| entry.get("fee").and_then(|v| v.as_f64()))
+                    .unwrap_or(0.0);
+                let fee_sats = (fee_btc * 1e8).round() as u64;
+                let vsize = entry.get("vsize").and_then(|v| v.as_u64()).unwrap_or(0);
+                let fee_rate = if vsize > 0 {
+                    (fee_sats as f64 / vsize as f64 * 100.0).round() / 100.0
+                } else {
+                    0.0
+                };
+                let rbf = entry
+                    .get("bip125-replaceable")
+                    .and_then(|v| v.as_str())
+                    .map(|s| s == "yes")
+                    .unwrap_or(false);
+                serde_json::json!({
+                    "txid": txid,
+                    "fee": fee_sats,
+                    "vsize": vsize,
+                    "fee_rate": fee_rate,
+                    "time": entry.get("time").and_then(|v| v.as_u64()).unwrap_or(0),
+                    "rbf": rbf,
+                })
+            })
+            .collect();
+
+        entries.sort_by(|a, b| {
+            let ta = a.get("time").and_then(|v| v.as_u64()).unwrap_or(0);
+            let tb = b.get("time").and_then(|v| v.as_u64()).unwrap_or(0);
+            tb.cmp(&ta)
+        });
+        entries.truncate(limit as usize);
+
+        serde_json::to_value(entries).map_err(|e| {
+            ErrorObjectOwned::owned(2, format!("Serialization error: {}", e), None::<()>)
+        })
+    }
+
+    async fn get_committed_transactions(
+        &self,
+        page: u32,
+        page_size: u32,
+    ) -> Result<Value, ErrorObjectOwned> {
+        info!(page = %page, page_size = %page_size, "get_committed_transactions request received");
+
+        let braid = self.braid_arc.read().await;
+        let mut all_entries: Vec<serde_json::Value> = Vec::new();
+
+        for bead in braid.beads.iter().rev() {
+            let bead_hash = bead.block_header.block_hash().to_string();
+            let timestamp = bead.committed_metadata.start_timestamp.to_consensus_u32();
+            for txid in &bead.committed_metadata.transaction_ids.0 {
+                all_entries.push(serde_json::json!({
+                    "txid": txid.to_string(),
+                    "bead_hash": bead_hash,
+                    "timestamp": timestamp,
+                }));
+            }
+        }
+
+        let total = all_entries.len();
+        let start = (page * page_size) as usize;
+        let end = (start + page_size as usize).min(total);
+        let page_entries: Vec<serde_json::Value> = if start < total {
+            all_entries[start..end].to_vec()
+        } else {
+            Vec::new()
+        };
+
+        Ok(serde_json::json!({
+            "total": total,
+            "page": page,
+            "page_size": page_size,
+            "transactions": page_entries,
+        }))
+    }
+
     async fn bitcoin_proxy(
         &self,
         method: String,
         params: serde_json::Value,
     ) -> Result<serde_json::Value, ErrorObjectOwned> {
         info!(method = %method, "bitcoin_proxy request received");
+
+        const ALLOWED: &[&str] = &[
+            "getrawmempool",
+            "getrawtransaction",
+            "getblockcount",
+            "getmempoolentry",
+            "getblocktemplate",
+            "getblockchaininfo",
+            "getblock",
+        ];
+        if !ALLOWED.contains(&method.as_str()) {
+            return Err(ErrorObjectOwned::owned(
+                7,
+                format!("bitcoinproxy: method '{}' is not permitted", method),
+                None::<()>,
+            ));
+        }
 
         let rpc_config = self.bitcoin_rpc_config.as_ref().ok_or_else(|| {
             ErrorObjectOwned::owned(

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -1081,7 +1081,8 @@ impl RpcServer for RpcServerImpl {
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0);
                     let has_block = tx_data.get("blockhash").is_some();
-                    let (btc_stage, btc_stage_name): (u8, &str) = if has_block && confirmations >= 6 {
+                    let (btc_stage, btc_stage_name): (u8, &str) = if has_block && confirmations >= 6
+                    {
                         (6, "confirmed")
                     } else if has_block {
                         (5, "mined")

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -1030,25 +1030,7 @@ impl RpcServer for RpcServerImpl {
     async fn get_transaction_status(&self, txid: String) -> Result<Value, ErrorObjectOwned> {
         info!(txid = %txid, "get_transaction_status request received");
 
-        // Stage 2: txid is in the current block template (staged for next share/block)
-        {
-            let template = self.latest_block.lock().await;
-            let in_template = template
-                .transactions
-                .iter()
-                .skip(1) // skip coinbase
-                .any(|tx| tx.compute_txid().to_string() == txid);
-            if in_template {
-                return Ok(serde_json::json!({
-                    "txid": txid,
-                    "stage": 2,
-                    "stage_name": "staged",
-                    "detail": {}
-                }));
-            }
-        }
-
-        // Stage 3: txid committed in a bead
+        // Parse first so all checks use the canonical Txid type (avoids case mismatch).
         let txid_parsed = txid.parse::<Txid>().map_err(|_| {
             ErrorObjectOwned::owned(
                 1,
@@ -1056,19 +1038,35 @@ impl RpcServer for RpcServerImpl {
                 None::<()>,
             )
         })?;
+        let mut best_stage: u8 = 0;
+        let mut best_stage_name = "unknown";
+        let mut best_detail = serde_json::json!({});
+
+        // Stage 3: txid committed in a bead.
         {
             let braid = self.braid_arc.read().await;
             if let Some(bead_hash) = braid.txid_to_bead.get(&txid_parsed) {
-                return Ok(serde_json::json!({
-                    "txid": txid,
-                    "stage": 3,
-                    "stage_name": "committed",
-                    "detail": { "bead_hash": bead_hash.to_string() }
-                }));
+                best_stage = 3;
+                best_stage_name = "committed";
+                best_detail = serde_json::json!({ "bead_hash": bead_hash.to_string() });
             }
         }
 
-        // Stages 1, 5, 6: query Bitcoin Core via getrawtransaction
+        // Stage 2: txid is in the current block template (staged for next share/block).
+        if best_stage < 2 {
+            let template = self.latest_block.lock().await;
+            let in_template = template
+                .transactions
+                .iter()
+                .skip(1) // skip coinbase
+                .any(|tx| tx.compute_txid() == txid_parsed);
+            if in_template {
+                best_stage = 2;
+                best_stage_name = "staged";
+                best_detail = serde_json::json!({});
+            }
+        }
+
         if let Some(rpc_config) = &self.bitcoin_rpc_config {
             match call_bitcoin_rpc_direct(
                 rpc_config,
@@ -1083,36 +1081,35 @@ impl RpcServer for RpcServerImpl {
                         .and_then(|v| v.as_u64())
                         .unwrap_or(0);
                     let has_block = tx_data.get("blockhash").is_some();
-                    let (stage, stage_name): (u8, &str) = if has_block && confirmations >= 6 {
+                    let (btc_stage, btc_stage_name): (u8, &str) = if has_block && confirmations >= 6 {
                         (6, "confirmed")
                     } else if has_block {
                         (5, "mined")
                     } else {
                         (1, "mempool")
                     };
-                    let mut detail = serde_json::json!({
-                        "fee": tx_data.get("fee"),
-                        "vsize": tx_data.get("vsize"),
-                        "size": tx_data.get("size"),
-                        "weight": tx_data.get("weight"),
-                        "version": tx_data.get("version"),
-                        "locktime": tx_data.get("locktime"),
-                        "vin": tx_data.get("vin"),
-                        "vout": tx_data.get("vout"),
-                    });
-                    if let Some(block_hash) = tx_data.get("blockhash") {
-                        detail["block_hash"] = block_hash.clone();
-                        detail["confirmations"] = serde_json::json!(confirmations);
-                        if let Some(bt) = tx_data.get("blocktime") {
-                            detail["blocktime"] = bt.clone();
+                    if btc_stage > best_stage {
+                        best_stage = btc_stage;
+                        best_stage_name = btc_stage_name;
+                        let mut detail = serde_json::json!({
+                            "fee": tx_data.get("fee"),
+                            "vsize": tx_data.get("vsize"),
+                            "size": tx_data.get("size"),
+                            "weight": tx_data.get("weight"),
+                            "version": tx_data.get("version"),
+                            "locktime": tx_data.get("locktime"),
+                            "vin": tx_data.get("vin"),
+                            "vout": tx_data.get("vout"),
+                        });
+                        if let Some(block_hash) = tx_data.get("blockhash") {
+                            detail["block_hash"] = block_hash.clone();
+                            detail["confirmations"] = serde_json::json!(confirmations);
+                            if let Some(bt) = tx_data.get("blocktime") {
+                                detail["blocktime"] = bt.clone();
+                            }
                         }
+                        best_detail = detail;
                     }
-                    return Ok(serde_json::json!({
-                        "txid": txid,
-                        "stage": stage,
-                        "stage_name": stage_name,
-                        "detail": detail,
-                    }));
                 }
                 Err(e) => {
                     warn!(txid = %txid, error = %e, "getrawtransaction failed in gettransactionstatus");
@@ -1122,9 +1119,9 @@ impl RpcServer for RpcServerImpl {
 
         Ok(serde_json::json!({
             "txid": txid,
-            "stage": 0,
-            "stage_name": "unknown",
-            "detail": {}
+            "stage": best_stage,
+            "stage_name": best_stage_name,
+            "detail": best_detail,
         }))
     }
 
@@ -1167,8 +1164,10 @@ impl RpcServer for RpcServerImpl {
                 };
                 let rbf = entry
                     .get("bip125-replaceable")
-                    .and_then(|v| v.as_str())
-                    .map(|s| s == "yes")
+                    .map(|v| {
+                        v.as_bool()
+                            .unwrap_or_else(|| v.as_str().map(|s| s == "yes").unwrap_or(false))
+                    })
                     .unwrap_or(false);
                 serde_json::json!({
                     "txid": txid,
@@ -1199,30 +1198,30 @@ impl RpcServer for RpcServerImpl {
         page_size: u32,
     ) -> Result<Value, ErrorObjectOwned> {
         info!(page = %page, page_size = %page_size, "get_committed_transactions request received");
+        let page_size_usize = page_size as usize;
+        let start = (page as usize).saturating_mul(page_size_usize);
+        let end = start.saturating_add(page_size_usize);
 
         let braid = self.braid_arc.read().await;
-        let mut all_entries: Vec<serde_json::Value> = Vec::new();
+        let mut total: usize = 0;
+        let mut page_entries: Vec<serde_json::Value> = Vec::new();
 
+        // Iterate once: count total and collect only the requested window.
         for bead in braid.beads.iter().rev() {
             let bead_hash = bead.block_header.block_hash().to_string();
             let timestamp = bead.committed_metadata.start_timestamp.to_consensus_u32();
             for txid in &bead.committed_metadata.transaction_ids.0 {
-                all_entries.push(serde_json::json!({
-                    "txid": txid.to_string(),
-                    "bead_hash": bead_hash,
-                    "timestamp": timestamp,
-                }));
+                if total >= start && total < end {
+                    page_entries.push(serde_json::json!({
+                        "txid": txid.to_string(),
+                        "bead_hash": bead_hash,
+                        "timestamp": timestamp,
+                    }));
+                }
+                total += 1;
             }
         }
-
-        let total = all_entries.len();
-        let start = (page * page_size) as usize;
-        let end = (start + page_size as usize).min(total);
-        let page_entries: Vec<serde_json::Value> = if start < total {
-            all_entries[start..end].to_vec()
-        } else {
-            Vec::new()
-        };
+        drop(braid);
 
         Ok(serde_json::json!({
             "total": total,
@@ -1247,6 +1246,7 @@ impl RpcServer for RpcServerImpl {
             "getblocktemplate",
             "getblockchaininfo",
             "getblock",
+            "getblockhash",
         ];
         if !ALLOWED.contains(&method.as_str()) {
             return Err(ErrorObjectOwned::owned(

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -1139,16 +1139,11 @@ impl RpcServer for RpcServerImpl {
             )
         })?;
 
-        let raw =
-            call_bitcoin_rpc_direct(rpc_config, "getrawmempool", &serde_json::json!([true]))
-                .await
-                .map_err(|e| {
-                    ErrorObjectOwned::owned(
-                        6,
-                        format!("Bitcoin RPC error: {}", e),
-                        None::<()>,
-                    )
-                })?;
+        let raw = call_bitcoin_rpc_direct(rpc_config, "getrawmempool", &serde_json::json!([true]))
+            .await
+            .map_err(|e| {
+                ErrorObjectOwned::owned(6, format!("Bitcoin RPC error: {}", e), None::<()>)
+            })?;
 
         let obj = raw.as_object().ok_or_else(|| {
             ErrorObjectOwned::owned(2, "Unexpected getrawmempool response", None::<()>)

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -25,6 +25,8 @@ use jsonrpsee::types::Request;
 use jsonrpsee::ConnectionId;
 use jsonrpsee::PendingSubscriptionSink;
 use serde::{Deserialize, Serialize};
+use tower::ServiceBuilder;
+use tower_http::cors::CorsLayer;
 use serde_json;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -33,7 +35,7 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, watch, RwLock};
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
 
 #[cfg(test)]
 use {
@@ -1068,13 +1070,16 @@ impl RpcServer for RpcServerImpl {
         }
 
         if let Some(rpc_config) = &self.bitcoin_rpc_config {
-            match call_bitcoin_rpc_direct(
+            // Map the error to String immediately so getrawtx_result is
+            // Result<JsonValue, String> — fully Send — before any further .await.
+            let getrawtx_result = call_bitcoin_rpc_direct(
                 rpc_config,
                 "getrawtransaction",
                 &serde_json::json!([txid, true]),
             )
             .await
-            {
+            .map_err(|e| e.to_string());
+            let needs_wallet_fallback = match getrawtx_result {
                 Ok(tx_data) => {
                     let confirmations = tx_data
                         .get("confirmations")
@@ -1111,9 +1116,67 @@ impl RpcServer for RpcServerImpl {
                         }
                         best_detail = detail;
                     }
+                    false
                 }
                 Err(e) => {
-                    warn!(txid = %txid, error = %e, "getrawtransaction failed in gettransactionstatus");
+                    debug!(txid = %txid, error = %e, "getrawtransaction unavailable; trying gettransaction wallet fallback");
+                    true 
+                }
+            };
+            if needs_wallet_fallback {
+                match call_bitcoin_rpc_direct(
+                    rpc_config,
+                    "gettransaction",
+                    &serde_json::json!([txid, true]),
+                )
+                .await
+                {
+                    Ok(wallet_tx) => {
+                        let confirmations = wallet_tx
+                            .get("confirmations")
+                            .and_then(|v| v.as_u64())
+                            .unwrap_or(0);
+                        let has_block = wallet_tx.get("blockhash").is_some();
+                        let (btc_stage, btc_stage_name): (u8, &str) =
+                            if has_block && confirmations >= 6 {
+                                (6, "confirmed")
+                            } else if has_block {
+                                (5, "mined")
+                            } else {
+                                (1, "mempool")
+                            };
+                        if btc_stage > best_stage {
+                            best_stage = btc_stage;
+                            best_stage_name = btc_stage_name;
+                            let mut detail = serde_json::json!({
+                                "fee": wallet_tx.get("fee"),
+                            });
+                            if let Some(block_hash) = wallet_tx.get("blockhash") {
+                                detail["block_hash"] = block_hash.clone();
+                                detail["confirmations"] =
+                                    serde_json::json!(confirmations);
+                                if let Some(bh) = wallet_tx.get("blockheight") {
+                                    detail["blockheight"] = bh.clone();
+                                }
+                                if let Some(bt) = wallet_tx.get("blocktime") {
+                                    detail["blocktime"] = bt.clone();
+                                }
+                            }
+                            best_detail = detail;
+                        }
+                    }
+                    Err(e2) => {
+                        let e2_str = e2.to_string();
+                        // Connection refused / unreachable = Bitcoin Core not running.
+                        // Log at debug to avoid spam; warn only for unexpected errors.
+                        if e2_str.contains("Connection refused")
+                            || e2_str.contains("error sending request")
+                        {
+                            debug!(txid = %txid, error = %e2_str, "gettransaction wallet fallback failed: Bitcoin Core unreachable");
+                        } else {
+                            warn!(txid = %txid, error = %e2_str, "gettransaction wallet fallback also failed in gettransactionstatus");
+                        }
+                    }
                 }
             }
         }
@@ -1361,8 +1424,10 @@ pub async fn run_rpc_server(
     let rpc_middleware =
         jsonrpsee::server::middleware::rpc::RpcServiceBuilder::new().layer_fn(LoggingMiddleware);
     //building the context/server supporting the http transport and ws
+    let cors = CorsLayer::permissive();
     let server = jsonrpsee::server::Server::builder()
         .set_rpc_middleware(rpc_middleware)
+        .set_http_middleware(ServiceBuilder::new().layer(cors))
         .build(bind_address)
         .await
         .map_err(|e| {

--- a/node/src/rpc_server.rs
+++ b/node/src/rpc_server.rs
@@ -25,8 +25,6 @@ use jsonrpsee::types::Request;
 use jsonrpsee::ConnectionId;
 use jsonrpsee::PendingSubscriptionSink;
 use serde::{Deserialize, Serialize};
-use tower::ServiceBuilder;
-use tower_http::cors::CorsLayer;
 use serde_json;
 use serde_json::Value;
 use std::collections::HashMap;
@@ -35,6 +33,8 @@ use std::future::Future;
 use std::net::SocketAddr;
 use std::sync::Arc;
 use tokio::sync::{mpsc, oneshot, watch, RwLock};
+use tower::ServiceBuilder;
+use tower_http::cors::CorsLayer;
 use tracing::{debug, error, info, warn};
 
 #[cfg(test)]
@@ -1120,7 +1120,7 @@ impl RpcServer for RpcServerImpl {
                 }
                 Err(e) => {
                     debug!(txid = %txid, error = %e, "getrawtransaction unavailable; trying gettransaction wallet fallback");
-                    true 
+                    true
                 }
             };
             if needs_wallet_fallback {
@@ -1153,8 +1153,7 @@ impl RpcServer for RpcServerImpl {
                             });
                             if let Some(block_hash) = wallet_tx.get("blockhash") {
                                 detail["block_hash"] = block_hash.clone();
-                                detail["confirmations"] =
-                                    serde_json::json!(confirmations);
+                                detail["confirmations"] = serde_json::json!(confirmations);
                                 if let Some(bh) = wallet_tx.get("blockheight") {
                                     detail["blockheight"] = bh.clone();
                                 }

--- a/node/src/utils/test_utils.rs
+++ b/node/src/utils/test_utils.rs
@@ -121,6 +121,7 @@ pub mod test_utility_functions {
                 cohorts: current_bead_cohorots,
                 cohort_tips: vec![HashSet::new()], // Cohorts tips are only used in extend(), so we can skip them here.
                 orphan_beads: Vec::new(),
+                txid_to_bead: HashMap::new(),
             },
             file_braid.clone(),
         )


### PR DESCRIPTION
## Pull Request Overview

This PR extends the Braidpool node's JSON-RPC interface to expose transaction and mempool information needed by the dashboard. It also partially removes the dashboard's dependency on external mempool APIs by connecting it to the node's RPC endpoints.

### Changes
* Update the dashboard to use the new node RPCs for transaction and mempool data where applicable.
* Add transaction stage information, filtering, and manual txid lookup to the dashboard.
* Improve transaction dialogues and handling of missing/RPC failure states.
* Add `tower` and `tower-http` with CORS support to the RPC server.

Overall, this connects the dashboard more closely with the Braidpool node and reduces its reliance on external mempool APIs for transaction monitoring.
This PR is dependent on PR #515.