### PR TITLE
Fix multi network persistance 

### DIFF
--- a/docs/braidpool_setup.md
+++ b/docs/braidpool_setup.md
@@ -66,6 +66,32 @@ You can find all available command-line arguments in [node/src/cli.rs](https://g
 
 -   `--ipc-socket <PATH>`: Specifies the path to the UNIX domain socket file (should be the same as bitcoin node).
 -   `--network <NETWORK>`: Sets the network. Valid options are `mainnet`, `testnet4`, `signet`, and `cpunet`. The default is `mainnet`.
+-   `--datadir <PATH>`: Parent directory for all on-disk state.
+
+#### Data directory layout
+
+State is persisted under a per-network subdirectory of `--datadir`, so several
+networks can be run side by side from one `--datadir` without sharing beads or
+identity:
+
+```
+<datadir>/
+└── <network>/            # e.g. cpunet, signet, regtest
+    ├── braidpool.db      # beads and braid state
+    ├── audit.db          # audit mode records
+    └── keystore          # node keypair -> PeerID
+```
+
+Networks are also isolated on the wire: libp2p protocol IDs and the floodsub
+topic are scoped by network name (`/braidpool/<network>/kad/1.0.0`,
+`/braidpool/<network>/bead-sync/1.0.0`, `/braidpool/<network>/identify/1.0.0`,
+`braidpool_channel/<network>`), so peers on different networks cannot negotiate
+a substream with each other.
+
+If you ran a node before network scoping existed, its database lives at the old
+unscoped location (`~/.braidpool/braidpool.db` on Linux). That file is no longer
+read; the node logs a warning pointing at it. Move it into
+`<datadir>/<network>/braidpool.db` to keep the beads, or delete it.
 
 ## For probing current braidpool-node 
 - `braidpool-cli` crate can be utilized for accessing current braid-state including information about the `bead-count`,`bead-by-beadhash`,`tips` etc.

--- a/node/src/behaviour/mod.rs
+++ b/node/src/behaviour/mod.rs
@@ -1,4 +1,5 @@
 use crate::bead::{Bead, BeadCodec, BeadHashes, BeadRequest, BeadResponse, BeadSyncError};
+use crate::config::PoolNetwork;
 use crate::utils::BeadHash;
 use libp2p::floodsub;
 use libp2p::{
@@ -12,12 +13,30 @@ use libp2p::{
 };
 use std::{error::Error, time::Duration};
 
-// Protocol names
-pub const KADPROTOCOLNAME: StreamProtocol = StreamProtocol::new("/braidpool/kad/1.0.0");
-pub const IDENTIFYPROTOCOLNAME: StreamProtocol = StreamProtocol::new("/braidpool/identify/1.0.0");
-pub const BEAD_SYNC_PROTOCOL: StreamProtocol = StreamProtocol::new("/braidpool/bead-sync/1.0.0");
-pub const BEAD_ANNOUNCE_PROTOCOL: StreamProtocol = StreamProtocol::new("/floodsub/1.0.0");
-pub const BRAIDPOOL_TOPIC: &str = "braidpool_channel";
+// Protocol IDs or names to be negotiated during the connection establishment
+// for network specific communication to be established.
+pub fn kad_protocol(network: PoolNetwork) -> StreamProtocol {
+    let name = network.name();
+    StreamProtocol::try_from_owned(format!("/braidpool/{name}/kad/1.0.0"))
+        .expect("network name produces invalid StreamProtocol")
+}
+
+/// Returns the identify protocol ID for `network`.
+pub fn identify_protocol(network: PoolNetwork) -> String {
+    format!("/braidpool/{}/identify/1.0.0", network.name())
+}
+
+/// Returns the bead-sync request/response protocol ID for `network`.
+pub fn bead_sync_protocol(network: PoolNetwork) -> StreamProtocol {
+    let name = network.name();
+    StreamProtocol::try_from_owned(format!("/braidpool/{name}/bead-sync/1.0.0"))
+        .expect("network name produces invalid StreamProtocol")
+}
+
+/// Returns the floodsub topic beads are announced on for `network`.
+pub fn braidpool_topic(network: PoolNetwork) -> String {
+    format!("braidpool_channel/{}", network.name())
+}
 
 // Configuration for the request-response protocol
 #[derive(Debug, Clone)]
@@ -44,11 +63,15 @@ pub struct BraidPoolBehaviour {
     pub bead_announce: floodsub::Floodsub,
 }
 impl BraidPoolBehaviour {
-    pub fn new(local_key: &Keypair) -> Result<BraidPoolBehaviour, Box<dyn Error>> {
+    /// Builds the composed network behaviour with every protocol scoped to `network`.
+    pub fn new(
+        local_key: &Keypair,
+        network: PoolNetwork,
+    ) -> Result<BraidPoolBehaviour, Box<dyn Error>> {
         //initializing the store for kademlia based DHT
         let store = MemoryStore::new(local_key.public().to_peer_id());
-        //custom kademlia protocol
-        let mut kad_config = kad::Config::new(KADPROTOCOLNAME);
+        //custom kademlia protocol, scoped by Bitcoin network
+        let mut kad_config = kad::Config::new(kad_protocol(network));
         kad_config.set_query_timeout(tokio::time::Duration::from_secs(60));
         //Querying the boot node for finding the neareast neigbor set up for 10 minutes
         //dynamic value can be changed not to small though
@@ -56,19 +79,21 @@ impl BraidPoolBehaviour {
         //custom kad configuration
         let kademlia_behaviour =
             kad::Behaviour::with_config(local_key.public().to_peer_id(), store, kad_config);
-        //identify protocol configuration
-        let identify_config =
-            identify::Config::new(IDENTIFYPROTOCOLNAME.to_string(), local_key.public());
+        //identify protocol configuration, scoped by Bitcoin network
+        let identify_config = identify::Config::new(identify_protocol(network), local_key.public());
         let identify_behaviour = identify::Behaviour::new(identify_config);
         let ping_config = ping::Config::default()
             .with_timeout(Duration::from_secs(3600))
             .with_interval(Duration::from_secs(5));
         let ping_behaviour = ping::Behaviour::new(ping_config.clone());
 
-        // Initialize bead download behaviour
+        // Initialize bead download behaviour, scoped by Bitcoin network
         let bead_sync_config = BeadSyncConfig::default();
         let bead_sync = request_response::Behaviour::new(
-            [(BEAD_SYNC_PROTOCOL, request_response::ProtocolSupport::Full)],
+            [(
+                bead_sync_protocol(network),
+                request_response::ProtocolSupport::Full,
+            )],
             request_response::Config::default()
                 .with_request_timeout(bead_sync_config.request_timeout)
                 .with_max_concurrent_streams(bead_sync_config.max_concurrent_requests),

--- a/node/src/behaviour/tests.rs
+++ b/node/src/behaviour/tests.rs
@@ -19,6 +19,39 @@ use libp2p::{Multiaddr, Swarm, SwarmBuilder};
 use std::str::FromStr;
 use tokio::time::timeout;
 
+#[test]
+fn network_scoped_protocol_names_are_distinct_per_network() {
+    const CPUNET: PoolNetwork = PoolNetwork::Cpunet;
+    const REGTEST: PoolNetwork = PoolNetwork::Bitcoin(bitcoin::Network::Regtest);
+    const SIGNET: PoolNetwork = PoolNetwork::Bitcoin(bitcoin::Network::Signet);
+    const MAINNET: PoolNetwork = PoolNetwork::Bitcoin(bitcoin::Network::Bitcoin);
+
+    // The whole point of network scoping is that cpunet and regtest peers
+    // cannot negotiate any substream with each other. Lock that in.
+    assert_ne!(
+        super::bead_sync_protocol(CPUNET),
+        super::bead_sync_protocol(REGTEST),
+    );
+    assert_ne!(super::kad_protocol(CPUNET), super::kad_protocol(SIGNET));
+    assert_ne!(
+        super::identify_protocol(CPUNET),
+        super::identify_protocol(MAINNET),
+    );
+    assert_ne!(
+        super::braidpool_topic(CPUNET),
+        super::braidpool_topic(REGTEST),
+    );
+    // Same network -> stable name (idempotent).
+    assert_eq!(
+        super::bead_sync_protocol(CPUNET),
+        super::bead_sync_protocol(CPUNET),
+    );
+    // Sanity check: the network name actually appears in the protocol id.
+    assert!(super::bead_sync_protocol(CPUNET)
+        .as_ref()
+        .contains(CPUNET.name()));
+}
+
 // Helper function to create a test bead
 fn create_test_bead() -> Bead {
     let _address = String::from("127.0.0.1:8888");
@@ -78,7 +111,9 @@ fn build_swarm() -> (Swarm<BraidPoolBehaviour>, PeerId) {
         .with_quic()
         .with_dns()
         .unwrap()
-        .with_behaviour(|local_key| BraidPoolBehaviour::new(local_key).unwrap())
+        .with_behaviour(|local_key| {
+            BraidPoolBehaviour::new(local_key, PoolNetwork::Cpunet).unwrap()
+        })
         .unwrap()
         .build();
     (swarm, peer_id)

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -70,9 +70,10 @@ impl DBHandler {
     pub async fn new(
         datadir: &Path,
         network: PoolNetwork,
+    ,
     ) -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
         debug!("Initializing schema for persistent database");
-        let db_connection_pool = match init_db(datadir).await {
+        let db_connection_pool = match init_db(datadir,network).await {
             Ok(conn) => conn,
             Err(error) => {
                 error!(error = ?error, "Failed to initialize database connection");

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -70,10 +70,9 @@ impl DBHandler {
     pub async fn new(
         datadir: &Path,
         network: PoolNetwork,
-    ,
     ) -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
         debug!("Initializing schema for persistent database");
-        let db_connection_pool = match init_db(datadir,network).await {
+        let db_connection_pool = match init_db(datadir, network).await {
             Ok(conn) => conn,
             Err(error) => {
                 error!(error = ?error, "Failed to initialize database connection");

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -1,6 +1,7 @@
 use sqlx::{sqlite::SqliteConnectOptions, Executor, SqlitePool};
 use std::{fs, path::Path, str::FromStr};
 
+use crate::config::PoolNetwork;
 use crate::error::DBErrors;
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
@@ -8,13 +9,42 @@ static SCHEMA_SQL: &str = include_str!("schema.sql");
 static AUDIT_SCHEMA_SQL: &str = include_str!("audit_schema.sql");
 
 /// Initializes the braid database inside the node's data directory.
-pub async fn init_db(datadir: &Path) -> Result<SqlitePool, DBErrors> {
-    setup_sqlite_db(datadir, "braidpool.db", SCHEMA_SQL).await
+/// Initializes the sqlite pool for a network-scoped data directory.
+pub async fn init_db(
+    network_datadir: PathBuf,
+    network: PoolNetwork,
+datadir: &Path) -> Result<SqlitePool, DBErrors> {
+    warn_on_legacy_db(&network_datadir, network);
+    setup_sqlite_db(&network_datadir, datadir, "braidpool.db", SCHEMA_SQL).await
 }
 
 /// Initializes the audit database inside the node's data directory.
 pub async fn init_audit_db(datadir: &Path) -> Result<SqlitePool, DBErrors> {
     setup_sqlite_db(datadir, "audit.db", AUDIT_SCHEMA_SQL).await
+}
+
+async fn setup_sqlite_db(
+    db_dir: &Path,
+    db_name: &str,
+    schema_sql: &str,
+) -> Result<SqlitePool, DBErrors> {
+/// Warns once if a pre-network-scoping database is still present in the legacy
+/// platform data directory. It is no longer read from or written to.
+fn warn_on_legacy_db(network_datadir: &Path, network: PoolNetwork) {
+    let Ok(legacy_dir) = get_data_dir() else {
+        return;
+    };
+    let legacy_path = legacy_dir.join("braidpool.db");
+    let new_path = network_datadir.join("braidpool.db");
+    if legacy_path.exists() && legacy_path != new_path && !new_path.exists() {
+        warn!(
+            legacy = %legacy_path.display(),
+            new = %new_path.display(),
+            network = %network,
+            "Legacy braidpool DB found outside the network-scoped data directory. \
+             It is no longer used; move or delete it to silence this warning."
+        );
+    }
 }
 
 async fn setup_sqlite_db(

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -1,21 +1,21 @@
 use sqlx::{sqlite::SqliteConnectOptions, Executor, SqlitePool};
-use std::{fs, path::Path, str::FromStr};
+use std::{
+    fs,
+    path::{Path, PathBuf},
+    str::FromStr,
+};
 
 use crate::config::PoolNetwork;
 use crate::error::DBErrors;
-#[allow(unused_imports)]
-use tracing::{debug, error, info, trace, warn};
+use std::env;
+use tracing::{error, info, warn};
 static SCHEMA_SQL: &str = include_str!("schema.sql");
 static AUDIT_SCHEMA_SQL: &str = include_str!("audit_schema.sql");
 
-/// Initializes the braid database inside the node's data directory.
 /// Initializes the sqlite pool for a network-scoped data directory.
-pub async fn init_db(
-    network_datadir: PathBuf,
-    network: PoolNetwork,
-datadir: &Path) -> Result<SqlitePool, DBErrors> {
-    warn_on_legacy_db(&network_datadir, network);
-    setup_sqlite_db(&network_datadir, datadir, "braidpool.db", SCHEMA_SQL).await
+pub async fn init_db(datadir: &Path, network: PoolNetwork) -> Result<SqlitePool, DBErrors> {
+    warn_on_legacy_db(&datadir, network);
+    setup_sqlite_db(&datadir, "braidpool.db", SCHEMA_SQL).await
 }
 
 /// Initializes the audit database inside the node's data directory.
@@ -23,15 +23,42 @@ pub async fn init_audit_db(datadir: &Path) -> Result<SqlitePool, DBErrors> {
     setup_sqlite_db(datadir, "audit.db", AUDIT_SCHEMA_SQL).await
 }
 
-async fn setup_sqlite_db(
-    db_dir: &Path,
-    db_name: &str,
-    schema_sql: &str,
-) -> Result<SqlitePool, DBErrors> {
+/// Gets the braidpool legacy data directory in a cross-platform manner.
+fn get_legacy_data_dir() -> Result<PathBuf, DBErrors> {
+    #[cfg(target_os = "linux")]
+    {
+        let home = env::var("HOME").map_err(|error| DBErrors::EnvVariableNotFetched {
+            error: error.to_string(),
+            var: "HOME".to_string(),
+        })?;
+        Ok(Path::new(&home).join(".braidpool"))
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        let home = env::var("HOME").map_err(|error| DBErrors::EnvVariableNotFetched {
+            error: error.to_string(),
+            var: "HOME".to_string(),
+        })?;
+        Ok(Path::new(&home)
+            .join("Library")
+            .join("Application Support")
+            .join("braidpool"))
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        Err(DBErrors::EnvVariableNotFetched {
+            error: "this platform is not supported yet".to_string(),
+            var: std::env::consts::OS.to_string(),
+        })
+    }
+}
+
 /// Warns once if a pre-network-scoping database is still present in the legacy
 /// platform data directory. It is no longer read from or written to.
 fn warn_on_legacy_db(network_datadir: &Path, network: PoolNetwork) {
-    let Ok(legacy_dir) = get_data_dir() else {
+    let Ok(legacy_dir) = get_legacy_data_dir() else {
         return;
     };
     let legacy_path = legacy_dir.join("braidpool.db");

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -19,12 +19,13 @@ use node::db::db_handlers::FETCH_BEAD_BATCH_SIZE;
 use node::ibd_manager::{IBD_TRIGGER_AFTER, MAX_IBD_INCOMING_THRESHOLD, MAX_IBD_RETRIES};
 use node::upstream_pool;
 use node::utils::compute_block_hash;
+use node::utils::is_routable_multiaddr;
 use node::utils::resolve_datadir;
 use node::utils::BeadHash;
 use node::SwarmHandler;
 use node::{
     bead::{Bead, BeadHashes, BeadRequest, BeadResponse, BeadSyncError},
-    behaviour::{self, BEAD_ANNOUNCE_PROTOCOL, BRAIDPOOL_TOPIC},
+    behaviour::{self, bead_sync_protocol, braidpool_topic, kad_protocol},
     braid, cli, config,
     db::db_handlers::DBHandler,
     ibd_manager::{IBDCommands, IBDManager, IBD_BATCH_SIZE},
@@ -49,15 +50,9 @@ use tracing::{debug, error, info, trace, warn};
 
 use behaviour::{BraidPoolBehaviour, BraidPoolBehaviourEvent};
 
-use crate::behaviour::KADPROTOCOLNAME;
 const LATENCY_ALPHA: u64 = 10; // seconds
-                               //boot nodes peerIds
-const BOOTNODES: [&str; 1] = ["12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3"];
-//dns NS
-const SEED_DNS: &str = "/dnsaddr/french.braidpool.net";
-//combined addr for dns resolution and dialing of boot for peer discovery
-const ADDR_REFRENCE: &str =
-    "/dnsaddr/french.braidpool.net/p2p/12D3KooWG9z8TziaNuYyEcc9FeUC3FTtrEf2XSnSdDpLvx4Jh2w3";
+                               //dns NS
+const SEED_DNS: [&str; 1] = ["/dnsaddr/french.braidpool.net"];
 use tokio::sync::{
     mpsc::{self},
     RwLock,
@@ -894,7 +889,7 @@ async fn main() -> Result<(), Box<dyn Error>> {
     //result in same peerID leading to OutgoingConnectionError
     // let keypair = identity::Keypair::generate_ed25519();
     //creating a main topic subscribing to the current test topic
-    let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(BRAIDPOOL_TOPIC);
+    let current_broadcast_topic: floodsub::Topic = floodsub::Topic::new(braidpool_topic(network));
 
     let swarm_builder = libp2p::SwarmBuilder::with_existing_identity(keypair)
         .with_tokio()
@@ -907,9 +902,10 @@ async fn main() -> Result<(), Box<dyn Error>> {
             )
         })?;
     // Note: with_behaviour closure must return behaviour directly (not Result), using expect for clear error message
+    let behaviour_network = network;
     let mut swarm = swarm_builder
-        .with_behaviour(|local_key| {
-            BraidPoolBehaviour::new(local_key).expect(
+        .with_behaviour(move |local_key| {
+            BraidPoolBehaviour::new(local_key, behaviour_network).expect(
                 "Failed to create BraidPoolBehaviour - check keypair and network configuration",
             )
         })?
@@ -947,36 +943,16 @@ async fn main() -> Result<(), Box<dyn Error>> {
     if !args.audit {
         //adding the boot nodes for peer discovery
         swarm.listen_on(multi_addr.clone())?;
-        for boot_peer in BOOTNODES {
-            let peer_id = match boot_peer.parse::<PeerId>() {
-                Ok(id) => id,
-                Err(e) => {
-                    error!(boot_peer = %boot_peer, error = %e, "Failed to parse boot peer ID, skipping");
-                    continue;
-                }
-            };
-            let seed_addr = match SEED_DNS.parse::<Multiaddr>() {
-                Ok(addr) => addr,
-                Err(e) => {
-                    error!(seed_dns = %SEED_DNS, error = %e, "Failed to parse seed DNS, skipping");
-                    continue;
-                }
-            };
-            swarm
-                .behaviour_mut()
-                .kademlia
-                .add_address(&peer_id, seed_addr);
+        for boot_peer in SEED_DNS {
+            let boot_addr: Multiaddr = boot_peer.parse().map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidInput,
+                    format!("Failed to parse boot address: {}", e),
+                )
+            })?;
+            swarm.dial(boot_addr)?;
+            info!(address = %boot_peer, "Dialed boot node");
         }
-
-        info!(boot_node_count = %BOOTNODES.len(), "Boot nodes added to DHT");
-        let boot_addr: Multiaddr = ADDR_REFRENCE.parse().map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::InvalidInput,
-                format!("Failed to parse boot address: {}", e),
-            )
-        })?;
-        swarm.dial(boot_addr)?;
-        info!(address = %ADDR_REFRENCE, "Dialed boot node");
     }
     //IPC(inter process communication) based `getblocktemplate` and `notification` to send to the downstream via the `cmempoold` architecture
     info!(socket = %args.ipc_socket, "IPC socket path");
@@ -1083,10 +1059,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
         };
     }
     let peer_manager_arc_for_swarm = peer_manager_arc.clone();
+    let swarm_network = network;
     let swarm_handle = if !args.audit {
         tokio::spawn(async move {
             let braid = std::sync::Arc::clone(&braid);
             let peer_manager_arc = peer_manager_arc_for_swarm;
+            let network = swarm_network;
+            let local_kad_protocol = kad_protocol(network);
+            let local_bead_sync_protocol = bead_sync_protocol(network);
             loop {
                 tokio::select! {
                   swarm_event = swarm.select_next_some()=>{
@@ -1320,32 +1300,64 @@ async fn main() -> Result<(), Box<dyn Error>> {
                           SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Identify(
                               identify::Event::Received { peer_id, info,  .. },
                           )) => {
-                              let info_reference = info.clone();
                               info!(
                                   peer = ?peer_id,
-                                  address_count = %info_reference.listen_addrs.len(),
+                                  address_count = %info.listen_addrs.len(),
                                   "Received listen addresses"
                               );
-                              if info.protocols.iter().any(|p| *p == KADPROTOCOLNAME) {
-                                  for addr in info.listen_addrs {
-                                      info!(address = %addr, "Received address via identify");
-                                  }
-                              } else {
-                                  info!(peer = ?peer_id, "Peer does not support Kademlia");
-                              }
-                              if info_reference
-                                  .clone()
+                              let supports_bead_sync = info
                                   .protocols
                                   .iter()
-                                  .any(|p| *p != BEAD_ANNOUNCE_PROTOCOL)
-                              {
-
-                                  info!(
-                                      peer_address = ?info_reference.observed_addr,
-                                      "Peer does not support floodsub"
+                                  .any(|p| p == &local_bead_sync_protocol);
+                              let supports_kad = info
+                                  .protocols
+                                  .iter()
+                                  .any(|p| p == &local_kad_protocol);
+                              if !supports_bead_sync {
+                                  warn!(
+                                      peer = %peer_id,
+                                      peer_protocols = ?info.protocols,
+                                      expected = %local_bead_sync_protocol,
+                                      network = %network,
+                                      "Peer protocol negotiation failed - beadsync, closing the connection stream"
                                   );
+                                  {
+                                      let mut peer_manager = peer_manager_arc.write().await;
+                                      peer_manager.drop_pending_peer(&peer_id);
+                                  }
+                                  let _ = swarm.disconnect_peer_id(peer_id);
+                              } else {
+                                  if supports_kad {
+                                      for addr in &info.listen_addrs {
+                                          if is_routable_multiaddr(addr) {
+                                              info!(peer = %peer_id, address = %addr, "Adding peer address to DHT via identify");
+                                              swarm
+                                                  .behaviour_mut()
+                                                  .kademlia
+                                                  .add_address(&peer_id, addr.clone());
+                                          } else {
+                                              trace!(peer = %peer_id, address = %addr, "Skipping non-routable listen address");
+                                          }
+                                      }
+                                  } else {
+                                      info!(peer = ?peer_id, "Peer kademlia protocol negotiation failed.");
+                                  }
+                                  swarm
+                                      .behaviour_mut()
+                                      .bead_announce
+                                      .add_node_to_partial_view(peer_id);
+                                  info!(peer = %peer_id, "Peer added to floodsub mesh");
+                                  {
+                                      let mut peer_manager = peer_manager_arc.write().await;
+                                      if !peer_manager.promote_pending_peer(&peer_id) {
+                                          debug!(
+                                              peer = %peer_id,
+                                              "No pending connection to promote; it closed before identify completed"
+                                          );
+                                      }
+                                  }
                               }
-                              debug!(info = ?info_reference, "Received peer info");
+                              debug!(info = ?info, "Received peer info");
                           }
                           SwarmEvent::Behaviour(BraidPoolBehaviourEvent::Kademlia(
                               kad::Event::OutboundQueryProgressed { result, .. },
@@ -1401,35 +1413,19 @@ async fn main() -> Result<(), Box<dyn Error>> {
                           SwarmEvent::ConnectionEstablished {
                               peer_id, endpoint, ..
                           } => {
-
-                              // Add the peer to the peer manager
-                              let remote_addr = endpoint.get_remote_address();
-                              swarm.behaviour_mut().kademlia.add_address(&peer_id,remote_addr.clone());
-                              info!(address = ?remote_addr, "DHT updated with peer address");
-                              swarm.behaviour_mut()
-                              .bead_announce
-                              .add_node_to_partial_view(peer_id);
-
-                              info!(peer = %peer_id, "Peer added to floodsub mesh");
-                              let ip = remote_addr.iter().find_map(|p| match p {
-                                  libp2p::core::multiaddr::Protocol::Ip4(ip) => {
-                                      Some(std::net::IpAddr::V4(ip))
-                                  }
-                                  libp2p::core::multiaddr::Protocol::Ip6(ip) => {
-                                      Some(std::net::IpAddr::V6(ip))
-                                  }
-                                  _ => None,
-                              });
-                                {
-                                    let mut peer_manager = peer_manager_arc.write().await;
-                                    peer_manager.add_peer(peer_id, !endpoint.is_dialer(), ip);
-                                }
+                              // Hold the connection metadata until the Identify exchange proves the
+                              // peer speaks this network's protocols; only then is it registered.
+                              let remote_addr = endpoint.get_remote_address().clone();
+                              let is_dialer = endpoint.is_dialer();
+                              {
+                                  let mut peer_manager = peer_manager_arc.write().await;
+                                  peer_manager.add_pending_peer(peer_id, remote_addr.clone(), is_dialer);
+                              }
                               info!(
                                  peer_id = ?peer_id,
                                  remote_addr = ?remote_addr,
-                                 "Connection established to peer"
+                                 "Connection established to peer protocol negotiation pending"
                              );
-
                           }
                           SwarmEvent::ConnectionClosed {
                               peer_id,
@@ -1439,15 +1435,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
                               cause,
                           } => {
                               info!(peer = %peer_id, connection_id = %connection_id, address = %endpoint.get_remote_address(), established = %num_established, cause = ?cause, "Connection closed");
-                              // Remove the peer from the peer manager
+                              // Remove the peer from the peer manager; this also drops
+                              // any pending entry that never got verified.
                               {
                                  let mut peer_manager = peer_manager_arc.write().await;
                                  peer_manager.remove_peer(&peer_id);
                               }
-                              swarm
-                                  .behaviour_mut()
-                                  .kademlia
-                                  .remove_address(&peer_id, endpoint.get_remote_address());
                           }
                           SwarmEvent::Behaviour(BraidPoolBehaviourEvent::BeadSync(
                          request_response::Event::Message {

--- a/node/src/peer_manager/mod.rs
+++ b/node/src/peer_manager/mod.rs
@@ -1,4 +1,5 @@
-use libp2p::PeerId;
+use libp2p::core::multiaddr::Protocol;
+use libp2p::{Multiaddr, PeerId};
 use serde_json::json;
 use std::collections::{HashMap, HashSet};
 use std::net::IpAddr;
@@ -63,12 +64,45 @@ impl PeerInfo {
     }
 }
 
+/// A connection that has been established but whose protocol negotiation has
+/// not yet completed.
+///
+/// Braidpool scopes its libp2p protocol IDs by network, so a peer on a different
+/// network can still open a transport connection but will fail to negotiate any
+/// substream. Connections are parked here until the Identify exchange proves the
+/// peer speaks this node's protocols, and only then promoted into `peers` - which
+/// keeps foreign-network peers out of peer selection and scoring entirely.
+#[derive(Debug, Clone)]
+pub struct PendingPeer {
+    /// Remote address the connection was established on
+    pub remote_addr: Multiaddr,
+    /// Whether the local node dialed the peer, rather than being dialed by it
+    pub is_dialer: bool,
+}
+
+impl PendingPeer {
+    /// Extracts the peer's IP address from its remote multiaddr, if it has one.
+    ///
+    /// # Returns
+    /// The first `Ip4`/`Ip6` component of the address, or `None` for addresses
+    /// that carry no literal IP (a DNS multiaddr, for example).
+    pub fn remote_ip(&self) -> Option<IpAddr> {
+        self.remote_addr.iter().find_map(|p| match p {
+            Protocol::Ip4(ip) => Some(IpAddr::V4(ip)),
+            Protocol::Ip6(ip) => Some(IpAddr::V6(ip)),
+            _ => None,
+        })
+    }
+}
+
 /// Manager for peer connections and selection
 pub struct PeerManager {
     /// Table of all known peers
     peers: HashMap<PeerId, PeerInfo>,
     /// Set of currently connected peers
     connected_peers: HashSet<PeerId>,
+    /// Connections established but not yet cleared by protocol negotiation
+    pending_peers: HashMap<PeerId, PendingPeer>,
     /// Maximum number of peers to maintain
     max_peers: usize,
     /// Minimum acceptable peer score
@@ -85,6 +119,7 @@ impl PeerManager {
         Self {
             peers: HashMap::new(),
             connected_peers: HashSet::new(),
+            pending_peers: HashMap::new(),
             max_peers,
             min_acceptable_score: -100.0,
             idle_penalty: 0.1,
@@ -112,11 +147,71 @@ impl PeerManager {
     }
 
     /// Remove a peer
+    ///
+    /// Also discards any pending entry for `peer_id`, so a connection that drops
+    /// before protocol negotiation completes leaves nothing behind.
     pub fn remove_peer(&mut self, peer_id: &PeerId) {
         if let Some(peer) = self.peers.get_mut(peer_id) {
             peer.connected = false;
         }
         self.connected_peers.remove(peer_id);
+        self.pending_peers.remove(peer_id);
+    }
+
+    /// Records a freshly established connection awaiting protocol negotiation.
+    ///
+    /// The peer takes no part in propagation or scoring until
+    /// [`PeerManager::promote_pending_peer`] accepts it.
+    ///
+    /// # Arguments
+    /// * `peer_id` - The peer that connected
+    /// * `remote_addr` - Address the connection was established on
+    /// * `is_dialer` - Whether the local node dialed the peer
+    pub fn add_pending_peer(&mut self, peer_id: PeerId, remote_addr: Multiaddr, is_dialer: bool) {
+        self.pending_peers.insert(
+            peer_id,
+            PendingPeer {
+                remote_addr,
+                is_dialer,
+            },
+        );
+    }
+
+    /// Discards a pending connection that failed protocol negotiation.
+    ///
+    /// # Arguments
+    /// * `peer_id` - The peer to discard
+    ///
+    /// # Returns
+    /// The discarded entry, or `None` if the peer was not pending.
+    pub fn drop_pending_peer(&mut self, peer_id: &PeerId) -> Option<PendingPeer> {
+        self.pending_peers.remove(peer_id)
+    }
+
+    /// Promotes a pending connection into a tracked peer after its protocol
+    /// negotiation succeeded.
+    ///
+    /// The peer's IP is taken from the address the connection was established on,
+    /// and `inbound` from whether the remote dialed us.
+    ///
+    /// # Arguments
+    /// * `peer_id` - The peer to promote
+    ///
+    /// # Returns
+    /// `true` if a pending entry existed and was promoted, `false` otherwise -
+    /// a `false` return means the connection closed before Identify completed.
+    pub fn promote_pending_peer(&mut self, peer_id: &PeerId) -> bool {
+        let Some(pending) = self.pending_peers.remove(peer_id) else {
+            return false;
+        };
+        let ip = pending.remote_ip();
+        self.add_peer(*peer_id, !pending.is_dialer, ip);
+        true
+    }
+
+    /// Returns the number of connections awaiting protocol negotiation.
+    pub fn num_pending_peers(&self) -> usize {
+        self.pending_peers.len()
     }
 
     /// Update the latency measurement for a peer
@@ -414,6 +509,111 @@ mod tests {
 
         manager.remove_peer(&peer_id);
         assert_eq!(manager.num_connected_peers(), 0);
+    }
+
+    fn test_multiaddr(s: &str) -> Multiaddr {
+        s.parse().expect("valid multiaddr literal")
+    }
+
+    #[test]
+    fn pending_peer_is_not_connected_until_promoted() {
+        let mut manager = PeerManager::new(10);
+        let peer_id = generate_peer_id();
+
+        manager.add_pending_peer(
+            peer_id,
+            test_multiaddr("/ip4/74.50.123.158/udp/6680/quic-v1"),
+            false,
+        );
+        // A peer awaiting protocol negotiation takes no part in peer selection.
+        assert_eq!(manager.num_pending_peers(), 1);
+        assert_eq!(manager.num_connected_peers(), 0);
+        assert!(manager.get_top_k_peers_for_propagation(5).is_empty());
+
+        assert!(manager.promote_pending_peer(&peer_id));
+        assert_eq!(manager.num_pending_peers(), 0);
+        assert_eq!(manager.num_connected_peers(), 1);
+    }
+
+    #[test]
+    fn promoting_records_ip_and_inbound_from_the_connection() {
+        let mut manager = PeerManager::new(10);
+        let inbound_peer = generate_peer_id();
+        let outbound_peer = generate_peer_id();
+
+        // is_dialer == false means the remote dialed us, so the peer is inbound.
+        manager.add_pending_peer(
+            inbound_peer,
+            test_multiaddr("/ip4/74.50.123.158/udp/6680/quic-v1"),
+            false,
+        );
+        manager.add_pending_peer(
+            outbound_peer,
+            test_multiaddr("/ip6/2001:4860:4860::8888/udp/6680/quic-v1"),
+            true,
+        );
+        assert!(manager.promote_pending_peer(&inbound_peer));
+        assert!(manager.promote_pending_peer(&outbound_peer));
+
+        let inbound = manager.peers.get(&inbound_peer).unwrap();
+        assert!(inbound.inbound);
+        assert_eq!(
+            inbound.ip_addr,
+            Some(IpAddr::V4(Ipv4Addr::new(74, 50, 123, 158)))
+        );
+
+        let outbound = manager.peers.get(&outbound_peer).unwrap();
+        assert!(!outbound.inbound);
+        assert_eq!(
+            outbound.ip_addr,
+            Some(IpAddr::V6(Ipv6Addr::new(
+                0x2001, 0x4860, 0x4860, 0, 0, 0, 0, 0x8888
+            )))
+        );
+    }
+
+    #[test]
+    fn failed_negotiation_drops_the_pending_peer() {
+        let mut manager = PeerManager::new(10);
+        let peer_id = generate_peer_id();
+
+        manager.add_pending_peer(
+            peer_id,
+            test_multiaddr("/ip4/74.50.123.158/udp/6680/quic-v1"),
+            true,
+        );
+        let dropped = manager.drop_pending_peer(&peer_id);
+        assert!(dropped.is_some());
+        assert!(dropped.unwrap().is_dialer);
+        assert_eq!(manager.num_pending_peers(), 0);
+
+        // A peer that never negotiated must not be promotable afterwards.
+        assert!(!manager.promote_pending_peer(&peer_id));
+        assert_eq!(manager.num_connected_peers(), 0);
+    }
+
+    #[test]
+    fn closing_a_connection_clears_its_pending_entry() {
+        let mut manager = PeerManager::new(10);
+        let peer_id = generate_peer_id();
+
+        manager.add_pending_peer(
+            peer_id,
+            test_multiaddr("/ip4/74.50.123.158/udp/6680/quic-v1"),
+            false,
+        );
+        manager.remove_peer(&peer_id);
+        assert_eq!(manager.num_pending_peers(), 0);
+        assert!(!manager.promote_pending_peer(&peer_id));
+    }
+
+    #[test]
+    fn pending_peer_without_literal_ip_has_no_ip() {
+        let pending = PendingPeer {
+            remote_addr: test_multiaddr("/dns4/example.com/udp/6680/quic-v1"),
+            is_dialer: true,
+        };
+        assert_eq!(pending.remote_ip(), None);
     }
 
     #[test]

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -225,7 +225,7 @@ pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
 #[cfg(test)]
 mod tests {
     use super::*;
-#[test]
+    #[test]
     fn server_endpoints_returns_single_endpoint_for_specific_host() {
         let result = server_endpoints("127.0.0.1", 8080, "http");
         assert_eq!(result, vec!["http://127.0.0.1:8080"]);

--- a/node/src/utils/mod.rs
+++ b/node/src/utils/mod.rs
@@ -13,6 +13,8 @@ use bitcoin::{
     hashes::Hash,
     secp256k1, CompactTarget, EcdsaSighashType, TxMerkleNode,
 };
+use libp2p::core::multiaddr::Protocol;
+use libp2p::Multiaddr;
 // Standard Imports
 #[allow(unused_imports)]
 use tracing::{debug, error, info, trace, warn};
@@ -131,6 +133,41 @@ pub fn resolve_datadir(datadir: &Path) -> std::io::Result<PathBuf> {
     Ok(datadir_path)
 }
 
+/// Basic filtering of IPs returns true if a multiaddr is reachable from peers on the
+/// public internet otherwise it would lead to unroutable `FIND_NODE` hops
+pub fn is_routable_multiaddr(addr: &Multiaddr) -> bool {
+    for proto in addr.iter() {
+        match proto {
+            Protocol::Ip4(ip) => {
+                let octets = ip.octets();
+                // Basic check for `CGNAT` being (100.64.x.x) to avoid addition
+                // to local DHT
+                let is_cgnat = octets[0] == 100 && (octets[1] & 0xC0) == 64;
+                return !(ip.is_loopback()
+                    || ip.is_private()
+                    || ip.is_link_local()
+                    || ip.is_unspecified()
+                    || ip.is_multicast()
+                    || ip.is_broadcast()
+                    || is_cgnat);
+            }
+            Protocol::Ip6(ip) => {
+                let seg = ip.segments();
+                let is_link_local = (seg[0] & 0xffc0) == 0xfe80;
+                return !(ip.is_loopback()
+                    || ip.is_unspecified()
+                    || ip.is_multicast()
+                    || is_link_local);
+            }
+            Protocol::Dns(_) | Protocol::Dns4(_) | Protocol::Dns6(_) | Protocol::Dnsaddr(_) => {
+                return true;
+            }
+            _ => continue,
+        }
+    }
+    false
+}
+
 // Helper function to create test beads
 pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
     let public_key = "020202020202020202020202020202020202020202020202020202020202020202"
@@ -188,56 +225,7 @@ pub fn create_test_bead(nonce: u32, prev_hash: Option<BlockHash>) -> Bead {
 #[cfg(test)]
 mod tests {
     use super::*;
-    fn unique_temp_test_path(label: &str) -> PathBuf {
-        let suffix = rand::random::<u8>();
-        std::env::temp_dir().join(format!(
-            "braidpool-test-{}-{}-{:02x}",
-            label,
-            std::process::id(),
-            suffix
-        ))
-    }
-
-    #[test]
-    fn resolve_datadir_creates_missing_directory() {
-        let root = unique_temp_test_path("test_create");
-        let nested = root.join("test_nested").join("datadir");
-
-        let resolved = resolve_datadir(&nested).expect("Missing directory creation failed.");
-
-        assert_eq!(resolved, nested);
-        assert!(nested.is_dir());
-
-        let _ = fs::remove_dir_all(&root);
-    }
-
-    #[test]
-    fn resolve_datadir_accepts_existing_directory() {
-        let dir = unique_temp_test_path("test_existing");
-        fs::create_dir_all(&dir).expect("Test directory creation failed.");
-
-        let resolved = resolve_datadir(&dir).expect("Existing directory not resolved.");
-
-        assert_eq!(resolved, dir);
-        assert!(dir.is_dir());
-
-        let _ = fs::remove_dir_all(&dir);
-    }
-
-    #[test]
-    fn resolve_datadir_rejects_path_that_is_not_a_directory() {
-        let file_path = unique_temp_test_path("test_file");
-        fs::write(&file_path, b"not a directory").expect("Test file creation failed.");
-
-        let error = resolve_datadir(&file_path).expect_err("a file must not be accepted");
-
-        assert_eq!(error.kind(), ErrorKind::InvalidInput);
-        assert!(file_path.is_file());
-
-        let _ = fs::remove_file(&file_path);
-    }
-
-    #[test]
+#[test]
     fn server_endpoints_returns_single_endpoint_for_specific_host() {
         let result = server_endpoints("127.0.0.1", 8080, "http");
         assert_eq!(result, vec!["http://127.0.0.1:8080"]);


### PR DESCRIPTION
- Braidpool nodes previously ran every network (mainnet, signet, regtest, cpunet) on the same libp2p protocol IDs, so peers from different networks could negotiate `substreams` against each other. That silently produced bead/hash divergence leading to breakdown of entire network mesh. 
- This PR isolates networks end-to-end across the p2p stack and on disk by protocol negotiation during `ConnectionEstablishment` and adding peers only when negotiation passes as well as persistence in network specific sub-directories having `--datadir` as parent directory.
- Addresses #462 and #533 . 





