### PR TITLE
feat: enhance miner inventory with CPU miner support and unified miner details

### DIFF
--- a/dashboard/src/URLs.ts
+++ b/dashboard/src/URLs.ts
@@ -25,6 +25,8 @@ export const API_URLS = {
   MEMPOOL_API_BASE: 'http://localhost:3002',
   // Miner Device Api endpoints
   MINER_DEVICE_URL: 'http://localhost:5001',
+  // CPU miner inventory
+  CPU_MINERS_URL: 'http://localhost:5001/api/cpu-miners',
 } as const;
 
 // Specific API endpoint functions for better type safety

--- a/dashboard/src/components/MinerInventory/MinerDetailsDialog.tsx
+++ b/dashboard/src/components/MinerInventory/MinerDetailsDialog.tsx
@@ -1,0 +1,222 @@
+import { UnifiedMiner, Miner, CpuMiner } from './Types';
+import { getAlerts } from './Utils';
+
+interface Props {
+  miner: UnifiedMiner;
+  onClose: () => void;
+}
+
+function formatUptime(s: number): string {
+  const d = Math.floor(s / 86400);
+  const h = Math.floor((s % 86400) / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  if (d > 0) return `${d}d ${h}h ${m}m`;
+  if (h > 0) return `${h}h ${m}m`;
+  return `${m}m`;
+}
+
+const AsicDetails = ({ miner }: { miner: Miner }) => {
+  const alerts = getAlerts(miner);
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Firmware</h3>
+          <p className="text-sm mt-1">{miner.firmware}</p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Chip Count</h3>
+          <p className="text-sm mt-1">{miner.chip_count}</p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Voltage</h3>
+          <p className="text-sm mt-1">{miner.voltage} V</p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Temperature</h3>
+          <p className="text-sm mt-1">
+            {miner.temperature}
+            {`\u00B0`}C (max {miner.temperature_max}
+            {`\u00B0`}C)
+          </p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">VR Temperature</h3>
+          <p className="text-sm mt-1">
+            {miner.vr_temperature}
+            {`\u00B0`}C
+          </p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Power Limit</h3>
+          <p className="text-sm mt-1">{miner.power_limit} W</p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Fan Speeds</h3>
+          <p className="text-sm mt-1">
+            {miner.fan_speeds.length ? miner.fan_speeds.join(', ') : 'N/A'} RPM
+          </p>
+        </div>
+      </div>
+
+      <div className="pt-4 border-t border-gray-700">
+        <h3 className="font-medium text-gray-400 mb-2">Pools</h3>
+        {miner.pools.length ? (
+          <ul className="text-sm space-y-1">
+            {miner.pools.map((p: any, idx: number) => (
+              <li key={idx}>{p.url || p.name || JSON.stringify(p)}</li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-500">No pools configured</p>
+        )}
+      </div>
+
+      {alerts.length > 0 && (
+        <div className="pt-4 border-t border-gray-700">
+          <h3 className="font-medium text-amber-300 mb-2">Alerts</h3>
+          <ul className="text-sm space-y-1 text-amber-300">
+            {alerts.map((a, idx) => (
+              <li key={idx}>{a.message}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {miner.errors.length > 0 && (
+        <div className="pt-4 border-t border-gray-700">
+          <h3 className="font-medium text-rose-300 mb-2">Errors</h3>
+          <ul className="text-sm space-y-1 text-rose-300">
+            {miner.errors.map((e: any, idx: number) => (
+              <li key={idx}>{typeof e === 'string' ? e : JSON.stringify(e)}</li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
+  );
+};
+
+const CpuDetails = ({ miner }: { miner: CpuMiner }) => {
+  const stats = miner.stats;
+  if (!stats) {
+    return <p className="text-sm text-gray-500">No stats reported yet.</p>;
+  }
+  return (
+    <>
+      <div className="grid grid-cols-2 gap-4">
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">API URL</h3>
+          <p className="text-sm mt-1 break-all">{miner.api_url}</p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Miner Version</h3>
+          <p className="text-sm mt-1">{stats.minerVersion}</p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Threads</h3>
+          <p className="text-sm mt-1">{stats.hashrate.threads}</p>
+        </div>
+        <div>
+          <h3 className="text-sm font-medium text-gray-400">Total Hashes</h3>
+          <p className="text-sm mt-1">
+            {stats.hashrate.totalHashes.toLocaleString()}
+          </p>
+        </div>
+      </div>
+
+      <div className="pt-4 border-t border-gray-700">
+        <h3 className="font-medium text-gray-400 mb-2">Connection</h3>
+        <div className="text-sm space-y-1">
+          <p>
+            <strong>Status:</strong> {stats.connection.status}
+          </p>
+          <p>
+            <strong>Pool:</strong> {stats.connection.poolUrl}
+          </p>
+          <p>
+            <strong>Username:</strong> {stats.connection.username}
+          </p>
+          <p>
+            <strong>Difficulty:</strong> {stats.connection.difficulty}
+          </p>
+        </div>
+      </div>
+
+      <div className="pt-4 border-t border-gray-700">
+        <h3 className="font-medium text-gray-400 mb-2">Worker Threads</h3>
+        {stats.workerThreads.length ? (
+          <ul className="text-sm space-y-1">
+            {stats.workerThreads.map((w) => (
+              <li key={w.id}>
+                Thread {w.id}: {w.status}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-500">No worker data</p>
+        )}
+      </div>
+
+      <div className="pt-4 border-t border-gray-700">
+        <h3 className="font-medium text-gray-400 mb-2">Recent Shares</h3>
+        {stats.recentShares.length ? (
+          <ul className="text-sm space-y-1">
+            {stats.recentShares.slice(0, 10).map((s, idx) => (
+              <li key={idx} className="break-all">
+                {new Date(s.timestamp).toLocaleTimeString()} — job {s.jobId} —{' '}
+                {s.accepted === null
+                  ? 'pending'
+                  : s.accepted
+                    ? 'accepted'
+                    : 'rejected'}
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-sm text-gray-500">No recent shares</p>
+        )}
+      </div>
+    </>
+  );
+};
+
+const MinerDetailsDialog = ({ miner, onClose }: Props) => {
+  return (
+    <>
+      <div
+        className="fixed inset-0 z-40"
+        onClick={onClose}
+        data-testid="overlay"
+      />
+
+      <div className="fixed right-0 top-14 z-50 h-[calc(100%-3.5rem)] w-full max-w-md sm:w-96 bg-[#1e1e1e] overflow-y-auto shadow-2xl text-white border border-gray-700">
+        <div className="sticky top-0 border-white bg-[#1e1e1e] p-4 flex justify-between items-center">
+          <h2 className="text-lg font-bold">Miner Details</h2>
+          <button
+            onClick={onClose}
+            className="text-gray-400 hover:text-white p-1 rounded-full hover:border-white/10 bg-[#1e1e1e]"
+            aria-label="Close dialog"
+          >
+            ✕
+          </button>
+        </div>
+
+        <div className="p-4 space-y-4">
+          <div>
+            <h3 className="text-sm font-medium text-gray-400">Uptime</h3>
+            <p className="text-sm mt-1">{formatUptime(miner.uptime)}</p>
+          </div>
+
+          {miner.type === 'asic' ? (
+            <AsicDetails miner={miner.raw as Miner} />
+          ) : (
+            <CpuDetails miner={miner.raw as CpuMiner} />
+          )}
+        </div>
+      </div>
+    </>
+  );
+};
+
+export default MinerDetailsDialog;

--- a/dashboard/src/components/MinerInventory/MinerInventoryDashboard.tsx
+++ b/dashboard/src/components/MinerInventory/MinerInventoryDashboard.tsx
@@ -1,32 +1,37 @@
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { Miner, HistoryPoint } from './Types';
+import { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { Miner, HistoryPoint, UnifiedMiner, CpuMiner } from './Types';
 import { API_URLS, WEBSOCKET_URLS } from '../../URLs';
 import AnalyticsCharts from './AnalyticsCharts';
 import MinerTable from './MinerTable';
+import MinerDetailsDialog from './MinerDetailsDialog';
 import MinerDashboardHeader from './MinerDashboardHeader';
 import MinerControls from './MinerControls';
 import { HISTORY_POINTS, REFRESH_INTERVAL } from './Constant';
-import { mapApiToMiner, getAlerts } from './Utils';
+import { mapApiToMiner, mapAsicToUnified, mapCpuToUnified } from './Utils';
 
 const MAX_HISTORY_POINTS = HISTORY_POINTS;
 
 const MinerInventoryDashboard = () => {
   const [miners, setMiners] = useState<Miner[]>([]);
+  const [cpuMiners, setCpuMiners] = useState<CpuMiner[]>([]);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [searchInput, setSearchInput] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
   const [sortBy, setSortBy] = useState<
-    'all' | 'efficiency' | 'hashrate' | 'power' | 'temperature'
+    'all' | 'efficiency' | 'hashrate' | 'power'
   >('all');
   const [statusFilter, setStatusFilter] = useState<
     'all' | 'online' | 'warning' | 'offline'
   >('all');
+  const [typeFilter, setTypeFilter] = useState<'all' | 'asic' | 'cpu'>('all');
+  const [selectedMiner, setSelectedMiner] = useState<UnifiedMiner | null>(null);
 
   const [lastUpdate, setLastUpdate] = useState<Date | null>(null);
   const [wsConnected, setWsConnected] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   const [fleetHistory, setFleetHistory] = useState<HistoryPoint[]>([]);
+  const [cpuBackendDown, setCpuBackendDown] = useState(false);
   useEffect(() => {
     let cancelled = false;
     const connect = () => {
@@ -98,66 +103,108 @@ const MinerInventoryDashboard = () => {
   useEffect(() => {
     fetchMiners();
   }, [fetchMiners]);
+
+  // Poll CPU miners every 5s alongside ASIC miners.
+  useEffect(() => {
+    let consecutiveFailures = 0;
+    const load = async () => {
+      try {
+        const r = await fetch(API_URLS.CPU_MINERS_URL);
+        if (r.ok) {
+          const d = await r.json();
+          setCpuMiners(d.cpu_miners ?? []);
+          consecutiveFailures = 0;
+          setCpuBackendDown(false);
+        } else {
+          throw new Error(`HTTP ${r.status}`);
+        }
+      } catch {
+        consecutiveFailures += 1;
+        // Only surface a warning after a few failed polls, so a single blip doesn't flash the UI.
+        if (consecutiveFailures >= 3) setCpuBackendDown(true);
+      }
+    };
+    load();
+    const t = setInterval(load, 5000);
+    return () => clearInterval(t);
+  }, []);
   useEffect(() => {
     if (wsConnected) return;
     const interval = setInterval(fetchMiners, REFRESH_INTERVAL * 1000);
     return () => clearInterval(interval);
   }, [wsConnected, fetchMiners]);
 
-  useEffect(() => {
-    if (miners.length === 0) return;
-    const timestamp = Date.now();
-    const totalHashrateNow = miners.reduce(
-      (sum, m) =>
-        m.status === 'online' || m.status === 'warning'
-          ? sum + (m.hashrate_current || 0)
-          : sum,
-      0
-    );
-    const totalExpectedNow = miners.reduce(
-      (sum, m) =>
-        m.status === 'online' || m.status === 'warning'
-          ? sum + (m.expected_hashrate || 0)
-          : sum,
-      0
-    );
-    const activeMiners = miners.filter(
+  const unifiedMiners = useMemo<UnifiedMiner[]>(
+    () => [...miners.map(mapAsicToUnified), ...cpuMiners.map(mapCpuToUnified)],
+    [miners, cpuMiners]
+  );
+
+  const activeUnifiedMiners = useMemo(
+    () =>
+      unifiedMiners.filter(
+        (m) => m.status === 'online' || m.status === 'warning'
+      ),
+    [unifiedMiners]
+  );
+
+  const fleetMetrics = useMemo(() => {
+    const activeAsicMiners = miners.filter(
       (m) => m.status === 'online' || m.status === 'warning'
     );
+    const efficiencyMiners = activeUnifiedMiners.filter(
+      (m) => m.efficiency !== null
+    );
 
-    const avgEfficiencyNow =
-      activeMiners.length > 0
-        ? activeMiners.reduce((sum, m) => sum + (m.efficiency || 0), 0) /
-          activeMiners.length
-        : 0;
-    const avgTempNow =
-      activeMiners.length > 0
-        ? activeMiners.reduce((sum, m) => sum + (m.temperature || 0), 0) /
-          activeMiners.length
-        : 0;
-    const avgVrTempNow =
-      activeMiners.length > 0
-        ? activeMiners.reduce((sum, m) => sum + (m.vr_temperature || 0), 0) /
-          activeMiners.length
-        : 0;
+    return {
+      totalHashrate: activeUnifiedMiners.reduce(
+        (sum, m) => sum + m.hashrateTHs,
+        0
+      ),
+      totalExpectedHashrate: activeAsicMiners.reduce(
+        (sum, m) => sum + (m.expected_hashrate || 0),
+        0
+      ),
+      averageEfficiency:
+        efficiencyMiners.length > 0
+          ? efficiencyMiners.reduce((sum, m) => sum + (m.efficiency || 0), 0) /
+            efficiencyMiners.length
+          : 0,
+      averageTemperature:
+        activeAsicMiners.length > 0
+          ? activeAsicMiners.reduce((sum, m) => sum + (m.temperature || 0), 0) /
+            activeAsicMiners.length
+          : 0,
+      averageVrTemperature:
+        activeAsicMiners.length > 0
+          ? activeAsicMiners.reduce(
+              (sum, m) => sum + (m.vr_temperature || 0),
+              0
+            ) / activeAsicMiners.length
+          : 0,
+    };
+  }, [miners, activeUnifiedMiners]);
+
+  useEffect(() => {
+    if (unifiedMiners.length === 0) return;
+    const timestamp = Date.now();
 
     setFleetHistory((prev) => {
       const next = [
         ...prev,
         {
           timestamp,
-          totalHashrate: totalHashrateNow,
-          expectedHashrate: totalExpectedNow,
-          efficiency: avgEfficiencyNow,
-          temperature: avgTempNow,
-          vrTemperature: avgVrTempNow,
+          totalHashrate: fleetMetrics.totalHashrate,
+          expectedHashrate: fleetMetrics.totalExpectedHashrate,
+          efficiency: fleetMetrics.averageEfficiency,
+          temperature: fleetMetrics.averageTemperature,
+          vrTemperature: fleetMetrics.averageVrTemperature,
         },
       ];
       return next.slice(-MAX_HISTORY_POINTS);
     });
-  }, [miners]);
+  }, [unifiedMiners.length, fleetMetrics]);
 
-  const deleteMiner = async (minerId: string) => {
+  const deleteAsicMiner = async (minerId: string) => {
     try {
       const response = await fetch(
         `${API_URLS.MINER_DEVICE_URL}/api/miners/${minerId}`,
@@ -187,56 +234,69 @@ const MinerInventoryDashboard = () => {
     }
   };
 
+  const deleteCpuMiner = async (minerId: string) => {
+    try {
+      const response = await fetch(`${API_URLS.CPU_MINERS_URL}/${minerId}`, {
+        method: 'DELETE',
+      });
+      if (!response.ok) {
+        throw new Error(`HTTP ${response.status}`);
+      }
+      setCpuMiners((prev) => prev.filter((m) => m.id !== minerId));
+    } catch (err) {
+      console.error('Error deleting CPU miner:', err);
+      setError('Failed to delete miner');
+    }
+  };
+
+  const handleUnifiedDelete = (miner: UnifiedMiner) => {
+    if (miner.type === 'asic') deleteAsicMiner(miner.id);
+    else deleteCpuMiner(miner.id);
+    if (selectedMiner?.id === miner.id) setSelectedMiner(null);
+  };
+
   const handleSearch = () => setSearchQuery(searchInput.trim());
   const clearSearch = () => {
     setSearchInput('');
     setSearchQuery('');
   };
 
-  const totalMiners = miners.length;
-  const onlineMiners = miners.filter((m) => m.status === 'online').length;
-  const warningMiners = miners.filter((m) => m.status === 'warning').length;
-  const offlineMiners = miners.filter((m) => m.status === 'offline').length;
-  const totalHashrate = miners.reduce(
-    (sum, m) =>
-      m.status === 'online' || m.status === 'warning'
-        ? sum + (m.hashrate_current || 0)
-        : sum,
+  const totalMiners = unifiedMiners.length;
+  const onlineMiners = unifiedMiners.filter(
+    (m) => m.status === 'online'
+  ).length;
+  const warningMiners = unifiedMiners.filter(
+    (m) => m.status === 'warning'
+  ).length;
+  const offlineMiners = unifiedMiners.filter(
+    (m) => m.status === 'offline'
+  ).length;
+  const totalHashrate = fleetMetrics.totalHashrate;
+  const totalPower = activeUnifiedMiners.reduce(
+    (sum, m) => sum + (m.power || 0),
     0
   );
-  const totalPower = miners.reduce(
-    (sum, m) =>
-      m.status === 'online' || m.status === 'warning'
-        ? sum + (m.power_usage || 0)
-        : sum,
-    0
-  );
-  const activeMiners = miners.filter(
-    (m) => m.status === 'online' || m.status === 'warning'
-  );
-
-  const avgEfficiency =
-    activeMiners.length > 0
-      ? activeMiners.reduce((sum, m) => sum + (m.efficiency || 0), 0) /
-        activeMiners.length
-      : 0;
+  const avgEfficiency = fleetMetrics.averageEfficiency;
 
   const displayedMiners =
     !searchQuery || searchQuery.length === 0
-      ? miners
-      : miners.filter((m) => {
+      ? unifiedMiners
+      : unifiedMiners.filter((m) => {
           const q = searchQuery.toLowerCase();
-          return (
-            (m.ip || '').toLowerCase().includes(q) ||
-            (m.hostname || '').toLowerCase().includes(q)
-          );
+          return m.name.toLowerCase().includes(q);
         });
+
+  // Apply type filter
+  const filteredByType =
+    typeFilter === 'all'
+      ? displayedMiners
+      : displayedMiners.filter((m) => m.type === typeFilter);
 
   // Apply status filter
   const filteredByStatus =
     statusFilter === 'all'
-      ? displayedMiners
-      : displayedMiners.filter((m) => m.status === statusFilter);
+      ? filteredByType
+      : filteredByType.filter((m) => m.status === statusFilter);
 
   // Apply sorting to the filtered list
   const sortedDisplayedMiners = (() => {
@@ -248,11 +308,9 @@ const MinerInventoryDashboard = () => {
         case 'efficiency':
           return (b.efficiency || 0) - (a.efficiency || 0);
         case 'hashrate':
-          return (b.hashrate_current || 0) - (a.hashrate_current || 0);
+          return (b.hashrateTHs || 0) - (a.hashrateTHs || 0);
         case 'power':
-          return (b.power_usage || 0) - (a.power_usage || 0);
-        case 'temperature':
-          return (b.temperature || 0) - (a.temperature || 0);
+          return (b.power || 0) - (a.power || 0);
         default:
           return 0;
       }
@@ -276,6 +334,15 @@ const MinerInventoryDashboard = () => {
             </div>
           )}
 
+          {cpuBackendDown && (
+            <div className="text-yellow-400 border border-yellow-500 px-4 py-3 rounded max-w-md mx-auto mb-4">
+              <strong className="font-bold">Warning: </strong>
+              <span className="block sm:inline">
+                CPU miner backend is unreachable. Retrying in the background…
+              </span>
+            </div>
+          )}
+
           <MinerControls
             loading={loading}
             lastUpdate={lastUpdate}
@@ -290,13 +357,13 @@ const MinerInventoryDashboard = () => {
           />
         </div>
 
-        {miners.length > 0 && (
+        {miners.length > 0 || cpuMiners.length > 0 ? (
           <div className="mb-6">
             <AnalyticsCharts fleetHistory={fleetHistory} />
           </div>
-        )}
+        ) : null}
 
-        {miners.length === 0 ? (
+        {unifiedMiners.length === 0 ? (
           <div className="text-center py-12 text-gray-400">
             <p className="text-xl">No miners found</p>
             <p className="text-md mt-2">
@@ -373,15 +440,24 @@ const MinerInventoryDashboard = () => {
                 </div>
 
                 <select
+                  value={typeFilter}
+                  onChange={(e) =>
+                    setTypeFilter(e.target.value as 'all' | 'asic' | 'cpu')
+                  }
+                  aria-label="Filter by miner type"
+                  className="px-3 py-2 text-sm border border-gray-600 bg-gray-800 rounded text-white focus:outline-none focus:ring-1 focus:ring-gray-500"
+                >
+                  <option value="all">All Types</option>
+                  <option value="asic">ASIC</option>
+                  <option value="cpu">CPU</option>
+                </select>
+
+                <select
                   value={sortBy}
                   onChange={(e) =>
                     setSortBy(
                       e.target.value as
-                        | 'all'
-                        | 'efficiency'
-                        | 'hashrate'
-                        | 'power'
-                        | 'temperature'
+                        'all' | 'efficiency' | 'hashrate' | 'power'
                     )
                   }
                   aria-label="Sort miners"
@@ -391,7 +467,6 @@ const MinerInventoryDashboard = () => {
                   <option value="efficiency">Efficiency (W/TH)</option>
                   <option value="hashrate">Hashrate (TH/s)</option>
                   <option value="power">Power (W)</option>
-                  <option value="temperature">Temperature (°C)</option>
                 </select>
               </div>
             </div>
@@ -404,11 +479,18 @@ const MinerInventoryDashboard = () => {
             ) : (
               <MinerTable
                 miners={sortedDisplayedMiners}
-                getAlerts={getAlerts}
-                onDelete={deleteMiner}
+                onSelect={setSelectedMiner}
+                onDelete={handleUnifiedDelete}
               />
             )}
           </>
+        )}
+
+        {selectedMiner && (
+          <MinerDetailsDialog
+            miner={selectedMiner}
+            onClose={() => setSelectedMiner(null)}
+          />
         )}
       </div>
     </div>

--- a/dashboard/src/components/MinerInventory/MinerTable.tsx
+++ b/dashboard/src/components/MinerInventory/MinerTable.tsx
@@ -1,5 +1,5 @@
-import React, { useState } from 'react';
-import { MinerTableProps } from './Types';
+import React from 'react';
+import { UnifiedMiner } from './Types';
 import colors from '@/theme/colors';
 
 function formatUptime(s: number): string {
@@ -10,6 +10,14 @@ function formatUptime(s: number): string {
   if (h > 0) return `${h}h ${m}m`;
   return `${m}m`;
 }
+function formatHashrate(thashPerSec: number): string {
+  if (thashPerSec >= 1) return `${thashPerSec.toFixed(4)} TH/s`;
+  const hashPerSec = thashPerSec * 1e12;
+  if (hashPerSec >= 1e9) return `${(hashPerSec / 1e9).toFixed(2)} GH/s`;
+  if (hashPerSec >= 1e6) return `${(hashPerSec / 1e6).toFixed(2)} MH/s`;
+  if (hashPerSec >= 1e3) return `${(hashPerSec / 1e3).toFixed(2)} kH/s`;
+  return `${hashPerSec.toFixed(0)} H/s`;
+}
 
 const STATUS_STYLES: Record<string, string> = {
   online: 'bg-emerald-500/10 text-emerald-300 border-emerald-500/40',
@@ -17,178 +25,105 @@ const STATUS_STYLES: Record<string, string> = {
   offline: 'bg-rose-500/10 text-rose-300 border-rose-500/40',
 };
 
-const MinerTable: React.FC<MinerTableProps> = ({
-  miners,
-  getAlerts,
-  onDelete,
-}) => {
-  const [expandedAlerts, setExpandedAlerts] = useState<Record<string, boolean>>(
-    {}
-  );
-  const hasAlerts = miners.some((m) => getAlerts(m).length > 0);
+const TYPE_STYLES: Record<string, string> = {
+  asic: 'bg-blue-500/10 text-blue-300 border-blue-500/40',
+  cpu: 'bg-purple-500/10 text-purple-300 border-purple-500/40',
+};
 
+const DASH = '\u2014';
+
+interface Props {
+  miners: UnifiedMiner[];
+  onSelect: (miner: UnifiedMiner) => void;
+  onDelete: (miner: UnifiedMiner) => void;
+}
+
+const MinerTable: React.FC<Props> = ({ miners, onSelect, onDelete }) => {
   return (
     <div className="w-full overflow-x-auto">
       <div
-        className="min-w-[800px] rounded-2xl bg-[#1e1e1e] p-4 border border-white/10 shadow-md"
+        className="min-w-[900px] rounded-2xl bg-[#1e1e1e] p-4 border border-white/10 shadow-md"
         style={{ borderColor: colors.cardAccentSecondary }}
       >
-        {/* Header row */}
-        <div
-          className={`grid ${hasAlerts ? 'grid-cols-10' : 'grid-cols-9'} gap-4 px-4 py-3 text-xs uppercase tracking-wide text-gray-400 border-b border-gray-800/60`}
-        >
-          <div>Model</div>
-          <div>Hashrate</div>
-          <div>Efficiency</div>
-          <div>Power </div>
+        <div className="grid grid-cols-9 gap-2 px-4 py-3 text-xs uppercase tracking-wide text-gray-400 border-b border-gray-800/60">
+          <div>Name</div>
+          <div>Type</div>
           <div>Status</div>
-          {hasAlerts && <div>Alerts</div>}
-          <div>Temp</div>
-          <div>Pool</div>
+          <div>Hashrate</div>
+          <div>Shares</div>
           <div>Uptime</div>
+          <div>Last Seen</div>
           <div>Actions</div>
         </div>
 
-        {/* Miner rows */}
         <div className="divide-y divide-gray-800/40">
-          {miners.map((miner) => {
-            const alerts = getAlerts(miner);
-            const isExpanded = expandedAlerts[miner.id] || false;
-            const firstAlert = alerts[0];
-            const remainingCount = alerts.length - 1;
-            const pool = miner.pools?.[0];
-
-            return (
-              <div
-                key={miner.id}
-                className={`grid ${hasAlerts ? 'grid-cols-10' : 'grid-cols-9'} gap-4 px-4 py-3 text-sm text-gray-200 items-start hover:bg-white/[0.02] transition-colors`}
-              >
-                <div>
-                  <div className="font-medium text-white truncate">
-                    {[miner.make, miner.model]
-                      .filter((v) => v && v !== 'Unknown')
-                      .join(' ') ||
-                      (miner.hostname !== 'Unknown'
-                        ? miner.hostname
-                        : 'Unknown')}
-                  </div>
-                </div>
-
-                {/* Hashrate */}
-                <div>
-                  <div className="whitespace-nowrap">
-                    {(miner.hashrate_current || 0).toFixed(2)} TH/s
-                  </div>
-                  <div className="text-xs text-gray-500 mt-0.5">
-                    {(miner.expected_hashrate || 0).toFixed(2)} exp
-                  </div>
-                </div>
-
-                {/* Efficiency */}
-                <div className="whitespace-nowrap">
-                  {miner.efficiency
-                    ? `${miner.efficiency.toFixed(1)} J/TH`
-                    : 'NA'}
-                </div>
-
-                {/* Power / Uptime */}
-                <div>
-                  <div className="whitespace-nowrap">
-                    {miner.power_usage || 0} W
-                  </div>
-                </div>
-
-                {/* Status */}
-                <div>
-                  <span
-                    className={`px-2 py-0.5 text-xs rounded border whitespace-nowrap ${STATUS_STYLES[miner.status] ?? ''}`}
-                  >
-                    {miner.status.toUpperCase()}
-                  </span>
-                </div>
-
-                {/* Alerts  */}
-                {hasAlerts &&
-                  (alerts.length > 0 ? (
-                    <div className="flex flex-col gap-1.5">
-                      <div
-                        className="cursor-pointer select-none"
-                        onClick={() =>
-                          setExpandedAlerts((prev) => ({
-                            ...prev,
-                            [miner.id]: !prev[miner.id],
-                          }))
-                        }
-                      >
-                        <div className="flex items-center gap-2 px-2.5 py-1.5 rounded-md border text-xs font-medium bg-gray-800/60 border-gray-700/40 text-amber-300 hover:bg-gray-800/80">
-                          <span>{firstAlert.message}</span>
-                          {remainingCount > 0 && (
-                            <span className="px-1.5 py-0.5 rounded bg-gray-700/50 text-gray-400 text-[10px]">
-                              +{remainingCount}
-                            </span>
-                          )}
-                          <span className="ml-auto text-gray-500 text-[10px]">
-                            {isExpanded ? '\u25B2' : '\u25BC'}
-                          </span>
-                        </div>
-                      </div>
-                      {isExpanded && alerts.length > 1 && (
-                        <div className="flex flex-col gap-1 pl-2 border-l-2 text-amber-300 border-gray-700/50">
-                          {alerts.slice(1).map((alert, idx) => (
-                            <div key={idx}>{alert.message}</div>
-                          ))}
-                        </div>
-                      )}
-                    </div>
-                  ) : (
-                    <div />
-                  ))}
-
-                {/* Temperature */}
-                <div className="text-gray-300">
-                  <div className="whitespace-nowrap">
-                    {miner.temperature || 0}
-                    {`\u00B0`}C{' '}
-                    <span className="text-gray-500 text-xs">ASIC</span>
-                  </div>
-                </div>
-
-                {/* Pool / Worker */}
-                <div>
-                  {miner.primary_pool && miner.primary_pool !== 'No Pool' ? (
-                    <>
-                      <div className="text-sm text-gray-200">
-                        {miner.primary_pool}
-                        {pool?.user ? ` | ${pool.user}` : ''}
-                      </div>
-                    </>
-                  ) : (
-                    <span className="text-gray-600">{'\u2014'}</span>
-                  )}
-                </div>
-                {/* Uptime */}
-                <div>
-                  {miner.uptime ? (
-                    <div className="text-sm text-gray-200">
-                      {formatUptime(miner.uptime)}
-                    </div>
-                  ) : null}
-                </div>
-                {/* Remove */}
-                <div>
-                  {onDelete && (
-                    <button
-                      onClick={() => onDelete(miner.id)}
-                      className="inline-flex px-3 py-1 text-xs rounded border border-rose-600/50 bg-rose-900/30 hover:bg-rose-800/50 text-rose-300 cursor-pointer transition-colors"
-                      title={`Remove ${miner.ip}`}
-                    >
-                      X
-                    </button>
-                  )}
-                </div>
+          {miners.map((miner) => (
+            <div
+              key={`${miner.type}-${miner.id}`}
+              className="grid grid-cols-9 gap-4 px-4 py-3 text-sm text-gray-200 items-center hover:bg-white/[0.02] transition-colors cursor-pointer"
+              onClick={() => onSelect(miner)}
+            >
+              <div className="font-medium text-white truncate">
+                {miner.name}
               </div>
-            );
-          })}
+              <div>
+                <span
+                  className={`px-2 py-0.5 text-xs rounded border whitespace-nowrap ${TYPE_STYLES[miner.type]}`}
+                >
+                  {miner.type.toUpperCase()}
+                </span>
+              </div>
+              <div>
+                <span
+                  className={`px-2 py-0.5 text-xs rounded border whitespace-nowrap ${STATUS_STYLES[miner.status]}`}
+                >
+                  {miner.status.toUpperCase()}
+                </span>
+              </div>
+
+              <div className="whitespace-nowrap">
+                {formatHashrate(miner.hashrateTHs)}
+              </div>
+
+              <div className="whitespace-nowrap">
+                {miner.sharesAccepted !== null
+                  ? `${miner.sharesAccepted} / ${miner.sharesSubmitted}`
+                  : DASH}
+              </div>
+
+              <div className="whitespace-nowrap">
+                {miner.uptime ? formatUptime(miner.uptime) : DASH}
+              </div>
+
+              <div className="whitespace-nowrap text-xs text-gray-400">
+                {miner.lastSeen}
+              </div>
+
+              <div className="flex gap-2">
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onDelete(miner);
+                  }}
+                  className="inline-flex px-3 py-1 text-xs rounded border border-rose-600/50 bg-rose-900/30 hover:bg-rose-800/50 text-rose-300 cursor-pointer transition-colors"
+                  title={`Remove ${miner.name}`}
+                >
+                  Remove
+                </button>
+              </div>
+              <div>
+                <button
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onSelect(miner);
+                  }}
+                  className="inline-flex px-3 py-1 text-xs rounded border border-gray-600 bg-gray-800/50 hover:bg-gray-700/60 text-gray-300 cursor-pointer transition-colors"
+                >
+                  Details
+                </button>
+              </div>
+            </div>
+          ))}
         </div>
       </div>
     </div>

--- a/dashboard/src/components/MinerInventory/Types.ts
+++ b/dashboard/src/components/MinerInventory/Types.ts
@@ -1,4 +1,3 @@
-import { Dispatch, SetStateAction } from 'react';
 export interface Miner {
   id: string;
   ip: string;
@@ -40,14 +39,6 @@ export interface Miner {
   primary_pool: string;
   pools: any[];
 }
-export type MinerAnalyticsPoint = {
-  timestamp: number;
-  hashrate: number;
-  expected: number;
-  efficiency: number;
-  temperature: number;
-  vrTemperature: number;
-};
 export type HistoryPoint = {
   timestamp: number;
   totalHashrate: number;
@@ -63,11 +54,6 @@ export type AnalyticsChartsProps = {
 export type MinerAlert = {
   message: string;
 };
-export interface MinerTableProps {
-  miners: Miner[];
-  getAlerts: (miner: Miner) => MinerAlert[];
-  onDelete?: (minerId: string) => void;
-}
 export interface MinerDashboardHeaderProps {
   totalMiners: number;
   totalHashrate: number;
@@ -78,4 +64,78 @@ export interface MinerControlsProps {
   loading: boolean;
   lastUpdate: Date | null;
   wsConnected: boolean;
+}
+export type MinerType = 'asic' | 'cpu';
+
+export interface ShareStats {
+  submitted: number;
+  accepted: number;
+  rejected: number;
+  acceptanceRate: number;
+  blocksFound: number;
+}
+
+export interface HashrateInfo {
+  currentKhashS: number;
+  totalHashes: number;
+  threads: number;
+}
+
+export interface ConnectionInfo {
+  status: 'disconnected' | 'connecting' | 'connected' | 'error';
+  poolUrl: string;
+  username: string;
+  uptimeSeconds: number;
+  difficulty: number;
+}
+
+export interface WorkerInfo {
+  id: number;
+  status: string;
+}
+
+export interface ShareRecord {
+  timestamp: string;
+  jobId: string;
+  nonce: string;
+  hash: string;
+  isBlockCandidate: boolean;
+  accepted: boolean | null;
+}
+
+export interface MiningStatsSnapshot {
+  minerId: string;
+  minerVersion: string;
+  uptimeSeconds: number;
+  hashrate: HashrateInfo;
+  shares: ShareStats;
+  connection: ConnectionInfo;
+  workerThreads: WorkerInfo[];
+  recentShares: ShareRecord[];
+}
+
+export interface CpuMiner {
+  id: string;
+  api_url: string;
+  label: string | null;
+  is_online: boolean;
+  last_seen: string | null;
+  stats: MiningStatsSnapshot | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface UnifiedMiner {
+  id: string;
+  type: MinerType;
+  name: string;
+  status: 'online' | 'warning' | 'offline';
+  hashrateTHs: number;
+  sharesAccepted: number | null;
+  sharesSubmitted: number | null;
+  uptime: number;
+  power: number | null;
+  efficiency: number | null;
+  lastSeen: string;
+  raw: Miner | CpuMiner;
 }

--- a/dashboard/src/components/MinerInventory/Utils.ts
+++ b/dashboard/src/components/MinerInventory/Utils.ts
@@ -1,5 +1,7 @@
-import { Miner, MinerAlert as Alert } from './Types';
+import { CpuMiner, Miner, MinerAlert as Alert, UnifiedMiner } from './Types';
 import { THRESHOLDS } from './Constant';
+
+const KHASH_TO_THASH = 1e9;
 const determineStatus = (data: any): 'online' | 'warning' | 'offline' => {
   // Truly offline device not responding on the network
   if (!data.is_online) return 'offline';
@@ -46,7 +48,6 @@ export const mapApiToMiner = (m: any, lastSeenFallback = 'Never'): Miner => ({
   primary_pool: m.primary_pool || 'No Pool',
   pools: m.pools || [],
 });
-
 //alerts from the device
 export const getAlerts = (miner: Miner): Alert[] => {
   if (miner.status === 'offline') return [];
@@ -78,3 +79,35 @@ export const getAlerts = (miner: Miner): Alert[] => {
   }
   return alerts;
 };
+
+export const mapAsicToUnified = (m: Miner): UnifiedMiner => ({
+  id: m.id,
+  type: 'asic',
+  name:
+    [m.make, m.model].filter((v) => v && v !== 'Unknown').join(' ') ||
+    (m.hostname !== 'Unknown' ? m.hostname : m.ip),
+  status: m.status,
+  hashrateTHs: m.hashrate_current || 0,
+  sharesAccepted: null,
+  sharesSubmitted: null,
+  uptime: m.uptime || 0,
+  power: m.power_usage ?? null,
+  efficiency: m.efficiency ?? null,
+  lastSeen: m.lastSeen,
+  raw: m,
+});
+
+export const mapCpuToUnified = (c: CpuMiner): UnifiedMiner => ({
+  id: c.id,
+  type: 'cpu',
+  name: c.label || c.api_url,
+  status: c.is_online ? 'online' : 'offline',
+  hashrateTHs: (c.stats?.hashrate.currentKhashS ?? 0) / KHASH_TO_THASH,
+  sharesAccepted: c.stats?.shares.accepted ?? null,
+  sharesSubmitted: c.stats?.shares.submitted ?? null,
+  uptime: c.stats?.uptimeSeconds ?? 0,
+  power: null,
+  efficiency: null,
+  lastSeen: c.last_seen ? new Date(c.last_seen).toLocaleTimeString() : 'Never',
+  raw: c,
+});


### PR DESCRIPTION
This PR integrates the `CPUNet Miner API` into the dashboard UI, allowing CPU miners to be monitored and managed alongside the existing miners.
Closes #360

https://github.com/user-attachments/assets/e790acb2-2423-42a8-969f-efccda09de9b
### **What’s Included**
- Combines ASIC and CPU miners into a unified inventory view.
- Adds miner type, status, hashrate, shares, uptime, and last-seen columns.
- Adds CPU hashrate formatting for H/s, kH/s, MH/s, GH/s, and TH/s.
- Adds CPU miner filtering and unified search/sorting.
- Adds a details panel for ASIC and CPU-specific information.
- Adds CPU backend availability feedback.
- Preserves ASIC WebSocket updates while polling CPU miner inventory separately.
- Consolidates shared fleet metric calculations used by dashboard summaries and history charts.
- Handles CPU miner deletion failures without removing the miner from local state prematurely.

### **Goal**
The goal is to provide a consistent UI experience for CPUNet miners while integrating their API data into the existing miner monitoring and inventory system.Updated todo list
