### PR TITLE
db:  --datadir inside init_db()

### DIFF
--- a/docs/braidpool_setup.md
+++ b/docs/braidpool_setup.md
@@ -66,6 +66,19 @@ You can find all available command-line arguments in [node/src/cli.rs](https://g
 
 -   `--ipc-socket <PATH>`: Specifies the path to the UNIX domain socket file (should be the same as bitcoin node).
 -   `--network <NETWORK>`: Sets the network. Valid options are `mainnet`, `testnet4`, `signet`, and `cpunet`. The default is `mainnet`.
+-   `--datadir <PATH>`: Directory holding all on-disk state. Defaults to `~/.braidpool/` on Linux and `~/Library/Application Support/braidpool/` on macOS.
+
+#### Data directory layout
+
+Everything the node persists lives under `--datadir`, so pointing two nodes at
+different directories keeps their state fully isolated:
+
+```
+<datadir>/
+├── braidpool.db      # beads and braid state
+├── audit.db          # audit mode records
+└── keystore          # node keypair -> PeerID
+```
 
 ## For probing current braidpool-node 
 - `braidpool-cli` crate can be utilized for accessing current braid-state including information about the `bead-count`,`bead-by-beadhash`,`tips` etc.

--- a/node/src/audit.rs
+++ b/node/src/audit.rs
@@ -440,8 +440,11 @@ impl AuditDAG {
         }
     }
 
-    pub async fn new_with_db(braid: Arc<RwLock<Braid>>) -> Result<Self, String> {
-        let db_handler = AuditDBHandler::new()
+    pub async fn new_with_db(
+        braid: Arc<RwLock<Braid>>,
+        datadir: Option<std::path::PathBuf>,
+    ) -> Result<Self, String> {
+        let db_handler = AuditDBHandler::new(datadir)
             .await
             .map_err(|e| format!("Failed to initialize audit database: {}", e))?;
 

--- a/node/src/db/audit_db_handlers.rs
+++ b/node/src/db/audit_db_handlers.rs
@@ -22,8 +22,8 @@ pub struct AuditDBHandler {
 }
 
 impl AuditDBHandler {
-    pub async fn new() -> Result<Self, DBErrors> {
-        let connection = match crate::db::init_db::init_audit_db().await {
+    pub async fn new(datadir: Option<std::path::PathBuf>) -> Result<Self, DBErrors> {
+        let connection = match crate::db::init_db::init_audit_db(datadir).await {
             Ok(conn) => conn,
             Err(error) => {
                 error!(error = ?error, "Failed to initialize audit database connection");

--- a/node/src/db/db_handlers.rs
+++ b/node/src/db/db_handlers.rs
@@ -66,9 +66,12 @@ pub struct DBHandler {
     pub network: PoolNetwork,
 }
 impl DBHandler {
-    pub async fn new(network: PoolNetwork) -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
+    pub async fn new(
+        datadir: Option<std::path::PathBuf>,
+        network: PoolNetwork,
+    ) -> Result<(Self, Sender<BraidpoolDBTypes>), DBErrors> {
         debug!("Initializing schema for persistent database");
-        let db_connection_pool = match init_db().await {
+        let db_connection_pool = match init_db(datadir).await {
             Ok(conn) => conn,
             Err(error) => {
                 error!(error = ?error, "Failed to initialize database connection");

--- a/node/src/db/init_db.rs
+++ b/node/src/db/init_db.rs
@@ -39,17 +39,51 @@ fn get_data_dir() -> Result<PathBuf, DBErrors> {
     }
 }
 
-pub async fn init_db() -> Result<SqlitePool, DBErrors> {
-    setup_sqlite_db("braidpool.db", SCHEMA_SQL).await
+/// Initializes the bead database pool.
+///
+/// # Arguments
+/// * `datadir` - Directory the database lives in, as resolved from `--datadir`.
+///   When `None`, the platform default data directory is used.
+///
+/// # Returns
+/// A connection pool to `<datadir>/braidpool.db`, creating the file and schema
+/// if it does not exist yet.
+///
+/// # Errors
+/// Returns a [`DBErrors`] when the data directory cannot be resolved or created,
+/// or when the connection or schema initialization fails.
+pub async fn init_db(datadir: Option<PathBuf>) -> Result<SqlitePool, DBErrors> {
+    setup_sqlite_db(datadir, "braidpool.db", SCHEMA_SQL).await
 }
 
-pub async fn init_audit_db() -> Result<SqlitePool, DBErrors> {
-    setup_sqlite_db("audit.db", AUDIT_SCHEMA_SQL).await
+/// Initializes the audit database pool.
+///
+/// # Arguments
+/// * `datadir` - Directory the database lives in, as resolved from `--datadir`.
+///   When `None`, the platform default data directory is used.
+///
+/// # Returns
+/// A connection pool to `<datadir>/audit.db`, creating the file and schema if it
+/// does not exist yet.
+///
+/// # Errors
+/// Returns a [`DBErrors`] when the data directory cannot be resolved or created,
+/// or when the connection or schema initialization fails.
+pub async fn init_audit_db(datadir: Option<PathBuf>) -> Result<SqlitePool, DBErrors> {
+    setup_sqlite_db(datadir, "audit.db", AUDIT_SCHEMA_SQL).await
 }
 
-async fn setup_sqlite_db(db_name: &str, schema_sql: &str) -> Result<SqlitePool, DBErrors> {
-    // Fetching the data directory
-    let db_dir = get_data_dir()?;
+async fn setup_sqlite_db(
+    datadir: Option<PathBuf>,
+    db_name: &str,
+    schema_sql: &str,
+) -> Result<SqlitePool, DBErrors> {
+    // Honour `--datadir` when the caller resolved one, otherwise fall back to
+    // the platform default data directory.
+    let db_dir = match datadir {
+        Some(dir) => dir,
+        None => get_data_dir()?,
+    };
     let db_path = db_dir.join(db_name);
     let dir_exists = db_dir.exists();
 
@@ -60,7 +94,7 @@ async fn setup_sqlite_db(db_name: &str, schema_sql: &str) -> Result<SqlitePool, 
             path: db_path,
         });
     } else if !dir_exists {
-        info!("DB directory created successfully");
+        info!(path = %db_dir.display(), "DB directory created successfully");
     }
 
     let db_exists = db_path.exists();
@@ -130,4 +164,99 @@ async fn setup_sqlite_db(db_name: &str, schema_sql: &str) -> Result<SqlitePool, 
     };
 
     Ok(pool)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Builds a unique, non-existent path under the system temp directory so
+    /// concurrently running tests never share a database.
+    fn unique_temp_dir(tag: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .expect("system clock before UNIX epoch")
+            .as_nanos();
+        env::temp_dir().join(format!(
+            "braidpool-{}-{}-{}",
+            tag,
+            std::process::id(),
+            nanos
+        ))
+    }
+
+    #[tokio::test]
+    async fn init_db_uses_supplied_datadir() {
+        let datadir = unique_temp_dir("init-db");
+        let pool = init_db(Some(datadir.clone()))
+            .await
+            .expect("database initialization failed");
+
+        assert!(
+            datadir.join("braidpool.db").exists(),
+            "braidpool.db was not created inside the supplied datadir"
+        );
+        assert_ne!(
+            datadir,
+            get_data_dir().expect("default data dir not resolved"),
+            "test datadir must not collide with the platform default"
+        );
+
+        pool.close().await;
+        let _ = fs::remove_dir_all(&datadir);
+    }
+
+    #[tokio::test]
+    async fn init_audit_db_uses_supplied_datadir() {
+        let datadir = unique_temp_dir("init-audit-db");
+        let pool = init_audit_db(Some(datadir.clone()))
+            .await
+            .expect("audit database initialization failed");
+
+        assert!(
+            datadir.join("audit.db").exists(),
+            "audit.db was not created inside the supplied datadir"
+        );
+
+        pool.close().await;
+        let _ = fs::remove_dir_all(&datadir);
+    }
+
+    #[tokio::test]
+    async fn init_db_creates_missing_nested_datadir() {
+        let root = unique_temp_dir("init-db-nested");
+        let datadir = root.join("nested").join("state");
+        let pool = init_db(Some(datadir.clone()))
+            .await
+            .expect("database initialization failed");
+
+        assert!(
+            datadir.join("braidpool.db").exists(),
+            "nested datadir was not created"
+        );
+
+        pool.close().await;
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    /// With no datadir supplied the platform default (HOME-derived) is used.
+    #[test]
+    fn absent_datadir_falls_back_to_platform_default() {
+        let home = env::var("HOME").expect("HOME must be set for this test");
+
+        #[cfg(target_os = "linux")]
+        let expected = Path::new(&home).join(".braidpool");
+
+        #[cfg(target_os = "macos")]
+        let expected = Path::new(&home)
+            .join("Library")
+            .join("Application Support")
+            .join("braidpool");
+
+        assert_eq!(
+            get_data_dir().expect("default data dir not resolved"),
+            expected
+        );
+    }
 }

--- a/node/src/main.rs
+++ b/node/src/main.rs
@@ -103,6 +103,33 @@ async fn main() -> Result<(), Box<dyn Error>> {
         AtomicBool::new(true)
     };
     let ibd_spinlock = Arc::new(ibd_or_not);
+    // Resolve `--datadir` before anything touches disk so the databases and the
+    // keystore all land under the directory the operator asked for.
+    let datadir_str = args.datadir.to_str().ok_or_else(|| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "Invalid datadir path encoding",
+        )
+    })?;
+    let datadir = shellexpand::full(datadir_str).map_err(|e| {
+        std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            format!("Shell expansion failed: {}", e),
+        )
+    })?;
+    let datadir_path = Path::new(&*datadir).to_path_buf();
+    match fs::metadata(&datadir_path) {
+        Ok(m) => {
+            if !m.is_dir() {
+                error!(datadir = %datadir, "Data directory exists but is not a directory");
+            }
+            info!(datadir = %datadir, "Using existing data directory");
+        }
+        Err(_) => {
+            info!(datadir = %datadir, "Creating data directory");
+            fs::create_dir_all(&datadir_path)?;
+        }
+    }
     // Initializing the braid object with read write lock
     //for supporting concurrent readers and single writer
     let braid: Arc<RwLock<braid::Braid>> =
@@ -112,12 +139,14 @@ async fn main() -> Result<(), Box<dyn Error>> {
 
     if !args.audit {
         //Initializing DB and db command handler
-        let (mut db_handler, tx) = DBHandler::new(network).await.map_err(|e| {
-            std::io::Error::new(
-                std::io::ErrorKind::Other,
-                format!("Database initialization failed: {:?}", e),
-            )
-        })?;
+        let (mut db_handler, tx) = DBHandler::new(Some(datadir_path.clone()), network)
+            .await
+            .map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::Other,
+                    format!("Database initialization failed: {:?}", e),
+                )
+            })?;
         db_tx = tx;
         optional_db_pool = Some(db_handler.db_connection_pool.clone());
         //Reconstructing local braid upon startup
@@ -330,7 +359,12 @@ async fn main() -> Result<(), Box<dyn Error>> {
         );
 
         // Initialize audit records
-        let audit_dag = match audit::AuditDAG::new_with_db(Arc::clone(&braid)).await {
+        let audit_dag = match audit::AuditDAG::new_with_db(
+            Arc::clone(&braid),
+            Some(datadir_path.clone()),
+        )
+        .await
+        {
             Ok(dag) => Arc::new(Mutex::new(dag)),
             Err(e) => {
                 error!("Failed to initialize audit DAG with database: {}", e);
@@ -843,32 +877,6 @@ async fn main() -> Result<(), Box<dyn Error>> {
             .await;
     });
 
-    let datadir_str = args.datadir.to_str().ok_or_else(|| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            "Invalid datadir path encoding",
-        )
-    })?;
-    let datadir = shellexpand::full(datadir_str).map_err(|e| {
-        std::io::Error::new(
-            std::io::ErrorKind::InvalidInput,
-            format!("Shell expansion failed: {}", e),
-        )
-    })?;
-    match fs::metadata(&*datadir) {
-        Ok(m) => {
-            if !m.is_dir() {
-                error!(datadir = %datadir, "Data directory exists but is not a directory");
-            }
-            info!(datadir = %datadir, "Using existing data directory");
-        }
-        Err(_) => {
-            info!(datadir = %datadir, "Creating data directory");
-            fs::create_dir_all(&*datadir)?;
-        }
-    }
-
-    let datadir_path = Path::new(&*datadir);
     let keystore_path = datadir_path.join("keystore");
     #[cfg(unix)]
     {

--- a/node/src/stratum.rs
+++ b/node/src/stratum.rs
@@ -4650,7 +4650,7 @@ mod test {
         client.authorized = true;
         client.extranonce1 = vec![0u8; 8];
         let test_braid = Arc::new(RwLock::new(braid::Braid::new(vec![], PoolNetwork::Cpunet)));
-        let (_db, db_tx) = DBHandler::new(PoolNetwork::Cpunet).await.unwrap();
+        let (_db, db_tx) = DBHandler::new_in_memory(PoolNetwork::Cpunet).await.unwrap();
         let (swarm, _rx) = SwarmHandler::new(test_braid, db_tx, DashboardEvents::new());
         let swarm_arc = Arc::new(Mutex::new(swarm));
         (client, map, swarm_arc, job_id)


### PR DESCRIPTION
Closes #533.

Split out of #534 so the `--datadir` fix can land on its own, independent of the network-isolation work in that PR.

