### PR TITLE
Worker name parsing for payout address of miner

### DIFF
--- a/braidpool-common/src/error.rs
+++ b/braidpool-common/src/error.rs
@@ -14,7 +14,7 @@ impl fmt::Display for ParseCpunetError {
 impl std::error::Error for ParseCpunetError {}
 
 /// Error type for cpunet address operations.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum CpunetAddressError {
     /// Bech32 decoding error
     Bech32(bech32::segwit::DecodeError),

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -3,6 +3,7 @@ use crate::stratum::{BlockTemplate, JobDetails};
 use crate::utils::BeadHash;
 use crate::TemplateId;
 use bitcoin::address::ParseError as AddressParseError;
+use braidpool_common::error::CpunetAddressError;
 use std::{fmt, path::PathBuf};
 use tokio::sync::oneshot;
 
@@ -165,8 +166,17 @@ impl fmt::Display for DBErrors {
 }
 #[derive(Debug, PartialEq)]
 pub enum UsernameValidationError {
-    NetworkIncompatibleAddress { network: String },
-    InvalidAddress { address: String },
+    NetworkIncompatibleAddress {
+        network: String,
+    },
+    InvalidAddress {
+        address: String,
+    },
+    /// The payout address decoded as bech32 but is not a valid cpunet address.
+    InvalidCpunetAddress {
+        address: String,
+        error: CpunetAddressError,
+    },
 }
 
 #[derive(Debug)]
@@ -267,6 +277,13 @@ impl fmt::Display for StratumErrors {
                 }
                 UsernameValidationError::InvalidAddress { address } => {
                     write!(f,"The provided payout address could not be parsed into a valid bitcoin payout address - {}",address)
+                }
+                UsernameValidationError::InvalidCpunetAddress { address, error } => {
+                    write!(
+                        f,
+                        "The provided payout address {} could not be parsed into a valid cpunet payout address - {}",
+                        address, error
+                    )
                 }
             },
             StratumErrors::ErrorFetchingCurrentUNIXTimestamp { error } => {

--- a/node/src/error.rs
+++ b/node/src/error.rs
@@ -163,8 +163,17 @@ impl fmt::Display for DBErrors {
         }
     }
 }
+#[derive(Debug, PartialEq)]
+pub enum UsernameValidationError {
+    NetworkIncompatibleAddress { network: String },
+    InvalidAddress { address: String },
+}
+
 #[derive(Debug)]
 pub enum StratumErrors {
+    UserNameParseError {
+        error: UsernameValidationError,
+    },
     InvalidMethod {
         method: String,
     },
@@ -252,6 +261,14 @@ pub enum StratumResponseErrors {}
 impl fmt::Display for StratumErrors {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
+            StratumErrors::UserNameParseError { error } => match error {
+                UsernameValidationError::NetworkIncompatibleAddress { network } => {
+                    write!(f,"The provided payout address is not compatible with the configured network - {}",network)
+                }
+                UsernameValidationError::InvalidAddress { address } => {
+                    write!(f,"The provided payout address could not be parsed into a valid bitcoin payout address - {}",address)
+                }
+            },
             StratumErrors::ErrorFetchingCurrentUNIXTimestamp { error } => {
                 write!(
                     f,

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -271,7 +271,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let stratum_config = StratumServerConfig {
         audit_mode: args.audit,
         audit_miner_difficulty: args.miner_difficulty,
-        network_name: network,
         ..Default::default()
     };
     let (block_submission_tx, block_submission_rx) =

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -271,6 +271,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     let stratum_config = StratumServerConfig {
         audit_mode: args.audit,
         audit_miner_difficulty: args.miner_difficulty,
+        network_name: network,
         ..Default::default()
     };
     let (block_submission_tx, block_submission_rx) =

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1,6 +1,7 @@
 use crate::config::PoolNetwork;
 use crate::error::StratumErrors;
 use crate::template_creator::calculate_merkle_root;
+use crate::utils::validate;
 use crate::utils::compute_block_hash;
 use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
 use bitcoin::absolute::Time;
@@ -8,7 +9,7 @@ use bitcoin::consensus::{serialize, Decodable};
 use bitcoin::hashes::Hash;
 use bitcoin::io::Cursor;
 use bitcoin::Transaction;
-use bitcoin::{block::Header as BlockHeader, BlockHash, TxMerkleNode, Txid, Witness};
+use bitcoin::{block::Header as BlockHeader, BlockHash, Network, TxMerkleNode, Txid, Witness};
 use futures::{lock::Mutex, FutureExt};
 use num::ToPrimitive;
 use rand::RngCore;
@@ -127,6 +128,8 @@ pub struct StratumServerConfig {
     pub audit_mode: bool,
     /// Audit mode miner weak difficulty
     pub audit_miner_difficulty: Option<f64>,
+    /// Network name (e.g., "main", "testnet", "cpunet") for network-specific PoW validation
+    pub network_name: Network,
 }
 
 impl Default for StratumServerConfig {
@@ -140,6 +143,7 @@ impl Default for StratumServerConfig {
             solo_address: None,
             audit_mode: false,
             audit_miner_difficulty: None,
+            network_name: Network::CPUNet,
         }
     }
 }
@@ -543,6 +547,19 @@ impl DownstreamClient {
         let worker_name = match worker_name_res {
             Ok(name) => name,
             Err(error) => return Err(error),
+        };
+        //Parsing payout address from worker name
+        let payout_address = match validate(worker_name, self.network_type) {
+            Ok((address, _worker)) => address.to_string(),
+            Err(e) => {
+                error!(
+                    connection_id = %connection_id_hex,
+                    worker = %worker_name,
+                    error = %e,
+                    "Worker payout address validation failed"
+                );
+                return Err(e);
+            }
         };
         debug!(
             connection_id = %connection_id_hex,
@@ -997,7 +1014,7 @@ impl DownstreamClient {
                 extranonce_2_raw_value,
                 &self.downstream_ip,
                 submitted_job.job_sent_time,
-                worker_name,
+                &payout_address,
                 extranonce_1_raw_value,
             )
             .await
@@ -1942,6 +1959,7 @@ impl DownstreamClient {
             is_proxy_mode: false,
             payout_address: None,
             audit_miner_difficulty: None,
+            network_type: Network::CPUNet,
         }
     }
 }
@@ -4562,7 +4580,7 @@ mod test {
         let valid_nonce_hex = format!("{:08x}", valid_nonce);
 
         let test_submit_request_params = json!([
-            "bitaxe",
+            "tc1qu3cdq9unyhdc3d2hw8mvpfgnnhvp6ucckkl6ft.bitaxe",
             numeric_job_id.to_string(),
             "0000000003000000",
             "68df7e33",
@@ -4660,7 +4678,7 @@ mod test {
     async fn non_hex_ntime_returns_err_before_coinbase_work() {
         let (mut client, map, swarm, job_id) = submit_setup().await;
         let params = json!([
-            "miner",
+            "tc1qu3cdq9unyhdc3d2hw8mvpfgnnhvp6ucckkl6ft.worker1",
             job_id.to_string(),
             "0000000000000000", // extranonce2
             "zzzzzzzz",         // invalid ntime — not hex

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -1,15 +1,15 @@
 use crate::config::PoolNetwork;
 use crate::error::StratumErrors;
 use crate::template_creator::calculate_merkle_root;
-use crate::utils::validate;
 use crate::utils::compute_block_hash;
+use crate::utils::validate;
 use crate::{SwarmHandler, TemplateId, EXTRANONCE1_SIZE, EXTRANONCE2_SIZE, EXTRANONCE_SEPARATOR};
 use bitcoin::absolute::Time;
 use bitcoin::consensus::{serialize, Decodable};
 use bitcoin::hashes::Hash;
 use bitcoin::io::Cursor;
 use bitcoin::Transaction;
-use bitcoin::{block::Header as BlockHeader, BlockHash, Network, TxMerkleNode, Txid, Witness};
+use bitcoin::{block::Header as BlockHeader, BlockHash, TxMerkleNode, Txid, Witness};
 use futures::{lock::Mutex, FutureExt};
 use num::ToPrimitive;
 use rand::RngCore;
@@ -128,8 +128,6 @@ pub struct StratumServerConfig {
     pub audit_mode: bool,
     /// Audit mode miner weak difficulty
     pub audit_miner_difficulty: Option<f64>,
-    /// Network name (e.g., "main", "testnet", "cpunet") for network-specific PoW validation
-    pub network_name: Network,
 }
 
 impl Default for StratumServerConfig {
@@ -143,7 +141,6 @@ impl Default for StratumServerConfig {
             solo_address: None,
             audit_mode: false,
             audit_miner_difficulty: None,
-            network_name: Network::CPUNet,
         }
     }
 }
@@ -549,7 +546,7 @@ impl DownstreamClient {
             Err(error) => return Err(error),
         };
         //Parsing payout address from worker name
-        let payout_address = match validate(worker_name, self.network_type) {
+        let payout_address = match validate(worker_name, self.network) {
             Ok((address, _worker)) => address.to_string(),
             Err(e) => {
                 error!(
@@ -1959,7 +1956,6 @@ impl DownstreamClient {
             is_proxy_mode: false,
             payout_address: None,
             audit_miner_difficulty: None,
-            network_type: Network::CPUNet,
         }
     }
 }

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -7,6 +7,11 @@ use crate::{
     uncommitted_metadata::UnCommittedMetadata,
 };
 use ::bitcoin::BlockHash;
+use bitcoin::base58;
+use bitcoin::constants::{
+    PUBKEY_ADDRESS_PREFIX_MAIN, PUBKEY_ADDRESS_PREFIX_TEST, SCRIPT_ADDRESS_PREFIX_MAIN,
+    SCRIPT_ADDRESS_PREFIX_TEST,
+};
 use bitcoin::{
     absolute::Time,
     block::{Header as BlockHeader, Version as BlockVersion},
@@ -14,6 +19,7 @@ use bitcoin::{
     hashes::Hash,
     secp256k1, CompactTarget, EcdsaSighashType, TxMerkleNode,
 };
+use braidpool_common::{cpunet::Cpunet, error::CpunetAddressError};
 // Standard Imports
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
@@ -46,31 +52,81 @@ pub fn compute_block_hash(block_header: &BlockHeader, network: PoolNetwork) -> B
 //Validation for usernames and parsing the payout_address for the downstream connected
 pub fn validate(
     username: &str,
-    network: bitcoin::Network,
+    network: PoolNetwork,
 ) -> Result<(&str, Option<&str>), StratumErrors> {
     let parts: Vec<&str> = username.splitn(2, '.').collect();
     let address_part = parts[0];
-    let address = address_part.parse::<bitcoin::Address<_>>().map_err(|_e| {
-        StratumErrors::UserNameParseError {
-            error: crate::error::UsernameValidationError::InvalidAddress {
-                address: address_part.to_string(),
-            },
+    // Worker name is the optional suffix after the first '.'
+    let worker = parts.get(1).copied();
+    match network {
+        PoolNetwork::Bitcoin(network) => {
+            let address = address_part.parse::<bitcoin::Address<_>>().map_err(|_e| {
+                StratumErrors::UserNameParseError {
+                    error: crate::error::UsernameValidationError::InvalidAddress {
+                        address: address_part.to_string(),
+                    },
+                }
+            })?;
+
+            address
+                .require_network(network)
+                .map_err(|_| StratumErrors::UserNameParseError {
+                    error: crate::error::UsernameValidationError::NetworkIncompatibleAddress {
+                        network: network.to_string(),
+                    },
+                })?;
+
+            Ok((address_part, worker))
         }
-    })?;
+        PoolNetwork::Cpunet => {
+            match Cpunet::decode_bech32_address(address_part) {
+                Ok(_) => return Ok((address_part, worker)),
+                Err(CpunetAddressError::Bech32(_)) => {}
+                Err(error) => {
+                    return Err(StratumErrors::UserNameParseError {
+                        error: crate::error::UsernameValidationError::InvalidCpunetAddress {
+                            address: address_part.to_string(),
+                            error,
+                        },
+                    });
+                }
+            }
 
-    address
-        .require_network(network)
-        .map_err(|_| StratumErrors::UserNameParseError {
-            error: crate::error::UsernameValidationError::NetworkIncompatibleAddress {
-                network: network.to_string(),
-            },
-        })?;
+            if address_part.len() > 50 {
+                return Err(StratumErrors::UserNameParseError {
+                    error: crate::error::UsernameValidationError::InvalidAddress {
+                        address: address_part.to_string(),
+                    },
+                });
+            }
+            let data = base58::decode_check(address_part).map_err(|_| {
+                StratumErrors::UserNameParseError {
+                    error: crate::error::UsernameValidationError::InvalidAddress {
+                        address: address_part.to_string(),
+                    },
+                }
+            })?;
+            if data.len() != 21 {
+                return Err(StratumErrors::UserNameParseError {
+                    error: crate::error::UsernameValidationError::InvalidAddress {
+                        address: address_part.to_string(),
+                    },
+                });
+            }
 
-    // Extract worker name if present
-    if parts.len() > 1 {
-        Ok((address_part, Some(parts[1])))
-    } else {
-        Ok((address_part, None))
+            let (prefix, _) = data.split_first().expect("length checked above");
+            match *prefix {
+                PUBKEY_ADDRESS_PREFIX_MAIN
+                | PUBKEY_ADDRESS_PREFIX_TEST
+                | SCRIPT_ADDRESS_PREFIX_MAIN
+                | SCRIPT_ADDRESS_PREFIX_TEST => Ok((address_part, worker)),
+                _ => Err(StratumErrors::UserNameParseError {
+                    error: crate::error::UsernameValidationError::InvalidAddress {
+                        address: address_part.to_string(),
+                    },
+                }),
+            }
+        }
     }
 }
 
@@ -276,7 +332,7 @@ mod tests {
     #[test]
     fn valid_address_with_worker() {
         let username = "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7.worker1";
-        let result = validate(username, Network::Bitcoin);
+        let result = validate(username, PoolNetwork::Bitcoin(Network::Bitcoin));
 
         assert!(result.is_ok());
 
@@ -288,7 +344,7 @@ mod tests {
     #[test]
     fn invalid_bitcoin_address() {
         let username = "not_a_valid_address.worker";
-        let result = validate(username, Network::Bitcoin);
+        let result = validate(username, PoolNetwork::Bitcoin(Network::Bitcoin));
 
         assert!(result.is_err());
 
@@ -309,7 +365,7 @@ mod tests {
     fn network_incompatible_address() {
         // Mainnet address checked against Testnet
         let username = "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7";
-        let result = validate(username, Network::Testnet(bitcoin::TestnetVersion::V4));
+        let result = validate(username, PoolNetwork::Bitcoin(Network::Testnet4));
 
         assert!(result.is_err());
 
@@ -325,6 +381,63 @@ mod tests {
             _ => panic!("Expected UserNameParseError for network mismatch"),
         }
     }
+    #[test]
+    fn valid_cpunet_address_with_worker() {
+        let address = Cpunet::encode_bech32_address(
+            &bitcoin::WitnessProgram::new(bitcoin::WitnessVersion::V0, &[0u8; 20])
+                .expect("valid witness program"),
+        );
+        let username = format!("{}.worker1", address);
+        let result = validate(&username, PoolNetwork::Cpunet);
+
+        assert!(result.is_ok());
+
+        let (payout_address, worker) = result.unwrap();
+        assert_eq!(payout_address, address);
+        assert_eq!(worker, Some("worker1"));
+    }
+
+    #[test]
+    fn cpunet_rejects_bitcoin_segwit_address() {
+        // Mainnet HRP checked against cpunet
+        let username = "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7.worker1";
+        let result = validate(username, PoolNetwork::Cpunet);
+
+        match result {
+            Err(StratumErrors::UserNameParseError { error }) => {
+                assert_eq!(
+                    error,
+                    UsernameValidationError::InvalidCpunetAddress {
+                        address: "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7".to_string(),
+                        error: CpunetAddressError::WrongNetwork {
+                            expected: "tc".to_string(),
+                            found: "bc".to_string(),
+                        },
+                    }
+                )
+            }
+            _ => panic!("Expected UserNameParseError for a non cpunet segwit address"),
+        }
+    }
+
+    #[test]
+    fn cpunet_rejects_malformed_address() {
+        let username = "not_a_valid_address.worker";
+        let result = validate(username, PoolNetwork::Cpunet);
+
+        match result {
+            Err(StratumErrors::UserNameParseError { error }) => {
+                assert_eq!(
+                    error,
+                    UsernameValidationError::InvalidAddress {
+                        address: "not_a_valid_address".to_string()
+                    }
+                )
+            }
+            _ => panic!("Expected UserNameParseError for an unparseable address"),
+        }
+    }
+
     #[test]
     fn server_endpoints_returns_single_endpoint_for_specific_host() {
         let result = server_endpoints("127.0.0.1", 8080, "http");

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -3,6 +3,7 @@ use crate::config::PoolNetwork;
 use crate::{
     bead::Bead,
     committed_metadata::{CommittedMetadata, TimeVec, TxIdVec},
+    error::StratumErrors,
     uncommitted_metadata::UnCommittedMetadata,
 };
 use ::bitcoin::BlockHash;
@@ -40,6 +41,37 @@ use std::{
 /// Computes a bead's block hash under the rules of `network`.
 pub fn compute_block_hash(block_header: &BlockHeader, network: PoolNetwork) -> BlockHash {
     network.block_hash(block_header)
+}
+
+//Validation for usernames and parsing the payout_address for the downstream connected
+pub fn validate(
+    username: &str,
+    network: bitcoin::Network,
+) -> Result<(&str, Option<&str>), StratumErrors> {
+    let parts: Vec<&str> = username.splitn(2, '.').collect();
+    let address_part = parts[0];
+    let address = address_part.parse::<bitcoin::Address<_>>().map_err(|_e| {
+        StratumErrors::UserNameParseError {
+            error: crate::error::UsernameValidationError::InvalidAddress {
+                address: address_part.to_string(),
+            },
+        }
+    })?;
+
+    address
+        .require_network(network)
+        .map_err(|_| StratumErrors::UserNameParseError {
+            error: crate::error::UsernameValidationError::NetworkIncompatibleAddress {
+                network: network.to_string(),
+            },
+        })?;
+
+    // Extract worker name if present
+    if parts.len() > 1 {
+        Ok((address_part, Some(parts[1])))
+    } else {
+        Ok((address_part, None))
+    }
 }
 
 /// Get list of actual local IPv4 addresses for servers binding to 0.0.0.0
@@ -187,6 +219,10 @@ pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
 
 #[cfg(test)]
 mod tests {
+    use bitcoin::Network;
+
+    use crate::error::UsernameValidationError;
+
     use super::*;
     fn unique_temp_test_path(label: &str) -> PathBuf {
         let suffix = rand::random::<u8>();
@@ -237,6 +273,58 @@ mod tests {
         let _ = fs::remove_file(&file_path);
     }
 
+    #[test]
+    fn valid_address_with_worker() {
+        let username = "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7.worker1";
+        let result = validate(username, Network::Bitcoin);
+
+        assert!(result.is_ok());
+
+        let (address, worker) = result.unwrap();
+        assert_eq!(address, "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7");
+        assert_eq!(worker, Some("worker1"));
+    }
+
+    #[test]
+    fn invalid_bitcoin_address() {
+        let username = "not_a_valid_address.worker";
+        let result = validate(username, Network::Bitcoin);
+
+        assert!(result.is_err());
+
+        match result {
+            Err(StratumErrors::UserNameParseError { error }) => {
+                assert_eq!(
+                    error,
+                    UsernameValidationError::InvalidAddress {
+                        address: "not_a_valid_address".to_string()
+                    }
+                )
+            }
+            _ => panic!("Expected UserNameParseError for invalid address"),
+        }
+    }
+
+    #[test]
+    fn network_incompatible_address() {
+        // Mainnet address checked against Testnet
+        let username = "bc1qpa77defz30uavu8lxef98q95rae6m7t8au9vp7";
+        let result = validate(username, Network::Testnet(bitcoin::TestnetVersion::V4));
+
+        assert!(result.is_err());
+
+        match result {
+            Err(StratumErrors::UserNameParseError { error }) => {
+                assert_eq!(
+                    error,
+                    UsernameValidationError::NetworkIncompatibleAddress {
+                        network: "testnet4".to_string()
+                    }
+                )
+            }
+            _ => panic!("Expected UserNameParseError for network mismatch"),
+        }
+    }
     #[test]
     fn server_endpoints_returns_single_endpoint_for_specific_host() {
         let result = server_endpoints("127.0.0.1", 8080, "http");


### PR DESCRIPTION
- The worker_name received from miners serve the purpose of getting miners payout address during `mining.submit` for each submission .
- Parsing it and passing it onto the bead formation in `lib.rs` .