### PR TITLE
fuzz: add cargo-fuzz harness with a merkle path proof target

### DIFF
--- a/braidpool-primitives/fuzz/.gitignore
+++ b/braidpool-primitives/fuzz/.gitignore
@@ -1,0 +1,5 @@
+target
+corpus
+artifacts
+coverage
+Cargo.lock

--- a/braidpool-primitives/fuzz/Cargo.toml
+++ b/braidpool-primitives/fuzz/Cargo.toml
@@ -1,0 +1,32 @@
+# Standalone workspace so the fuzz crate is not pulled into the root
+# braidpool workspace build (cargo-fuzz convention).
+[workspace]
+
+[package]
+name = "braidpool-primitives-fuzz"
+version = "0.0.0"
+publish = false
+edition = "2021"
+
+[package.metadata]
+cargo-fuzz = true
+
+[dependencies]
+libfuzzer-sys = "0.4"
+arbitrary = { version = "1", features = ["derive"] }
+bitcoin = { git = "https://github.com/braidpool/rust-bitcoin.git", features = ["serde"] }
+
+[dependencies.braidpool-primitives]
+path = ".."
+
+# Each fuzz target is its own binary.
+[[bin]]
+name = "merkle_path_proof"
+path = "fuzz_targets/merkle_path_proof.rs"
+test = false
+doc = false
+bench = false
+
+# Fuzzers need debug info for useful crash reports, but still optimised.
+[profile.release]
+debug = 1

--- a/braidpool-primitives/fuzz/README.md
+++ b/braidpool-primitives/fuzz/README.md
@@ -1,0 +1,44 @@
+# Fuzzing braidpool-primitives
+
+Fuzz targets for the core data structures, built on
+[`cargo-fuzz`](https://github.com/rust-fuzz/cargo-fuzz) (libFuzzer).
+
+## Setup
+
+`cargo-fuzz` needs a nightly toolchain:
+
+```
+rustup toolchain install nightly
+cargo install cargo-fuzz
+```
+
+## Run
+
+From the `braidpool-primitives` crate directory:
+
+```
+cargo +nightly fuzz build
+cargo +nightly fuzz run merkle_path_proof
+```
+
+Add a time budget with `-- -max_total_time=60` for a bounded run. Crashes are
+written to `fuzz/artifacts/<target>/` and replayed with:
+
+```
+cargo +nightly fuzz run merkle_path_proof fuzz/artifacts/merkle_path_proof/<crash-file>
+```
+
+## Targets
+
+| Target | Exercises |
+|---|---|
+| `merkle_path_proof` | `MerklePathProof::calculate_corresponding_merkle_root` on arbitrary proof shapes, including empty and single-element paths across both `is_right_leaf` branches. |
+
+## Adding a target
+
+1. Create `fuzz_targets/<name>.rs` with a `fuzz_target!` closure.
+2. Add a matching `[[bin]]` entry in `fuzz/Cargo.toml`.
+3. Build structured inputs from `&[u8]` with `arbitrary::Unstructured`.
+
+Targets are intentionally thin so they can be retargeted as the core
+structures change.

--- a/braidpool-primitives/fuzz/fuzz_targets/merkle_path_proof.rs
+++ b/braidpool-primitives/fuzz/fuzz_targets/merkle_path_proof.rs
@@ -1,0 +1,49 @@
+#![no_main]
+
+use arbitrary::Unstructured;
+use bitcoin::{TxMerkleNode, Txid};
+use braidpool_primitives::utils::bitcoin::MerklePathProof;
+use libfuzzer_sys::fuzz_target;
+
+// Cap the reconstructed path length so the fuzzer spends its budget exploring
+// logic, not allocating huge vectors. Well past any realistic proof depth.
+const MAX_MERKLE_PATH: usize = 64;
+
+// Build an arbitrary `MerklePathProof` from raw fuzz bytes and run the merkle
+// root computation on it. The point is to exercise the path-shaping logic on
+// inputs a real node could receive over the wire, especially the empty and
+// single-element paths and both `is_right_leaf` branches, which are the shapes
+// most likely to hit an unchecked index.
+fuzz_target!(|data: &[u8]| {
+    let mut u = Unstructured::new(data);
+
+    let Ok(tx_bytes) = u.arbitrary::<[u8; 32]>() else {
+        return;
+    };
+    let transaction_hash = Txid::from_byte_array(tx_bytes);
+
+    let Ok(is_right_leaf) = u.arbitrary::<bool>() else {
+        return;
+    };
+
+    let Ok(mut len) = u.arbitrary_len::<[u8; 32]>() else {
+        return;
+    };
+    len = len.min(MAX_MERKLE_PATH);
+
+    let mut merkle_path = Vec::with_capacity(len);
+    for _ in 0..len {
+        let Ok(node_bytes) = u.arbitrary::<[u8; 32]>() else {
+            break;
+        };
+        merkle_path.push(TxMerkleNode::from_byte_array(node_bytes));
+    }
+
+    let proof = MerklePathProof {
+        transaction_hash,
+        is_right_leaf,
+        merkle_path,
+    };
+
+    let _ = proof.calculate_corresponding_merkle_root();
+});


### PR DESCRIPTION
Sets up the fuzzing framework from #133 using cargo-fuzz.

It adds a fuzz workspace under braidpool-primitives/fuzz with one target, merkle_path_proof, that builds an arbitrary MerklePathProof and runs calculate_corresponding_merkle_root, covering empty and single-element paths on both is_right_leaf branches. A short README covers running it and adding targets. The target is kept thin so it can be retargeted as the core structures change, and more can follow as the types stabilise.

On its first run it surfaces a panic in get_merkle_hashing_order for an empty merkle path with is_right_leaf set, where merkle_path[0] is indexed without a bounds check. I reported that in #546 so the fix can be reviewed on its own rather than bundled here.

To run: cargo +nightly fuzz run merkle_path_proof